### PR TITLE
Cache lock failure

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Changes
 
+## Version 1.0.3
+
+* Cache locking failures to reduce unnecessary contention - Issue #70
+
 ## Version 1.0.2
 
 * Locking failures log too much - Issue #58

--- a/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/CASLockFactory.java
+++ b/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/CASLockFactory.java
@@ -23,6 +23,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.Executors;
@@ -247,6 +248,12 @@ public class CASLockFactory implements LockFactory, Closeable
         }
 
         return false;
+    }
+
+    @Override
+    public Optional<LockException> getCachedLockException(String dataCenter, String resource)
+    {
+        return myLockCache.getCachedFailure(dataCenter, resource);
     }
 
     @Override

--- a/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/CASLockFactory.java
+++ b/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/CASLockFactory.java
@@ -113,6 +113,7 @@ public class CASLockFactory implements LockFactory, Closeable
     private final PreparedStatement myRemoveLockStatement;
     private final PreparedStatement myUpdateLockStatement;
     private final PreparedStatement myRemoveLockPriorityStatement;
+    private final LockCache myLockCache;
 
     private CASLockFactory(Builder builder)
     {
@@ -194,34 +195,14 @@ public class CASLockFactory implements LockFactory, Closeable
         }
 
         myUuid = hostId;
+
+        myLockCache = new LockCache(this::doTryLock);
     }
 
     @Override
     public DistributedLock tryLock(String dataCenter, String resource, int priority, Map<String, String> metadata) throws LockException
     {
-        LOG.trace("Trying lock for {} - {}", dataCenter, resource);
-
-        if (!sufficientNodesForLocking(dataCenter, resource))
-        {
-            LOG.error("Not sufficient nodes to lock resource {} in datacenter {}", resource, dataCenter);
-            throw new LockException("Not sufficient nodes to lock");
-        }
-
-        try
-        {
-            CASLock casLock = new CASLock(dataCenter, resource, priority, metadata); // NOSONAR
-            if (casLock.lock())
-            {
-                return casLock;
-            }
-        }
-        catch (Exception e)
-        {
-            LOG.warn("Unable to lock resource {} in datacenter {} - {}", resource, dataCenter, e.getMessage());
-            throw new LockException(e);
-        }
-
-        throw new LockException(String.format("Unable to lock resource %s in datacenter %s", resource, dataCenter));
+        return myLockCache.getLock(dataCenter, resource, priority, metadata);
     }
 
     @Override
@@ -337,6 +318,33 @@ public class CASLockFactory implements LockFactory, Closeable
 
             return new CASLockFactory(this);
         }
+    }
+
+    private DistributedLock doTryLock(String dataCenter, String resource, int priority, Map<String, String> metadata) throws LockException
+    {
+        LOG.trace("Trying lock for {} - {}", dataCenter, resource);
+
+        if (!sufficientNodesForLocking(dataCenter, resource))
+        {
+            LOG.error("Not sufficient nodes to lock resource {} in datacenter {}", resource, dataCenter);
+            throw new LockException("Not sufficient nodes to lock");
+        }
+
+        try
+        {
+            CASLock casLock = new CASLock(dataCenter, resource, priority, metadata); // NOSONAR
+            if (casLock.lock())
+            {
+                return casLock;
+            }
+        }
+        catch (Exception e)
+        {
+            LOG.warn("Unable to lock resource {} in datacenter {} - {}", resource, dataCenter, e.getMessage());
+            throw new LockException(e);
+        }
+
+        throw new LockException(String.format("Unable to lock resource %s in datacenter %s", resource, dataCenter));
     }
 
     private Set<Host> getHostsForResource(String dataCenter, String resource) throws UnsupportedEncodingException

--- a/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/CASLockFactory.java
+++ b/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/CASLockFactory.java
@@ -251,7 +251,7 @@ public class CASLockFactory implements LockFactory, Closeable
     }
 
     @Override
-    public Optional<LockException> getCachedLockException(String dataCenter, String resource)
+    public Optional<LockException> getCachedFailure(String dataCenter, String resource)
     {
         return myLockCache.getCachedFailure(dataCenter, resource);
     }

--- a/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/LockCache.java
+++ b/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/LockCache.java
@@ -48,6 +48,11 @@ public class LockCache
                 .build();
     }
 
