### PR TITLE
Fix scaling scenario

### DIFF
--- a/core/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/repair/state/TestRepairStateImpl.java
+++ b/core/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/repair/state/TestRepairStateImpl.java
@@ -29,6 +29,7 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -82,8 +83,7 @@ public class TestRepairStateImpl
 
         VnodeRepairState vnodeRepairState = new VnodeRepairState(new LongTokenRange(1, 2), Sets.newHashSet(host), VnodeRepairState.UNREPAIRED);
 
-        VnodeRepairStates vnodeRepairStates = VnodeRepairStates.newBuilder()
-                .combineVnodeRepairState(vnodeRepairState)
+        VnodeRepairStates vnodeRepairStates = VnodeRepairStates.newBuilder(Collections.singletonList(vnodeRepairState))
                 .build();
 
         when(mockVnodeRepairStateFactory.calculateNewState(eq(tableReference), isNull(RepairStateSnapshot.class))).thenReturn(vnodeRepairStates);
@@ -116,9 +116,7 @@ public class TestRepairStateImpl
         VnodeRepairState vnodeRepairState = new VnodeRepairState(new LongTokenRange(1, 2), Sets.newHashSet(host), VnodeRepairState.UNREPAIRED);
         VnodeRepairState repairedVnodeRepairState = new VnodeRepairState(new LongTokenRange(2, 3), Sets.newHashSet(host), now);
 
-        VnodeRepairStates vnodeRepairStates = VnodeRepairStates.newBuilder()
-                .combineVnodeRepairState(vnodeRepairState)
-                .combineVnodeRepairState(repairedVnodeRepairState)
+        VnodeRepairStates vnodeRepairStates = VnodeRepairStates.newBuilder(Arrays.asList(vnodeRepairState, repairedVnodeRepairState))
                 .build();
 
         when(mockVnodeRepairStateFactory.calculateNewState(eq(tableReference), isNull(RepairStateSnapshot.class))).thenReturn(vnodeRepairStates);
@@ -145,8 +143,7 @@ public class TestRepairStateImpl
 
         VnodeRepairState vnodeRepairState = new VnodeRepairState(new LongTokenRange(1, 2), Sets.newHashSet(mockHost("DC1")), expectedRepairedAt);
 
-        VnodeRepairStates vnodeRepairStates = VnodeRepairStates.newBuilder()
-                .combineVnodeRepairState(vnodeRepairState)
+        VnodeRepairStates vnodeRepairStates = VnodeRepairStates.newBuilder(Collections.singletonList(vnodeRepairState))
                 .build();
 
         when(mockVnodeRepairStateFactory.calculateNewState(eq(tableReference), isNull(RepairStateSnapshot.class))).thenReturn(vnodeRepairStates);

--- a/core/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/repair/state/TestRepairedAt.java
+++ b/core/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/repair/state/TestRepairedAt.java
@@ -36,8 +36,7 @@ public class TestRepairedAt
         VnodeRepairState vnodeRepairState = new VnodeRepairState(range, Sets.newHashSet(host1), 1234L);
         VnodeRepairState vnodeRepairState2 = new VnodeRepairState(range2, Sets.newHashSet(host1), 1235L);
 
-        VnodeRepairStates vnodeRepairStates = VnodeRepairStates.newBuilder()
-                .combineVnodeRepairStates(Arrays.asList(vnodeRepairState, vnodeRepairState2))
+        VnodeRepairStates vnodeRepairStates = VnodeRepairStates.newBuilder(Arrays.asList(vnodeRepairState, vnodeRepairState2))
                 .build();
 
         RepairedAt repairedAt = RepairedAt.generate(vnodeRepairStates);
@@ -58,8 +57,7 @@ public class TestRepairedAt
         VnodeRepairState vnodeRepairState = new VnodeRepairState(range, Sets.newHashSet(host1), 1234L);
         VnodeRepairState vnodeRepairState2 = new VnodeRepairState(range2, Sets.newHashSet(host1), VnodeRepairState.UNREPAIRED);
 
-        VnodeRepairStates vnodeRepairStates = VnodeRepairStates.newBuilder()
-                .combineVnodeRepairStates(Arrays.asList(vnodeRepairState, vnodeRepairState2))
+        VnodeRepairStates vnodeRepairStates = VnodeRepairStates.newBuilder(Arrays.asList(vnodeRepairState, vnodeRepairState2))
                 .build();
 
         RepairedAt repairedAt = RepairedAt.generate(vnodeRepairStates);
