### PR TITLE
Introduce equalsverifier tests

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -114,6 +114,12 @@
                 </exclusion>
             </exclusions>
         </dependency>
+
+        <dependency>
+            <groupId>nl.jqno.equalsverifier</groupId>
+            <artifactId>equalsverifier</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/repair/RepairConfiguration.java
+++ b/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/repair/RepairConfiguration.java
@@ -103,7 +103,7 @@ public class RepairConfiguration
                 myRepairWarningTimeInMs == that.myRepairWarningTimeInMs &&
                 myRepairErrorTimeInMs == that.myRepairErrorTimeInMs &&
                 myRepairParallelism == that.myRepairParallelism &&
-                myRepairUnwindRatio == that.myRepairUnwindRatio;
+                Double.compare(myRepairUnwindRatio, that.myRepairUnwindRatio) == 0;
     }
 
     @Override

--- a/core/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/TestLockCache.java
+++ b/core/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/TestLockCache.java
@@ -16,6 +16,7 @@ package com.ericsson.bss.cassandra.ecchronos.core;
 
 import com.ericsson.bss.cassandra.ecchronos.core.exceptions.LockException;
 import com.ericsson.bss.cassandra.ecchronos.core.scheduling.LockFactory.DistributedLock;
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -108,6 +109,12 @@ public class TestLockCache
 
         DistributedLock expectedLock = doReturnLockOnGetLock();
         assertGetLockRetrievesExpectedLock(expectedLock);
+    }
+
+    @Test
+    public void testEqualsContract()
+    {
+        EqualsVerifier.forClass(LockCache.LockKey.class).usingGetClass().verify();
     }
 
     private void assertGetLockRetrievesExpectedLock(DistributedLock expectedLock) throws LockException

--- a/core/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/repair/TestRepairConfiguration.java
+++ b/core/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/repair/TestRepairConfiguration.java
@@ -14,6 +14,7 @@
  */
 package com.ericsson.bss.cassandra.ecchronos.core.repair;
 
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.Test;
 
 import java.util.concurrent.TimeUnit;
@@ -96,5 +97,11 @@ public class TestRepairConfiguration
         assertThat(repairConfiguration.getRepairWarningTimeInMs()).isEqualTo(DEFAULT_REPAIR_WARNING_TIME_IN_MS);
         assertThat(repairConfiguration.getRepairErrorTimeInMs()).isEqualTo(DEFAULT_REPAIR_ERROR_TIME_IN_MS);
         assertThat(repairConfiguration.getRepairUnwindRatio()).isEqualTo(1.0d);
+    }
+
+    @Test
+    public void testEqualsContract()
+    {
+        EqualsVerifier.forClass(RepairConfiguration.class).usingGetClass().verify();
     }
 }

--- a/core/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/repair/TestRepairResource.java
+++ b/core/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/repair/TestRepairResource.java
@@ -14,6 +14,7 @@
  */
 package com.ericsson.bss.cassandra.ecchronos.core.repair;
 
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -41,5 +42,11 @@ public class TestRepairResource
         assertThat(repairResource).isEqualTo(equalRepairResource);
         assertThat(repairResource).isNotEqualTo(repairResourceWithDifferentDc);
         assertThat(repairResource).isNotEqualTo(repairResourceWithDifferentResource);
+    }
+
+    @Test
+    public void testEqualsContract()
+    {
+        EqualsVerifier.forClass(RepairResource.class).usingGetClass().verify();
     }
 }

--- a/core/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/repair/state/TestRepairEntry.java
+++ b/core/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/repair/state/TestRepairEntry.java
@@ -16,6 +16,7 @@ package com.ericsson.bss.cassandra.ecchronos.core.repair.state;
 
 import com.ericsson.bss.cassandra.ecchronos.core.utils.LongTokenRange;
 import com.google.common.collect.Sets;
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.Test;
 
 import java.net.InetAddress;
@@ -86,5 +87,11 @@ public class TestRepairEntry
         RepairEntry repairEntry2 = new RepairEntry(new LongTokenRange(0, 1), 6, Sets.newHashSet(InetAddress.getLocalHost()), "FAILED");
 
         assertThat(repairEntry).isNotEqualTo(repairEntry2);
+    }
+
+    @Test
+    public void testEqualsContract()
+    {
+        EqualsVerifier.forClass(RepairEntry.class).usingGetClass().verify();
     }
 }