+    public Optional<LockException> getCachedFailure(String dataCenter, String resource)
+    {
+        return getCachedFailure(new LockKey(dataCenter, resource));
+    }
+
     public DistributedLock getLock(String dataCenter, String resource, int priority, Map<String, String> metadata) throws LockException
     {
         LockKey lockKey = new LockKey(dataCenter, resource);

--- a/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/LockCache.java
+++ b/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/LockCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Telefonaktiebolaget LM Ericsson
+ * Copyright 2019 Telefonaktiebolaget LM Ericsson
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,12 +16,14 @@ package com.ericsson.bss.cassandra.ecchronos.core;
 
 import com.ericsson.bss.cassandra.ecchronos.core.exceptions.LockException;
 import com.ericsson.bss.cassandra.ecchronos.core.scheduling.LockFactory.DistributedLock;
+import com.google.common.base.Preconditions;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
@@ -95,12 +97,13 @@ public class LockCache
     static final class LockKey
     {
         private final String myDataCenter;
-        private final String myResource;
+        private final String myResourceName;
 
         LockKey(String dataCenter, String resource)
         {
+            Preconditions.checkNotNull(resource);
             myDataCenter = dataCenter;
-            myResource = resource;
+            myResourceName = resource;
         }
 
         @Override
@@ -108,19 +111,15 @@ public class LockCache
         {
             if (this == o) return true;
             if (o == null || getClass() != o.getClass()) return false;
-
             LockKey lockKey = (LockKey) o;
-
-            if (myDataCenter != null ? !myDataCenter.equals(lockKey.myDataCenter) : lockKey.myDataCenter != null) return false;
-            return myResource.equals(lockKey.myResource);
+            return Objects.equals(myDataCenter, lockKey.myDataCenter) &&
+                    myResourceName.equals(lockKey.myResourceName);
         }
 
         @Override
         public int hashCode()
         {
-            int result = myDataCenter != null ? myDataCenter.hashCode() : 0;
-            result = 31 * result + myResource.hashCode();
-            return result;
+            return Objects.hash(myDataCenter, myResourceName);
         }
     }
 }

--- a/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/LockCache.java
+++ b/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/LockCache.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2018 Telefonaktiebolaget LM Ericsson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ericsson.bss.cassandra.ecchronos.core;
+
+import com.ericsson.bss.cassandra.ecchronos.core.exceptions.LockException;
+import com.ericsson.bss.cassandra.ecchronos.core.scheduling.LockFactory.DistributedLock;
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+public class LockCache
+{
+    private static final Logger LOG = LoggerFactory.getLogger(LockCache.class);
+
+    private static final long DEFAULT_EXPIRE_TIME_IN_SECONDS = 30;
+
+    private final Cache<LockKey, LockException> myFailureCache;
+    private final LockSupplier myLockSupplier;
+
+    public LockCache(LockSupplier lockSupplier)
+    {
+        this(lockSupplier, DEFAULT_EXPIRE_TIME_IN_SECONDS, TimeUnit.SECONDS);
+    }
+
+    LockCache(LockSupplier lockSupplier, long expireTime, TimeUnit expireTimeUnit)
+    {
+        myLockSupplier = lockSupplier;
+
+        myFailureCache = CacheBuilder.newBuilder()
+                .expireAfterWrite(expireTime, expireTimeUnit)
+                .build();
+    }
+
+    public DistributedLock getLock(String dataCenter, String resource, int priority, Map<String, String> metadata) throws LockException
+    {
+        LockKey lockKey = new LockKey(dataCenter, resource);
+
+        Optional<LockException> cachedFailure = getCachedFailure(lockKey);
+
+        if (cachedFailure.isPresent())
+        {
+            throwCachedLockException(cachedFailure.get());
+        }
+
+        try
+        {
+            return myLockSupplier.getLock(dataCenter, resource, priority, metadata);
+        }
+        catch (LockException e)
+        {
+            myFailureCache.put(lockKey, e);
+            throw e;
+        }
+    }
+
+    private void throwCachedLockException(LockException e) throws LockException
+    {
+        LOG.debug("Encountered cached locking failure, throwing exception", e);
+        throw e;
+    }
+
+    private Optional<LockException> getCachedFailure(LockKey lockKey)
+    {
+        return Optional.ofNullable(myFailureCache.getIfPresent(lockKey));
+    }
+
+    @FunctionalInterface
+    public interface LockSupplier
+    {
+        DistributedLock getLock(String dataCenter, String resource, int priority, Map<String, String> metadata) throws LockException;
+    }
+
+    static final class LockKey
+    {
+        private final String myDataCenter;
+        private final String myResource;
+
+        LockKey(String dataCenter, String resource)
+        {
+            myDataCenter = dataCenter;
+            myResource = resource;
+        }
+
+        @Override
+        public boolean equals(Object o)
+        {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            LockKey lockKey = (LockKey) o;
+
+            if (myDataCenter != null ? !myDataCenter.equals(lockKey.myDataCenter) : lockKey.myDataCenter != null) return false;
+            return myResource.equals(lockKey.myResource);
+        }
+
+        @Override
+        public int hashCode()
+        {
+            int result = myDataCenter != null ? myDataCenter.hashCode() : 0;
+            result = 31 * result + myResource.hashCode();
+            return result;
+        }
+    }
+}