@@ -80,8 +78,7 @@ public class TestRepairedAt
         VnodeRepairState vnodeRepairState = new VnodeRepairState(range, Sets.newHashSet(host1), VnodeRepairState.UNREPAIRED);
         VnodeRepairState vnodeRepairState2 = new VnodeRepairState(range2, Sets.newHashSet(host1), VnodeRepairState.UNREPAIRED);
 
-        VnodeRepairStates vnodeRepairStates = VnodeRepairStates.newBuilder()
-                .combineVnodeRepairStates(Arrays.asList(vnodeRepairState, vnodeRepairState2))
+        VnodeRepairStates vnodeRepairStates = VnodeRepairStates.newBuilder(Arrays.asList(vnodeRepairState, vnodeRepairState2))
                 .build();
 
         RepairedAt repairedAt = RepairedAt.generate(vnodeRepairStates);

--- a/core/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/repair/state/TestVnodeRepairStates.java
+++ b/core/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/repair/state/TestVnodeRepairStates.java
@@ -20,6 +20,7 @@ import com.google.common.collect.Sets;
 import org.junit.Test;
 
 import java.util.Arrays;
+import java.util.Collections;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
@@ -36,8 +37,7 @@ public class TestVnodeRepairStates
         VnodeRepairState vnodeRepairState = new VnodeRepairState(range, Sets.newHashSet(host1), VnodeRepairState.UNREPAIRED);
         VnodeRepairState vnodeRepairState2 = new VnodeRepairState(range2, Sets.newHashSet(host1), VnodeRepairState.UNREPAIRED);
 
-        VnodeRepairStates vnodeRepairStates = VnodeRepairStates.newBuilder()
-                .combineVnodeRepairStates(Arrays.asList(vnodeRepairState, vnodeRepairState2))
+        VnodeRepairStates vnodeRepairStates = VnodeRepairStates.newBuilder(Arrays.asList(vnodeRepairState, vnodeRepairState2))
                 .build();
 
         assertThat(vnodeRepairStates.getVnodeRepairStates()).containsExactlyInAnyOrder(vnodeRepairState, vnodeRepairState2);
@@ -52,10 +52,9 @@ public class TestVnodeRepairStates
         VnodeRepairState vnodeRepairState = new VnodeRepairState(range, Sets.newHashSet(host1), VnodeRepairState.UNREPAIRED);
         VnodeRepairState updatedVnodeRepairState = new VnodeRepairState(range, Sets.newHashSet(host1), 1234L);
 
-        VnodeRepairStates vnodeRepairStates = VnodeRepairStates.newBuilder()
-                .combineVnodeRepairState(vnodeRepairState)
-                .combineVnodeRepairState(updatedVnodeRepairState)
-                .combineVnodeRepairState(vnodeRepairState)
+        VnodeRepairStates vnodeRepairStates = VnodeRepairStates.newBuilder(Collections.singletonList(vnodeRepairState))
+                .updateVnodeRepairState(updatedVnodeRepairState)
+                .updateVnodeRepairState(vnodeRepairState)
                 .build();
 
         assertThat(vnodeRepairStates.getVnodeRepairStates()).containsExactly(updatedVnodeRepairState);
@@ -72,11 +71,10 @@ public class TestVnodeRepairStates
         VnodeRepairState vnodeRepairState = new VnodeRepairState(range, Sets.newHashSet(host1, host2), 1234L);
         VnodeRepairState updatedVnodeRepairState = new VnodeRepairState(range, Sets.newHashSet(host1, host3), VnodeRepairState.UNREPAIRED);
 
-        VnodeRepairStates vnodeRepairStates = VnodeRepairStates.newBuilder()
-                .combineVnodeRepairState(vnodeRepairState)
-                .combineVnodeRepairState(updatedVnodeRepairState)
+        VnodeRepairStates vnodeRepairStates = VnodeRepairStates.newBuilder(Collections.singletonList(vnodeRepairState))
+                .updateVnodeRepairState(updatedVnodeRepairState)
                 .build();
 
-        assertThat(vnodeRepairStates.getVnodeRepairStates()).containsExactly(updatedVnodeRepairState);
+        assertThat(vnodeRepairStates.getVnodeRepairStates()).containsExactly(vnodeRepairState);
     }
 }


### PR DESCRIPTION
Create VnodeRepairStates for current vnodes and then only update
repaired at for them. This way we don't keep track of old vnodes
based on the old topology.

This also means that repair state might be reset for the new vnodes
as we will then use the old repaired at from the whole table rather
than the individual vnodes.