### PR TITLE
Change replicated table provider log level

### DIFF
--- a/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/utils/ReplicatedTableProviderImpl.java
+++ b/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/utils/ReplicatedTableProviderImpl.java
@@ -104,7 +104,7 @@ public class ReplicatedTableProviderImpl implements ReplicatedTableProvider
 
         if (!replication.containsKey(localDc))
         {
-            LOG.info("Keyspace {} not replicated by local node, ignoring.", keyspace);
+            LOG.debug("Keyspace {} not replicated by local node, ignoring.", keyspace);
             return false;
         }
 


### PR DESCRIPTION
It will log very often if there are keyspaces that are not replicated locally.