--- a/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/LockCache.java
+++ b/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/LockCache.java
@@ -16,7 +16,6 @@ package com.ericsson.bss.cassandra.ecchronos.core;
 
 import com.ericsson.bss.cassandra.ecchronos.core.exceptions.LockException;
 import com.ericsson.bss.cassandra.ecchronos.core.scheduling.LockFactory.DistributedLock;
-import com.google.common.base.Preconditions;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import org.slf4j.Logger;
@@ -26,6 +25,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
+
+import static com.google.common.base.Preconditions.checkNotNull;
 
 public class LockCache
 {
@@ -99,11 +100,10 @@ public class LockCache
         private final String myDataCenter;
         private final String myResourceName;
 
-        LockKey(String dataCenter, String resource)
+        LockKey(String dataCenter, String resourceName)
         {
-            Preconditions.checkNotNull(resource);
             myDataCenter = dataCenter;
-            myResourceName = resource;
+            myResourceName = checkNotNull(resourceName);
         }
 
         @Override
@@ -113,7 +113,7 @@ public class LockCache
             if (o == null || getClass() != o.getClass()) return false;
             LockKey lockKey = (LockKey) o;
             return Objects.equals(myDataCenter, lockKey.myDataCenter) &&
-                    myResourceName.equals(lockKey.myResourceName);
+                    Objects.equals(myResourceName, lockKey.myResourceName);
         }
 
         @Override

--- a/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/repair/RepairLockFactoryImpl.java
+++ b/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/repair/RepairLockFactoryImpl.java
@@ -50,18 +50,18 @@ public class RepairLockFactoryImpl implements RepairLockFactory
             throw new LockException(msg);
         }
 
-        validateNoCachedExceptions(lockFactory, repairResources);
+        validateNoCachedFailures(lockFactory, repairResources);
 
         Collection<LockFactory.DistributedLock> locks = getRepairResourceLocks(lockFactory, repairResources, metadata, priority);
 
         return new LockCollection(locks);
     }
 
