### PR TITLE
Reduce jetty logging

### DIFF
--- a/ecchronos-binary/src/resources/logback.xml
+++ b/ecchronos-binary/src/resources/logback.xml
@@ -59,6 +59,7 @@
 
     <logger name="com.datastax" level="ERROR" />
     <logger name="io.netty" level="WARN" />
+    <logger name="org.eclipse.jetty" level="INFO" />
 
     <root level="DEBUG">
         <appender-ref ref="STDOUT" />

--- a/standalone-integration/src/test/resources/logback-test.xml
+++ b/standalone-integration/src/test/resources/logback-test.xml
@@ -25,6 +25,7 @@
 
     <logger name="com.datastax" level="ERROR" />
     <logger name="io.netty" level="WARN" />
+    <logger name="org.eclipse.jetty" level="INFO" />
 
     <root level="INFO">
         <appender-ref ref="STDOUT" />


### PR DESCRIPTION
Debug logging on jetty is showing a lot of exceptions during
simple REST requests.