### PR TITLE
Reduce error levels to warn

### DIFF
--- a/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/CASLockFactory.java
+++ b/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/CASLockFactory.java
@@ -222,7 +222,7 @@ public class CASLockFactory implements LockFactory, Closeable
         }
         catch (Exception e)
         {
-            LOG.error("Unable to retrieve metadata for resource {}", resource, e);
+            LOG.warn("Unable to retrieve metadata for resource {}", resource, e);
         }
 
         return null;
@@ -333,7 +333,7 @@ public class CASLockFactory implements LockFactory, Closeable
 
         if (!sufficientNodesForLocking(dataCenter, resource))
         {
-            LOG.error("Not sufficient nodes to lock resource {} in datacenter {}", resource, dataCenter);
+            LOG.warn("Not sufficient nodes to lock resource {} in datacenter {}", resource, dataCenter);
             throw new LockException("Not sufficient nodes to lock");
         }
 

--- a/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/LockCollection.java
+++ b/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/LockCollection.java
@@ -49,7 +49,7 @@ public class LockCollection implements LockFactory.DistributedLock
             }
             catch (Exception e)
             {
-                LOG.error("Unable to release lock {} ", lock, e);
+                LOG.warn("Unable to release lock {} ", lock, e);
             }
         }
     }

--- a/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/repair/RepairLockFactoryImpl.java
+++ b/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/repair/RepairLockFactoryImpl.java
@@ -101,7 +101,7 @@ public class RepairLockFactoryImpl implements RepairLockFactory
             }
             catch (Exception e)
             {
-                LOG.error("Unable to release lock {} for {} ", lock, this, e);
+                LOG.warn("Unable to release lock {} for {} ", lock, this, e);
             }
         }
     }


### PR DESCRIPTION
These log messages are not critical and should be recoverable,
no need to log them on error level.