-    private void validateNoCachedExceptions(LockFactory lockFactory, Set<RepairResource> repairResources) throws LockException
+    private void validateNoCachedFailures(LockFactory lockFactory, Set<RepairResource> repairResources) throws LockException
     {
         for (RepairResource repairResource : repairResources)
         {
-            Optional<LockException> cachedException = lockFactory.getCachedLockException(repairResource.getDataCenter(), repairResource.getResourceName(LOCKS_PER_RESOURCE));
+            Optional<LockException> cachedException = lockFactory.getCachedFailure(repairResource.getDataCenter(), repairResource.getResourceName(LOCKS_PER_RESOURCE));
             if (cachedException.isPresent())
             {
                 LOG.debug("Found cached locking failure for {}, rethrowing", repairResource, cachedException.get());

--- a/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/repair/RepairLockFactoryImpl.java
+++ b/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/repair/RepairLockFactoryImpl.java
@@ -23,18 +23,21 @@ import org.slf4j.LoggerFactory;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 public class RepairLockFactoryImpl implements RepairLockFactory
 {
     private static final Logger LOG = LoggerFactory.getLogger(RepairLockFactoryImpl.class);
 
+    private static final int LOCKS_PER_RESOURCE = 1;
+
     @Override
     public LockFactory.DistributedLock getLock(LockFactory lockFactory, Set<RepairResource> repairResources, Map<String, String> metadata, int priority) throws LockException
     {
         for (RepairResource repairResource : repairResources)
         {
-            if (!lockFactory.sufficientNodesForLocking(repairResource.getDataCenter(), repairResource.getResourceName(1)))
+            if (!lockFactory.sufficientNodesForLocking(repairResource.getDataCenter(), repairResource.getResourceName(LOCKS_PER_RESOURCE)))
             {
                 throw new LockException(repairResource + " not lockable. Repair will be retried later.");
             }
@@ -47,9 +50,24 @@ public class RepairLockFactoryImpl implements RepairLockFactory
             throw new LockException(msg);
         }
 
+        validateNoCachedExceptions(lockFactory, repairResources);
+
         Collection<LockFactory.DistributedLock> locks = getRepairResourceLocks(lockFactory, repairResources, metadata, priority);
 
         return new LockCollection(locks);
+    }
+
+    private void validateNoCachedExceptions(LockFactory lockFactory, Set<RepairResource> repairResources) throws LockException
+    {
+        for (RepairResource repairResource : repairResources)
+        {
+            Optional<LockException> cachedException = lockFactory.getCachedLockException(repairResource.getDataCenter(), repairResource.getResourceName(LOCKS_PER_RESOURCE));
+            if (cachedException.isPresent())
+            {
+                LOG.debug("Found cached locking failure for {}, rethrowing", repairResource, cachedException.get());
+                throw cachedException.get();
+            }
+        }
     }
 
     private Collection<LockFactory.DistributedLock> getRepairResourceLocks(LockFactory lockFactory, Collection<RepairResource> repairResources, Map<String, String> metadata, int priority) throws LockException
@@ -94,7 +112,7 @@ public class RepairLockFactoryImpl implements RepairLockFactory
 
         String dataCenter = repairResource.getDataCenter();
 
-        String resource = repairResource.getResourceName(1);
+        String resource = repairResource.getResourceName(LOCKS_PER_RESOURCE);
         try
         {
             myLock = lockFactory.tryLock(dataCenter, resource, priority, metadata);

--- a/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/repair/RepairResource.java
+++ b/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/repair/RepairResource.java
@@ -14,9 +14,9 @@
  */
 package com.ericsson.bss.cassandra.ecchronos.core.repair;
 
-import com.google.common.base.Preconditions;
-
 import java.util.Objects;
+
+import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * A lock resource for repair.
@@ -28,9 +28,8 @@ public class RepairResource
 
     public RepairResource(String dataCenter, String resourceName)
     {
-        Preconditions.checkNotNull(resourceName);
         myDataCenter = dataCenter;
-        myResourceName = resourceName;
+        myResourceName = checkNotNull(resourceName);
     }
 
     public String getDataCenter()
@@ -56,7 +55,7 @@ public class RepairResource
         if (o == null || getClass() != o.getClass()) return false;
         RepairResource that = (RepairResource) o;
         return Objects.equals(myDataCenter, that.myDataCenter) &&
-                myResourceName.equals(that.myResourceName);
+                Objects.equals(myResourceName, that.myResourceName);
     }
 
     @Override

--- a/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/repair/RepairResource.java
+++ b/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/repair/RepairResource.java
@@ -14,6 +14,8 @@
  */
 package com.ericsson.bss.cassandra.ecchronos.core.repair;
 
+import com.google.common.base.Preconditions;
+
 import java.util.Objects;
 
 /**
@@ -26,6 +28,7 @@ public class RepairResource
 
     public RepairResource(String dataCenter, String resourceName)
     {
+        Preconditions.checkNotNull(resourceName);
         myDataCenter = dataCenter;
         myResourceName = resourceName;
     }
@@ -53,13 +56,12 @@ public class RepairResource
         if (o == null || getClass() != o.getClass()) return false;
         RepairResource that = (RepairResource) o;
         return Objects.equals(myDataCenter, that.myDataCenter) &&
-                Objects.equals(myResourceName, that.myResourceName);
+                myResourceName.equals(that.myResourceName);
     }
 
     @Override
     public int hashCode()
     {
-
         return Objects.hash(myDataCenter, myResourceName);
     }
 }

--- a/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/scheduling/LockFactory.java
+++ b/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/scheduling/LockFactory.java
@@ -16,6 +16,7 @@ package com.ericsson.bss.cassandra.ecchronos.core.scheduling;
 
 import java.io.Closeable;
 import java.util.Map;
+import java.util.Optional;
 
 import com.ericsson.bss.cassandra.ecchronos.core.exceptions.LockException;
 
@@ -67,6 +68,18 @@ public interface LockFactory
      *            Indicates if local_quorum is met.
      */
     boolean sufficientNodesForLocking(String dataCenter, String resource);
+
+    /**
+     * Utility method to return a cached lock exception if one is available.
+     *
+     * @param dataCenter The data center the lock is for.
+     * @param resource The resource the lock is for.
+     * @return A cached exception if available.
+     */
+    default Optional<LockException> getCachedLockException(String dataCenter, String resource)
+    {
+        return Optional.empty();
+    }
 
     /**
      * A locked resource that gets released by the call of the {@link DistributedLock#close() close()} method.

--- a/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/scheduling/LockFactory.java
+++ b/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/scheduling/LockFactory.java
@@ -30,7 +30,7 @@ public interface LockFactory
      * Try to lock a distributed resource using the provided priority.
      *
      * @param dataCenter
-     *            The data center the lock belongs to.
+     *            The data center the lock belongs to or null if it's a global lock.
      * @param resource
      *            The resource to lock.
      * @param priority
@@ -47,7 +47,7 @@ public interface LockFactory
      * Get the metadata of a resource lock.
      *
      * @param dataCenter
-     *            The data center the lock belongs to.
+     *            The data center the lock belongs to or null if it's a global lock.
      * @param resource
      *            The data center resource:
      *             i.e "RepairResource-DC1-1".
@@ -60,7 +60,7 @@ public interface LockFactory
      * Checks if local_quorum is met.
      *
      * @param dataCenter
-     *            The data center the lock belongs to.
+     *            The data center the lock belongs to or null if it's a global lock.
      * @param resource
      *            The data center resource.
      *             i.e "RepairResource-DC1-1".
@@ -72,7 +72,7 @@ public interface LockFactory
     /**
      * Utility method to return a cached lock exception if one is available.
      *
-     * @param dataCenter The data center the lock is for.
+     * @param dataCenter The data center the lock is for or null if it's a global lock.
      * @param resource The resource the lock is for.
      * @return A cached exception if available.
      */

--- a/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/scheduling/LockFactory.java
+++ b/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/scheduling/LockFactory.java
@@ -76,7 +76,7 @@ public interface LockFactory
      * @param resource The resource the lock is for.
      * @return A cached exception if available.
      */
-    default Optional<LockException> getCachedLockException(String dataCenter, String resource)
+    default Optional<LockException> getCachedFailure(String dataCenter, String resource)
     {
         return Optional.empty();
     }

--- a/core/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/TestCASLockFactory.java
+++ b/core/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/TestCASLockFactory.java
@@ -123,6 +123,7 @@ public class TestCASLockFactory extends AbstractCassandraTest
         }
 
         assertPriorityListEmpty("lock");
+        assertThat(myLockFactory.getCachedLockException(DATA_CENTER, "lock")).isEmpty();
     }
 
     @Test
@@ -132,6 +133,7 @@ public class TestCASLockFactory extends AbstractCassandraTest
         {
         }
         assertPriorityListEmpty("lock");
+        assertThat(myLockFactory.getCachedLockException(null, "lock")).isEmpty();
     }
 
     @Test
@@ -141,6 +143,7 @@ public class TestCASLockFactory extends AbstractCassandraTest
 
         assertThatExceptionOfType(LockException.class).isThrownBy(() -> myLockFactory.tryLock(null, "lock", 1, new HashMap<>()));
         assertPrioritiesInList("lock", 1);
+        assertThat(myLockFactory.getCachedLockException(null, "lock")).isNotEmpty();
     }
 
     @Test
