### PR TITLE
Start docker containers only once for OSGi integration tests

### DIFF
--- a/standalone-integration/pom.xml
+++ b/standalone-integration/pom.xml
@@ -129,11 +129,6 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>io.fabric8</groupId>
-                <artifactId>docker-maven-plugin</artifactId>
-            </plugin>
-
-            <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
                     <source>1.8</source>


### PR DESCRIPTION
Remove docker start from standalone integration tests