### PR TITLE
Support symlink creation of binary file

### DIFF
--- a/ecchronos-binary/src/bin/ecChronos.sh
+++ b/ecchronos-binary/src/bin/ecChronos.sh
@@ -15,8 +15,10 @@
 #
 
 if [ "x$ECCHRONOS_HOME" = "x" ]; then
-  ECCHRONOS_HOME="`dirname "$0"`/.."
+    ECCHRONOS_HOME=$(dirname $(readlink -f $0))/..
 fi
+
+cd $ECCHRONOS_HOME
 
 CLASSPATH="$ECCHRONOS_HOME"/conf/
 JVM_ENV=-Decchronos.config="$ECCHRONOS_HOME"/conf/ecChronos.cfg


### PR DESCRIPTION
Make it possible to create a symlink of the ecChronos binary file.
For example: ln -s /opt/ecchronos/bin/ecChronos /usr/bin/ecChronos