@@ -163,6 +166,7 @@ public class TestCASLockFactory extends AbstractCassandraTest
         assertThat(getWriteCount(TABLE_LOCK)).isEqualTo(expectedLockWriteCount);
 
         assertPrioritiesInList("lock", 2);
+        assertThat(myLockFactory.getCachedLockException(null, "lock")).isNotEmpty();
     }
 
     @Test
@@ -172,6 +176,7 @@ public class TestCASLockFactory extends AbstractCassandraTest
 
         assertThatExceptionOfType(LockException.class).isThrownBy(() -> myLockFactory.tryLock(DATA_CENTER, "lock", 1, new HashMap<>()));
         assertPrioritiesInList("lock", 1, 2);
+        assertThat(myLockFactory.getCachedLockException(DATA_CENTER, "lock")).isNotEmpty();
     }
 
     @Test
@@ -181,6 +186,7 @@ public class TestCASLockFactory extends AbstractCassandraTest
 
         assertThatExceptionOfType(LockException.class).isThrownBy(() -> myLockFactory.tryLock(DATA_CENTER, "lock", 1, new HashMap<>()));
         assertPrioritiesInList("lock", 1);
+        assertThat(myLockFactory.getCachedLockException(DATA_CENTER, "lock")).isNotEmpty();
     }
 
     @Test
