### PR TITLE
Close file descriptors when running in background

### DIFF
--- a/ecchronos-binary/src/bin/ecChronos.sh
+++ b/ecchronos-binary/src/bin/ecChronos.sh
@@ -29,5 +29,5 @@ done
 if [ "$1" = "-f" ]; then
     java $JVM_ENV -cp $CLASSPATH com.ericsson.bss.cassandra.ecchronos.application.ECChronos $@
 else
-    java $JVM_ENV -cp $CLASSPATH com.ericsson.bss.cassandra.ecchronos.application.ECChronos $@ <&- &
+    java $JVM_ENV -cp $CLASSPATH com.ericsson.bss.cassandra.ecchronos.application.ECChronos $@ <&- 1>&- 2>&- &
 fi


### PR DESCRIPTION
stdout and stderr was supposed to be closed in the Java application but
this did not work properly.

Only stdin was closed properly when running in background, but all file
descriptors should be closed:
  <&- (close stdin)
  1>&- (close stdout)
  2>&- (close stderr)

Close all file descriptors from the binary file.

Before fix:
```
$ ps -ef | grep ecChronos
esimfon   2175 13619  0 00:41 pts/3    00:00:00 grep --color=auto ecChronos
$ bin/ecChronos 
$ 00:41:19.054 [main] INFO  c.e.b.c.e.application.ECChronos - Using connection properties Connection(native=class com.ericsson.bss.cassandra.ecchronos.application.DefaultNativeConnectionProvider, jmx=class com.ericsson.bss.cassandra.ecchronos.application.DefaultJmxConnectionProvider, statementDecorator=class com.ericsson.bss.cassandra.ecchronos.application.NoopStatementDecorator)
00:41:19.057 [main] INFO  c.e.b.c.e.a.DefaultNativeConnectionProvider - Connecting through CQL using NativeConnection(localhost:9042)
00:41:21.796 [main] INFO  c.e.b.c.e.c.DataCenterAwarePolicy - Using provided data-center name 'datacenter1' for DataCenterAwareLoadBalancingPolicy
00:41:21.812 [main] INFO  c.e.b.c.e.a.DefaultJmxConnectionProvider - Connecting through JMX using JmxConnection(localhost:7199)
# Stays open
```

After fix:
```
$ ps -ef | grep ecChronos
esimfon   1695 13619  0 00:36 pts/3    00:00:00 grep --color=auto ecChronos
$ bin/ecChronos # No output
$ ps -ef | grep ecChronos # Process running in background
esimfon   1699     1 64 00:36 pts/3    00:00:01 java -Decchronos.config=bin/../conf/ecChronos.cfg -cp bin/../conf/:bin/../lib/application-1.0.7-SNAPSHOT.jar:bin/../lib/cassandra-driver-core-3.4.0.jar:bin/../lib/connection-1.0.7-SNAPSHOT.jar:bin/../lib/connection.impl-1.0.7-SNAPSHOT.jar:bin/../lib/core-1.0.7-SNAPSHOT.jar:bin/../lib/fm-1.0.7-SNAPSHOT.jar:bin/../lib/fm.impl-1.0.7-SNAPSHOT.jar:bin/../lib/guava-18.0.jar:bin/../lib/joda-time-2.9.9.jar:bin/../lib/logback-classic-1.2.3.jar:bin/../lib/logback-core-1.2.3.jar:bin/../lib/metrics-core-3.2.2.jar:bin/../lib/netty-buffer-4.0.47.Final.jar:bin/../lib/netty-codec-4.0.47.Final.jar:bin/../lib/netty-common-4.0.47.Final.jar:bin/../lib/netty-handler-4.0.47.Final.jar:bin/../lib/netty-transport-4.0.47.Final.jar:bin/../lib/slf4j-api-1.7.23.jar com.ericsson.bss.cassandra.ecchronos.application.ECChronos
esimfon   1743 13619  0 00:36 pts/3    00:00:00 grep --color=auto ecChronos
```