### PR TITLE
Add JVM options file

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 * Avoid concurrent modification exception in RSI#close - Issue #99
 * Support symlink of ecc binary - PR #114
 * Close file descriptors in background mode - PR #115
+* Add JVM options file
 
 ## Version 1.0.6
 

--- a/ecchronos-binary/src/assembly/assembly.xml
+++ b/ecchronos-binary/src/assembly/assembly.xml
@@ -33,6 +33,7 @@
             <outputDirectory>conf</outputDirectory>
             <includes>
                 <include>ecChronos.cfg</include>
+                <include>jvm.options</include>
                 <include>logback.xml</include>
                 <include>create_keyspace_sample.cql</include>
             </includes>

--- a/ecchronos-binary/src/bin/ecChronos.sh
+++ b/ecchronos-binary/src/bin/ecChronos.sh
@@ -21,15 +21,23 @@ fi
 cd $ECCHRONOS_HOME
 
 CLASSPATH="$ECCHRONOS_HOME"/conf/
-JVM_ENV=-Decchronos.config="$ECCHRONOS_HOME"/conf/ecChronos.cfg
 
 for library in "$ECCHRONOS_HOME"/lib/*.jar
 do
     CLASSPATH="$CLASSPATH:$library"
 done
 
+# Read user-defined JVM options from jvm.options file
+JVM_OPTS_FILE=$ECCHRONOS_HOME/conf/jvm.options
+for opt in $(grep "^-" $JVM_OPTS_FILE)
+do
+  JVM_OPTS="$JVM_OPTS $opt"
+done
+
+JVM_OPTS="$JVM_OPTS -Decchronos.config="$ECCHRONOS_HOME"/conf/ecChronos.cfg"
+
 if [ "$1" = "-f" ]; then
-    java $JVM_ENV -cp $CLASSPATH com.ericsson.bss.cassandra.ecchronos.application.ECChronos $@
+    java $JVM_OPTS -cp $CLASSPATH com.ericsson.bss.cassandra.ecchronos.application.ECChronos $@
 else
-    java $JVM_ENV -cp $CLASSPATH com.ericsson.bss.cassandra.ecchronos.application.ECChronos $@ <&- 1>&- 2>&- &
+    java $JVM_OPTS -cp $CLASSPATH com.ericsson.bss.cassandra.ecchronos.application.ECChronos $@ <&- 1>&- 2>&- &
 fi

--- a/ecchronos-binary/src/resources/jvm.options
+++ b/ecchronos-binary/src/resources/jvm.options
@@ -1,0 +1,36 @@
+#################################################################
+#                             jvm.options                       #
+#                                                               #
+# - all flags defined here will be used by to startup the JVM   #
+# - one flag should be specified per line                       #
+# - lines that do not start with '-' will be ignored            #
+# - only static flags are accepted (no variables or parameters) #
+#################################################################
+
+########################
+# GENERAL JVM SETTINGS #
+########################
+
+# Make sure all memory is faulted and zeroed on startup.
+# This helps prevent soft faults in containers and makes
+# transparent hugepage allocation more effective.
+#-XX:+AlwaysPreTouch
+
+# Sets the number of threads used during parallel phases of the garbage collectors.
+# The default value varies with the platform on which the JVM is running.
+# Having this value unset on JDK 8 and earlier versions may cause issues.
+# https://bugs.java.com/bugdatabase/view_bug.do?bug_id=6858051
+#-XX:ParallelGCThreads=1
+
+#################
+# HEAP SETTINGS #
+#################
+
+# Initial and minimum heap size.
+#-Xms256M
+
+# Maximum heap size.
+#-Xmx512M
+
+# Size of the heap for young generation.
+#-Xmn100M

--- a/pom.xml
+++ b/pom.xml
@@ -440,6 +440,7 @@ limitations under the License.
                             <exclude>**/*.txt</exclude>
                             <exclude>**/pom.xml.tag</exclude>
                             <exclude>**/pom.xml.releaseBackup</exclude>
+                            <exclude>**/*.options</exclude>
                             <exclude>release.properties</exclude>
                             <exclude>code_style.xml</exclude>
                         </excludes>


### PR DESCRIPTION
Make it possible to set JVM options from file.

It's currently possible to set JVM options from command-line but I think this solution (which I copied from Cassandra project) is more elegant.

I only added a few example values which I know are good to set, if you know any other write them here and I'll add them. 