@@ -194,6 +200,7 @@ public class TestCASLockFactory extends AbstractCassandraTest
         }
 
         assertPrioritiesInList("lock", 2);
+        assertThat(myLockFactory.getCachedLockException(DATA_CENTER, "lock")).isEmpty();
     }
 
     @Test
@@ -207,6 +214,7 @@ public class TestCASLockFactory extends AbstractCassandraTest
         }
 
         assertPriorityListEmpty("lock");
+        assertThat(myLockFactory.getCachedLockException(DATA_CENTER, "lock")).isEmpty();
     }
 
     @Test
@@ -223,6 +231,7 @@ public class TestCASLockFactory extends AbstractCassandraTest
         }
 
         assertPriorityListEmpty("lock");
+        assertThat(myLockFactory.getCachedLockException(DATA_CENTER, "lock")).isEmpty();
     }
 
     @Test
@@ -268,6 +277,8 @@ public class TestCASLockFactory extends AbstractCassandraTest
             lockUpdateTask.run();
             assertThat(lockUpdateTask.getFailedAttempts()).isEqualTo(0);
         }
+
+        assertThat(myLockFactory.getCachedLockException(DATA_CENTER, "lock")).isEmpty();
     }
 
     @Test

--- a/core/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/TestCASLockFactory.java
+++ b/core/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/TestCASLockFactory.java
@@ -123,7 +123,7 @@ public class TestCASLockFactory extends AbstractCassandraTest
         }
 
         assertPriorityListEmpty("lock");
-        assertThat(myLockFactory.getCachedLockException(DATA_CENTER, "lock")).isEmpty();
+        assertThat(myLockFactory.getCachedFailure(DATA_CENTER, "lock")).isEmpty();
     }
 
     @Test
@@ -133,7 +133,7 @@ public class TestCASLockFactory extends AbstractCassandraTest
         {
         }
         assertPriorityListEmpty("lock");
-        assertThat(myLockFactory.getCachedLockException(null, "lock")).isEmpty();
+        assertThat(myLockFactory.getCachedFailure(null, "lock")).isEmpty();
     }
 
     @Test
@@ -143,7 +143,7 @@ public class TestCASLockFactory extends AbstractCassandraTest
 
         assertThatExceptionOfType(LockException.class).isThrownBy(() -> myLockFactory.tryLock(null, "lock", 1, new HashMap<>()));
         assertPrioritiesInList("lock", 1);
-        assertThat(myLockFactory.getCachedLockException(null, "lock")).isNotEmpty();
+        assertThat(myLockFactory.getCachedFailure(null, "lock")).isNotEmpty();
     }
 
     @Test
@@ -166,7 +166,7 @@ public class TestCASLockFactory extends AbstractCassandraTest
         assertThat(getWriteCount(TABLE_LOCK)).isEqualTo(expectedLockWriteCount);
 
         assertPrioritiesInList("lock", 2);
-        assertThat(myLockFactory.getCachedLockException(null, "lock")).isNotEmpty();
+        assertThat(myLockFactory.getCachedFailure(null, "lock")).isNotEmpty();
     }
 
     @Test
@@ -176,7 +176,7 @@ public class TestCASLockFactory extends AbstractCassandraTest
 
         assertThatExceptionOfType(LockException.class).isThrownBy(() -> myLockFactory.tryLock(DATA_CENTER, "lock", 1, new HashMap<>()));
         assertPrioritiesInList("lock", 1, 2);
