### PR TITLE
Incremental repairs

### DIFF
--- a/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/repair/RepairGroup.java
+++ b/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/repair/RepairGroup.java
@@ -14,7 +14,6 @@
  */
 package com.ericsson.bss.cassandra.ecchronos.core.repair;
 
-import com.datastax.driver.core.Host;
 import com.ericsson.bss.cassandra.ecchronos.core.JmxProxyFactory;
 import com.ericsson.bss.cassandra.ecchronos.core.exceptions.LockException;
 import com.ericsson.bss.cassandra.ecchronos.core.exceptions.ScheduledJobException;
@@ -139,13 +138,6 @@ public class RepairGroup extends ScheduledTask
         }
         else
         {
-            Set<Host> replicas = myReplicaRepairGroup.getReplicas();
-
-            if (!replicas.isEmpty())
-            {
-                builder.withReplicas(replicas);
-            }
-
             builder.withTokenRanges(myReplicaRepairGroup.getVnodes());
             tasks.add(builder.build());
         }

--- a/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/repair/state/IncrementalRepairGroupFactory.java
+++ b/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/repair/state/IncrementalRepairGroupFactory.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2018 Telefonaktiebolaget LM Ericsson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ericsson.bss.cassandra.ecchronos.core.repair.state;
+
+import com.datastax.driver.core.Host;
+import com.ericsson.bss.cassandra.ecchronos.core.utils.LongTokenRange;
+import com.ericsson.bss.cassandra.ecchronos.core.utils.TableReference;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class IncrementalRepairGroupFactory implements ReplicaRepairGroupFactory
+{
+    private final TableReference myTableReference;
+    private final ReplicationState myReplicationState;
+
+    public IncrementalRepairGroupFactory(TableReference tableReference, ReplicationState replicationState)
+    {
+        myTableReference = tableReference;
+        myReplicationState = replicationState;
+    }
+
+    @Override
+    public List<ReplicaRepairGroup> generateReplicaRepairGroups(List<VnodeRepairState> availableVnodeRepairStates)
+    {
+        if (availableVnodeRepairStates.isEmpty())
+        {
+            return Collections.emptyList();
+        }
+
+        Map<LongTokenRange, ImmutableSet<Host>> tokenRangeToReplicaMap = myReplicationState.getTokenRangeToReplicas(myTableReference);
+
+        Set<LongTokenRange> repairableRanges = availableVnodeRepairStates.stream().map(VnodeRepairState::getTokenRange).collect(Collectors.toSet());
+
+        if (Sets.symmetricDifference(tokenRangeToReplicaMap.keySet(), repairableRanges).isEmpty())
+        {
+            Set<Host> allHosts = tokenRangeToReplicaMap.values().stream().flatMap(Set::stream).collect(Collectors.toSet());
+
+            ReplicaRepairGroup replicaRepairGroup = new ReplicaRepairGroup(allHosts, Lists.newArrayList(repairableRanges));
+
+            return Collections.singletonList(replicaRepairGroup);
+        }
+
+        return Collections.emptyList();
+    }
+}

--- a/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/repair/state/RepairStateFactoryImpl.java
+++ b/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/repair/state/RepairStateFactoryImpl.java
@@ -25,7 +25,7 @@ public class RepairStateFactoryImpl implements RepairStateFactory
 {
     private final HostStates myHostStates;
     private final TableRepairMetrics myTableRepairMetrics;
-
+    private final ReplicationState myReplicationState;
     private final VnodeRepairStateFactoryImpl myVnodeRepairStateFactory;
 
     private RepairStateFactoryImpl(Builder builder)
@@ -33,8 +33,8 @@ public class RepairStateFactoryImpl implements RepairStateFactory
         myHostStates = builder.myHostStates;
         myTableRepairMetrics = builder.myTableRepairMetrics;
 
-        ReplicationState replicationState = new ReplicationState(builder.myMetadata, builder.myHost);
-        myVnodeRepairStateFactory = new VnodeRepairStateFactoryImpl(replicationState, builder.myRepairHistoryProvider);
+        myReplicationState = new ReplicationState(builder.myMetadata, builder.myHost);
+        myVnodeRepairStateFactory = new VnodeRepairStateFactoryImpl(myReplicationState, builder.myRepairHistoryProvider);
     }
 
     @Override
@@ -46,6 +46,9 @@ public class RepairStateFactoryImpl implements RepairStateFactory
         {
             case VNODE:
                 replicaRepairGroupFactory = VnodeRepairGroupFactory.INSTANCE;
+                break;
+            case INCREMENTAL:
+                replicaRepairGroupFactory = new IncrementalRepairGroupFactory(tableReference, myReplicationState);
                 break;
             default:
                 throw new IllegalArgumentException("Repair type " + repairConfiguration.getRepairType() + " not supported yet");

--- a/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/repair/state/ReplicaRepairGroup.java
+++ b/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/repair/state/ReplicaRepairGroup.java
@@ -21,6 +21,7 @@ import com.google.common.collect.ImmutableSet;
 
 import java.util.Iterator;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -65,5 +66,22 @@ public class ReplicaRepairGroup implements Iterable<LongTokenRange>
     public String toString()
     {
         return String.format("(replicas=%s,vnodes=%s)", myReplicas, myVnodes);
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ReplicaRepairGroup that = (ReplicaRepairGroup) o;
+        return Objects.equals(myReplicas, that.myReplicas) &&
+                Objects.equals(myVnodes, that.myVnodes) &&
+                Objects.equals(myDataCenters, that.myDataCenters);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(myReplicas, myVnodes, myDataCenters);
     }
 }

