### PR TITLE
Dynamic license header check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ cache:
   - $HOME/.m2
 matrix:
   include:
+  - name: "License check"
+    env: TEST_SUITE='com.mycila:license-maven-plugin:check'
   - name: "PMD"
     env: TEST_SUITE='pmd:pmd pmd:cpd pmd:check pmd:cpd-check'
   - name: "Javadoc"

--- a/pom.xml
+++ b/pom.xml
@@ -396,7 +396,7 @@
                     <version>${com.mycila.license-maven-plugin.version}</version>
                     <configuration>
                         <inlineHeader><![CDATA[
-Copyright 2018 Telefonaktiebolaget LM Ericsson
+Copyright YEAR Telefonaktiebolaget LM Ericsson
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -411,12 +411,18 @@ limitations under the License.
 ]]>
                         </inlineHeader>
                         <mapping>
-                            <pom.xml>XML_STYLE</pom.xml>
                             <java>SLASHSTAR_STYLE</java>
                             <cfg>SCRIPT_STYLE</cfg>
                         </mapping>
                         <strictCheck>true</strictCheck>
                         <failIfUnknown>true</failIfUnknown>
+                        <headerSections>
+                            <headerSection>
+                                <key>YEAR</key>
+                                <defaultValue>2019</defaultValue>
+                                <ensureMatch>[0-9-]+</ensureMatch>
+                            </headerSection>
+                        </headerSections>
                         <excludes>
                             <exclude>src/test/resources/cassandra.yaml</exclude>
                             <exclude>src/test/resources/cassandra-rackdc.properties</exclude>
@@ -462,19 +468,6 @@ limitations under the License.
         </pluginManagement>
 
         <plugins>
-            <plugin>
-                <groupId>com.mycila</groupId>
-                <artifactId>license-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>check-license</id>
-                        <goals>
-                            <goal>check</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>


### PR DESCRIPTION
Fixing issue #37 have a configurable year for the license headers.

Also remove license check from normal build and have it in a verification phase in travis instead.