--- a/core/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/repair/state/TestVnodeRepairState.java
+++ b/core/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/repair/state/TestVnodeRepairState.java
@@ -17,6 +17,7 @@ package com.ericsson.bss.cassandra.ecchronos.core.repair.state;
 import com.datastax.driver.core.Host;
 import com.ericsson.bss.cassandra.ecchronos.core.utils.LongTokenRange;
 import com.google.common.collect.ImmutableSet;
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -81,5 +82,14 @@ public class TestVnodeRepairState
         VnodeRepairState otherVnodeRepairState = new VnodeRepairState(otherRange, ImmutableSet.of(host1, host2, host3), VnodeRepairState.UNREPAIRED);
 
         assertThat(vnodeRepairState.isSameVnode(otherVnodeRepairState)).isFalse();
+    }
+
+    @Test
+    public void testEqualsContract()
+    {
+        EqualsVerifier.forClass(VnodeRepairState.class)
+                .withPrefabValues(ImmutableSet.class, ImmutableSet.of(1), ImmutableSet.of(2))
+                .usingGetClass()
+                .verify();
     }
 }

--- a/core/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/repair/state/TestVnodeRepairStates.java
+++ b/core/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/repair/state/TestVnodeRepairStates.java
@@ -16,7 +16,9 @@ package com.ericsson.bss.cassandra.ecchronos.core.repair.state;
 
 import com.datastax.driver.core.Host;
 import com.ericsson.bss.cassandra.ecchronos.core.utils.LongTokenRange;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -76,5 +78,14 @@ public class TestVnodeRepairStates
                 .build();
 
         assertThat(vnodeRepairStates.getVnodeRepairStates()).containsExactly(vnodeRepairState);
+    }
+
+    @Test
+    public void testEqualsContract()
+    {
+        EqualsVerifier.forClass(VnodeRepairStates.class)
+                .withPrefabValues(ImmutableList.class, ImmutableList.of(1), ImmutableList.of(2))
+                .usingGetClass()
+                .verify();
     }
 }

--- a/core/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/utils/TestLongToken.java
+++ b/core/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/utils/TestLongToken.java
@@ -16,6 +16,7 @@ package com.ericsson.bss.cassandra.ecchronos.core.utils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.Test;
 
 public class TestLongToken
@@ -49,5 +50,11 @@ public class TestLongToken
         assertThat(token1.compareTo(token2)).isLessThan(0);
         assertThat(token2.compareTo(token1)).isGreaterThan(0);
         assertThat(token1.hashCode()).isNotEqualTo(token2.hashCode());
+    }
+
+    @Test
+    public void testEqualsContract()
+    {
+        EqualsVerifier.forClass(LongToken.class).usingGetClass().verify();
     }
 }

--- a/core/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/utils/TestLongTokenRange.java
+++ b/core/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/utils/TestLongTokenRange.java
@@ -16,6 +16,7 @@ package com.ericsson.bss.cassandra.ecchronos.core.utils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.Test;
 
 public class TestLongTokenRange
@@ -37,5 +38,11 @@ public class TestLongTokenRange
         LongTokenRange range2 = new LongTokenRange(2, 3);
 
         assertThat(range1).isNotEqualTo(range2);
+    }
+
+    @Test
+    public void testEqualsContract()
+    {
+        EqualsVerifier.forClass(LongTokenRange.class).usingGetClass().verify();
     }
 }

--- a/core/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/utils/TestTableReference.java
+++ b/core/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/utils/TestTableReference.java
@@ -14,6 +14,7 @@
  */
 package com.ericsson.bss.cassandra.ecchronos.core.utils;
 
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -60,5 +61,11 @@ public class TestTableReference
 
         assertThat(tableReference1).isNotEqualTo(tableReference2);
         assertThat(tableReference1.hashCode()).isNotEqualTo(tableReference2.hashCode());
+    }
+
+    @Test
+    public void testEqualsContract()
+    {
+        EqualsVerifier.forClass(TableReference.class).usingGetClass().verify();
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,7 @@
         <javax.inject.version>1</javax.inject.version>
         <awaitility.version>3.0.0</awaitility.version>
         <jcip.version>1.0</jcip.version>
+        <equalsverifier.version>3.1.10</equalsverifier.version>
 
         <!-- Plugin versions -->
         <org.apache.maven.plugins.maven-compiler-plugin.version>3.8.0</org.apache.maven.plugins.maven-compiler-plugin.version>
@@ -303,6 +304,13 @@
                 <groupId>net.jcip</groupId>
                 <artifactId>jcip-annotations</artifactId>
                 <version>${jcip.version}</version>
+                <scope>test</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>nl.jqno.equalsverifier</groupId>
+                <artifactId>equalsverifier</artifactId>
+                <version>${equalsverifier.version}</version>
                 <scope>test</scope>
             </dependency>
         </dependencies>


### PR DESCRIPTION
To verify that implemented equals and hashCode methods
follow the "equals contract".