--- a/core/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/repair/state/TestIncrementalRepairGroupFactory.java
+++ b/core/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/repair/state/TestIncrementalRepairGroupFactory.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2018 Telefonaktiebolaget LM Ericsson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ericsson.bss.cassandra.ecchronos.core.repair.state;
+
+import com.datastax.driver.core.Host;
+import com.ericsson.bss.cassandra.ecchronos.core.utils.LongTokenRange;
+import com.ericsson.bss.cassandra.ecchronos.core.utils.TableReference;
+import com.google.common.collect.ImmutableSet;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class TestIncrementalRepairGroupFactory
+{
+    private static final TableReference TABLE_REFERENCE = new TableReference("ks", "tb");
+
+    @Mock
+    private ReplicationState mockReplicationState;
+
+    @Test
+    public void testNoRepairableVnodesAndNoState()
+    {
+        when(mockReplicationState.getTokenRangeToReplicas(eq(TABLE_REFERENCE))).thenReturn(Collections.emptyMap());
+        List<VnodeRepairState> vnodeRepairStates = new ArrayList<>();
+
+        IncrementalRepairGroupFactory repairGroupFactory = new IncrementalRepairGroupFactory(TABLE_REFERENCE, mockReplicationState);
+        List<ReplicaRepairGroup> replicaRepairGroups = repairGroupFactory.generateReplicaRepairGroups(vnodeRepairStates);
+
+        assertThat(replicaRepairGroups).isEmpty();
+    }
+
+    @Test
+    public void testNoRepairableVnodes()
+    {
+        Host host1 = mockHost("dc1");
+        Host host2 = mockHost("dc1");
+        LongTokenRange longTokenRange = new LongTokenRange(1, 2);
+
+        Map<LongTokenRange, ImmutableSet<Host>> tokenRangeToHostMap = new HashMap<>();
+        tokenRangeToHostMap.put(longTokenRange, ImmutableSet.of(host1, host2));
+
+        when(mockReplicationState.getTokenRangeToReplicas(eq(TABLE_REFERENCE))).thenReturn(tokenRangeToHostMap);
+        List<VnodeRepairState> vnodeRepairStates = new ArrayList<>();
+
+        IncrementalRepairGroupFactory repairGroupFactory = new IncrementalRepairGroupFactory(TABLE_REFERENCE, mockReplicationState);
+        List<ReplicaRepairGroup> replicaRepairGroups = repairGroupFactory.generateReplicaRepairGroups(vnodeRepairStates);
+
+        assertThat(replicaRepairGroups).isEmpty();
+    }
+
+    @Test
+    public void testMatchingRepairableVnodesAndState()
+    {
+        Host host1 = mockHost("dc1");
+        Host host2 = mockHost("dc1");
+        LongTokenRange longTokenRange = new LongTokenRange(1, 2);
+        ImmutableSet<Host> replicas = ImmutableSet.of(host1, host2);
+
+        Map<LongTokenRange, ImmutableSet<Host>> tokenRangeToHostMap = new HashMap<>();
+        tokenRangeToHostMap.put(longTokenRange, replicas);
+
+        when(mockReplicationState.getTokenRangeToReplicas(eq(TABLE_REFERENCE))).thenReturn(tokenRangeToHostMap);
+        List<VnodeRepairState> vnodeRepairStates = new ArrayList<>();
+        vnodeRepairStates.add(new VnodeRepairState(longTokenRange, replicas, VnodeRepairState.UNREPAIRED));
+
+        IncrementalRepairGroupFactory repairGroupFactory = new IncrementalRepairGroupFactory(TABLE_REFERENCE, mockReplicationState);
+        List<ReplicaRepairGroup> replicaRepairGroups = repairGroupFactory.generateReplicaRepairGroups(vnodeRepairStates);
+
+        ReplicaRepairGroup expectedReplicaRepairGroup = new ReplicaRepairGroup(replicas, Collections.singletonList(longTokenRange));
+
+        assertThat(replicaRepairGroups).containsExactly(expectedReplicaRepairGroup);
+    }
+
+    @Test
+    public void testNonMatchingRepairableVnodesAndState()
+    {
+        Host host1 = mockHost("dc1");
+        Host host2 = mockHost("dc1");
+        LongTokenRange longTokenRange1 = new LongTokenRange(1, 2);
+        LongTokenRange longTokenRange2 = new LongTokenRange(2, 3);
+        ImmutableSet<Host> replicas = ImmutableSet.of(host1, host2);
+
+        Map<LongTokenRange, ImmutableSet<Host>> tokenRangeToHostMap = new HashMap<>();
+        tokenRangeToHostMap.put(longTokenRange1, replicas);
+        tokenRangeToHostMap.put(longTokenRange2, replicas);
+
+        when(mockReplicationState.getTokenRangeToReplicas(eq(TABLE_REFERENCE))).thenReturn(tokenRangeToHostMap);
+        List<VnodeRepairState> vnodeRepairStates = new ArrayList<>();
+        vnodeRepairStates.add(new VnodeRepairState(longTokenRange1, replicas, VnodeRepairState.UNREPAIRED));
+
+        IncrementalRepairGroupFactory repairGroupFactory = new IncrementalRepairGroupFactory(TABLE_REFERENCE, mockReplicationState);
+        List<ReplicaRepairGroup> replicaRepairGroups = repairGroupFactory.generateReplicaRepairGroups(vnodeRepairStates);
+
+        assertThat(replicaRepairGroups).isEmpty();
+    }
+
+    private Host mockHost(String dc)
+    {
+        Host host = mock(Host.class);
+        when(host.getDatacenter()).thenReturn(dc);
+        return host;
+    }
+}


### PR DESCRIPTION
Add support for creating incremental replica repair groups with
the new structure.

One difference to legacy behavior is that we no longer perform
"reduced" repairs with the replicas available.