### PR TITLE
Only update/remove priority for current job

### DIFF
--- a/core/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/TestCASLockFactory.java
+++ b/core/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/TestCASLockFactory.java
@@ -160,6 +160,32 @@ public class TestCASLockFactory extends AbstractCassandraTest
     }
 
     @Test
+    public void testGetLockWithLocallyHigherPriority() throws LockException
+    {
+        UUID localHostId = getNativeConnectionProvider().getLocalHost().getHostId();
+        execute(myCompeteStatement.bind("lock", localHostId, 2));
+
+        try (DistributedLock lock = myLockFactory.tryLock(DATA_CENTER, "lock", 1, new HashMap<>()))
+        {
+        }
+
+        assertPrioritiesInList("lock", 2);
+    }
+
+    @Test
+    public void testGetLockWithLocallyLowerPriority() throws LockException
+    {
+        UUID localHostId = getNativeConnectionProvider().getLocalHost().getHostId();
+        execute(myCompeteStatement.bind("lock", localHostId, 1));
+
+        try (DistributedLock lock = myLockFactory.tryLock(DATA_CENTER, "lock", 2, new HashMap<>()))
+        {
+        }
+
+        assertPriorityListEmpty("lock");
+    }
+
+    @Test
     public void testReadMetadata() throws LockException
     {
         Map<String, String> expectedMetadata = new HashMap<>();


### PR DESCRIPTION
Previously we always wrote the current jobs priority and removed
it afterwards. Jobs are tried in order from highest to lowest
priority and we could end up overwriting/deleting the priority from
other local jobs. To avoid this we should check what priority is
currently there first.