### PR TITLE
Use correct PID name for TableRepairMetricsService

### DIFF
--- a/core.osgi/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/osgi/TableRepairMetricsService.java
+++ b/core.osgi/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/osgi/TableRepairMetricsService.java
@@ -35,7 +35,6 @@ import org.osgi.service.metatype.annotations.ObjectClassDefinition;
 @Designate(ocd = TableRepairMetricsService.Configuration.class)
 public final class TableRepairMetricsService implements TableRepairMetrics
 {
-    private static final String DEFAULT_STATISTICS_DIRECTORY = "/var/lib/cassandra/repair/metrics/";
     private static final long DEFAULT_STATISTICS_REPORT_INTERVAL_IN_SECONDS = 60L;
 
     @Reference(service = TableStorageStates.class, cardinality = ReferenceCardinality.MANDATORY, policy = ReferencePolicy.STATIC)
@@ -85,7 +84,7 @@ public final class TableRepairMetricsService implements TableRepairMetrics
     public @interface Configuration
     {
         @AttributeDefinition(name = "Metrics directory", description = "The directory which the repair metrics will be stored in")
-        String metricsDirectory() default DEFAULT_STATISTICS_DIRECTORY;
+        String metricsDirectory();
 
         @AttributeDefinition(name = "Report interval in seconds", description = "The interval in which the metrics will be reported")
         long metricsReportIntervalInSeconds() default DEFAULT_STATISTICS_REPORT_INTERVAL_IN_SECONDS;

--- a/osgi-integration/src/test/java/com/ericsson/bss/cassandra/ecchronos/osgi/TestBase.java
+++ b/osgi-integration/src/test/java/com/ericsson/bss/cassandra/ecchronos/osgi/TestBase.java
@@ -40,7 +40,7 @@ public class TestBase
     protected static final String CASSANDRA_NATIVE_PORT = System.getProperty("it-cassandra.native.port");
     protected static final String CASSANDRA_JMX_PORT = System.getProperty("it-cassandra.jmx.port");
 
-    protected static final String REPAIR_METRICS_PID = "com.ericsson.bss.cassandra.ecchronos.core.metrics.osgi.TableRepairMetricsService";
+    protected static final String REPAIR_METRICS_PID = "com.ericsson.bss.cassandra.ecchronos.core.osgi.TableRepairMetricsService";
 
     protected static final String NATIVE_CONNECTION_PID = "com.ericsson.bss.cassandra.ecchronos.connection.impl.OSGiLocalNativeConnectionProvider";
     protected static final String JMX_CONNECTION_PID = "com.ericsson.bss.cassandra.ecchronos.connection.impl.OSGiLocalJmxConnectionProvider";


### PR DESCRIPTION
Remove warnings during OSGi tests