-        assertThat(myLockFactory.getCachedLockException(DATA_CENTER, "lock")).isNotEmpty();
+        assertThat(myLockFactory.getCachedFailure(DATA_CENTER, "lock")).isNotEmpty();
     }
 
     @Test
@@ -186,7 +186,7 @@ public class TestCASLockFactory extends AbstractCassandraTest
 
         assertThatExceptionOfType(LockException.class).isThrownBy(() -> myLockFactory.tryLock(DATA_CENTER, "lock", 1, new HashMap<>()));
         assertPrioritiesInList("lock", 1);
-        assertThat(myLockFactory.getCachedLockException(DATA_CENTER, "lock")).isNotEmpty();
+        assertThat(myLockFactory.getCachedFailure(DATA_CENTER, "lock")).isNotEmpty();
     }
 
     @Test
@@ -200,7 +200,7 @@ public class TestCASLockFactory extends AbstractCassandraTest
         }
 
         assertPrioritiesInList("lock", 2);
-        assertThat(myLockFactory.getCachedLockException(DATA_CENTER, "lock")).isEmpty();
+        assertThat(myLockFactory.getCachedFailure(DATA_CENTER, "lock")).isEmpty();
     }
 
     @Test
@@ -214,7 +214,7 @@ public class TestCASLockFactory extends AbstractCassandraTest
         }
 
         assertPriorityListEmpty("lock");
-        assertThat(myLockFactory.getCachedLockException(DATA_CENTER, "lock")).isEmpty();
+        assertThat(myLockFactory.getCachedFailure(DATA_CENTER, "lock")).isEmpty();
     }
 
     @Test
@@ -231,7 +231,7 @@ public class TestCASLockFactory extends AbstractCassandraTest
         }
 
         assertPriorityListEmpty("lock");
-        assertThat(myLockFactory.getCachedLockException(DATA_CENTER, "lock")).isEmpty();
+        assertThat(myLockFactory.getCachedFailure(DATA_CENTER, "lock")).isEmpty();
     }
 
     @Test
@@ -278,7 +278,7 @@ public class TestCASLockFactory extends AbstractCassandraTest
             assertThat(lockUpdateTask.getFailedAttempts()).isEqualTo(0);
         }
 
-        assertThat(myLockFactory.getCachedLockException(DATA_CENTER, "lock")).isEmpty();
+        assertThat(myLockFactory.getCachedFailure(DATA_CENTER, "lock")).isEmpty();
     }
 
     @Test

--- a/core/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/TestLockCache.java
+++ b/core/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/TestLockCache.java
@@ -108,6 +108,7 @@ public class TestLockCache
     private void assertExpectedLockIsRetrieved(String resource) throws LockException
     {
         assertThat(myLockCache.getLock(DATA_CENTER, resource, PRIORITY, METADATA)).isEqualTo(mockedDistributedLock);
+        assertThat(myLockCache.getCachedFailure(DATA_CENTER, resource)).isEmpty();
     }
 
     private void assertCacheThrowsException()
@@ -118,6 +119,7 @@ public class TestLockCache
     private void assertCacheThrowsException(String resource)
     {
         assertThatExceptionOfType(LockException.class).isThrownBy(() -> myLockCache.getLock(DATA_CENTER, resource, PRIORITY, METADATA));
+        assertThat(myLockCache.getCachedFailure(DATA_CENTER, resource)).isNotEmpty();
     }
 
     private void doReturnLockOnSupply() throws LockException

--- a/core/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/TestLockCache.java
+++ b/core/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/TestLockCache.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2018 Telefonaktiebolaget LM Ericsson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ericsson.bss.cassandra.ecchronos.core;
+
+import com.ericsson.bss.cassandra.ecchronos.core.exceptions.LockException;
+import com.ericsson.bss.cassandra.ecchronos.core.scheduling.LockFactory;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class TestLockCache
+{
+    private static final String DATA_CENTER = "DC1";
+    private static final String RESOURCE = "RepairResource-91e32362-7af4-11e9-8f9e-2a86e4085a59-1";
+    private static final int PRIORITY = 1;
+    private static final Map<String, String> METADATA = new HashMap<>();
+
+    @Mock
+    private LockCache.LockSupplier mockedLockSupplier;
+
+    @Mock
+    private LockFactory.DistributedLock mockedDistributedLock;
+
+    private LockCache myLockCache;
+
+    @Before
+    public void setup()
+    {
+        myLockCache = new LockCache(mockedLockSupplier);
+    }
+
+    @Test
+    public void testGetLock() throws LockException
+    {
+        doReturnLockOnSupply();
+
+        assertExpectedLockIsRetrieved();
+    }
+
+    @Test
+    public void testGetThrowingLockIsCached() throws LockException
+    {
+        doThrowOnSupply();
+
+        assertCacheThrowsException();
+
+        // Reset return type, locking should still throw
+        doReturnLockOnSupply();
+
+        assertCacheThrowsException();
+    }
+
+    @Test
+    public void testGetOtherLockAfterThrowing() throws LockException
+    {
+        String otherResource = "RepairResource-b2e33e60-7af6-11e9-8f9e-2a86e4085a59-1";
+
+        doThrowOnSupply(RESOURCE);
+        doReturnLockOnSupply(otherResource);
+
+        assertCacheThrowsException(RESOURCE);
+        assertExpectedLockIsRetrieved(otherResource);
+    }
+
+    @Test
+    public void testGetLockAfterCachedExceptionHasExpired() throws LockException, InterruptedException
+    {
+        myLockCache = new LockCache(mockedLockSupplier, 20, TimeUnit.MILLISECONDS);
+
+        doThrowOnSupply();
+        assertCacheThrowsException();
+
+        Thread.sleep(20);
+
+        doReturnLockOnSupply();
+        assertExpectedLockIsRetrieved();
+    }
+
+    private void assertExpectedLockIsRetrieved() throws LockException
+    {
+        assertExpectedLockIsRetrieved(RESOURCE);
+    }
+
+    private void assertExpectedLockIsRetrieved(String resource) throws LockException
+    {
+        assertThat(myLockCache.getLock(DATA_CENTER, resource, PRIORITY, METADATA)).isEqualTo(mockedDistributedLock);
+    }
+
+    private void assertCacheThrowsException()
+    {
+        assertCacheThrowsException(RESOURCE);
+    }
+
+    private void assertCacheThrowsException(String resource)
+    {
+        assertThatExceptionOfType(LockException.class).isThrownBy(() -> myLockCache.getLock(DATA_CENTER, resource, PRIORITY, METADATA));
+    }
+
+    private void doReturnLockOnSupply() throws LockException
+    {
+        doReturnLockOnSupply(RESOURCE);
+    }
+
+    private void doReturnLockOnSupply(String resouce) throws LockException
+    {
+        when(mockedLockSupplier.getLock(eq(DATA_CENTER), eq(resouce), eq(PRIORITY), eq(METADATA))).thenReturn(mockedDistributedLock);
+    }
+
+    private void doThrowOnSupply() throws LockException
+    {
+        doThrowOnSupply(RESOURCE);
+    }
+
+    private void doThrowOnSupply(String resource) throws LockException
+    {
+        when(mockedLockSupplier.getLock(eq(DATA_CENTER), eq(resource), eq(PRIORITY), eq(METADATA))).thenThrow(new LockException(""));
+    }
+}

--- a/core/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/repair/TestRepairLockFactoryImpl.java
+++ b/core/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/repair/TestRepairLockFactoryImpl.java
@@ -230,7 +230,6 @@ public class TestRepairLockFactoryImpl
     private void withSuccessfulLocking(RepairResource repairResource, int priority, Map<String, String> metadata) throws LockException
     {
         when(mockLockFactory.tryLock(eq(repairResource.getDataCenter()), eq(repairResource.getResourceName(LOCKS_PER_RESOURCE)), eq(priority), eq(metadata))).thenReturn(mockLock);
-        withSufficientNodesForLocking(repairResource);
     }
 
     private void withUnsuccessfulLocking(RepairResource repairResource, int priority, Map<String, String> metadata) throws LockException


### PR DESCRIPTION
Cache locking failures to avoid retrying the same lock over and over.

- Add lock cache in CASLockFactory.
- Add possibility for repair to fail-fast if locks are already known to be unavailable.

Fixes Issue #70 