### PR TITLE
Check run policy after tasks and sub-tasks

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 * Support symlink of ecc binary - PR #114
 * Close file descriptors in background mode - PR #115
 * Add JVM options file
+* Make policy changes quicker - Issue #117
 
 ## Version 1.0.6
 

--- a/application/src/main/java/com/ericsson/bss/cassandra/ecchronos/application/ECChronos.java
+++ b/application/src/main/java/com/ericsson/bss/cassandra/ecchronos/application/ECChronos.java
@@ -90,7 +90,7 @@ public class ECChronos implements Closeable
                 .withScheduleManager(myECChronosInternals.getScheduleManager())
                 .withRepairStateFactory(repairStateFactoryImpl)
                 .withRepairLockType(repairProperties.getRepairLockType())
-                .withRepairPolices(Collections.singletonList(myTimeBasedRunPolicy))
+                .withRepairPolicies(Collections.singletonList(myTimeBasedRunPolicy))
                 .build();
 
         myDefaultRepairConfigurationProvider = DefaultRepairConfigurationProvider.newBuilder()

--- a/application/src/main/java/com/ericsson/bss/cassandra/ecchronos/application/ECChronos.java
+++ b/application/src/main/java/com/ericsson/bss/cassandra/ecchronos/application/ECChronos.java
@@ -17,6 +17,7 @@ package com.ericsson.bss.cassandra.ecchronos.application;
 import java.io.Closeable;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.util.Collections;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 
@@ -89,6 +90,7 @@ public class ECChronos implements Closeable
                 .withScheduleManager(myECChronosInternals.getScheduleManager())
                 .withRepairStateFactory(repairStateFactoryImpl)
                 .withRepairLockType(repairProperties.getRepairLockType())
+                .withRepairPolices(Collections.singletonList(myTimeBasedRunPolicy))
                 .build();
 
         myDefaultRepairConfigurationProvider = DefaultRepairConfigurationProvider.newBuilder()

--- a/core.osgi/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/osgi/RepairSchedulerService.java
+++ b/core.osgi/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/osgi/RepairSchedulerService.java
@@ -73,7 +73,7 @@ public class RepairSchedulerService implements RepairScheduler
                 .withScheduleManager(myScheduleManager)
                 .withRepairStateFactory(myRepairStateFactory)
                 .withRepairLockType(configuration.repairLockType())
-                .withRepairPolices(myRepairPolicies)
+                .withRepairPolicies(myRepairPolicies)
                 .build();
     }
 

--- a/core.osgi/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/osgi/RepairSchedulerService.java
+++ b/core.osgi/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/osgi/RepairSchedulerService.java
@@ -15,12 +15,8 @@
 package com.ericsson.bss.cassandra.ecchronos.core.osgi;
 
 import com.ericsson.bss.cassandra.ecchronos.core.JmxProxyFactory;
-import com.ericsson.bss.cassandra.ecchronos.core.repair.RepairConfiguration;
-import com.ericsson.bss.cassandra.ecchronos.core.repair.RepairLockType;
-import com.ericsson.bss.cassandra.ecchronos.core.repair.RepairScheduler;
+import com.ericsson.bss.cassandra.ecchronos.core.repair.*;
 import com.ericsson.bss.cassandra.ecchronos.core.repair.state.RepairStateFactory;
-import com.ericsson.bss.cassandra.ecchronos.core.repair.RepairSchedulerImpl;
-import com.ericsson.bss.cassandra.ecchronos.core.repair.TableRepairJob;
 
 import com.ericsson.bss.cassandra.ecchronos.core.metrics.TableRepairMetrics;
 import com.ericsson.bss.cassandra.ecchronos.core.scheduling.ScheduleManager;
@@ -35,6 +31,8 @@ import org.osgi.service.component.annotations.ReferencePolicy;
 import org.osgi.service.metatype.annotations.AttributeDefinition;
 import org.osgi.service.metatype.annotations.Designate;
 import org.osgi.service.metatype.annotations.ObjectClassDefinition;
+
+import java.util.List;
 
 /**
  * A factory creating {@link TableRepairJob}'s for tables that replicates data over multiple nodes.
@@ -60,6 +58,9 @@ public class RepairSchedulerService implements RepairScheduler
     @Reference(service = RepairStateFactory.class, cardinality = ReferenceCardinality.MANDATORY, policy = ReferencePolicy.STATIC)
     private volatile RepairStateFactory myRepairStateFactory;
 
+    @Reference(service = TableRepairPolicy.class, cardinality = ReferenceCardinality.AT_LEAST_ONE, policy = ReferencePolicy.STATIC)
+    private volatile List<TableRepairPolicy> myRepairPolicies;
+
     private volatile RepairSchedulerImpl myDelegateRepairSchedulerImpl;
 
     @Activate
@@ -72,6 +73,7 @@ public class RepairSchedulerService implements RepairScheduler
                 .withScheduleManager(myScheduleManager)
                 .withRepairStateFactory(myRepairStateFactory)
                 .withRepairLockType(configuration.repairLockType())
+                .withRepairPolices(myRepairPolicies)
                 .build();
     }
 

--- a/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/TimeBasedRunPolicy.java
+++ b/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/TimeBasedRunPolicy.java
@@ -23,6 +23,7 @@ import java.util.concurrent.TimeUnit;
 import com.datastax.driver.core.querybuilder.QueryBuilder;
 import com.ericsson.bss.cassandra.ecchronos.connection.StatementDecorator;
 import com.ericsson.bss.cassandra.ecchronos.core.repair.TableRepairJob;
+import com.ericsson.bss.cassandra.ecchronos.core.repair.TableRepairPolicy;
 import com.ericsson.bss.cassandra.ecchronos.core.scheduling.RunPolicy;
 import com.ericsson.bss.cassandra.ecchronos.core.scheduling.ScheduledJob;
 import com.ericsson.bss.cassandra.ecchronos.core.utils.TableReference;
@@ -60,7 +61,7 @@ import static com.datastax.driver.core.querybuilder.QueryBuilder.eq;
  * end_minute int,
  * PRIMARY KEY(keyspace_name, table_name, start_hour, start_minute));
  */
-public class TimeBasedRunPolicy implements RunPolicy, Closeable
+public class TimeBasedRunPolicy implements TableRepairPolicy, RunPolicy, Closeable
 {
     private static final Logger LOG = LoggerFactory.getLogger(TimeBasedRunPolicy.class);
 
@@ -117,6 +118,12 @@ public class TimeBasedRunPolicy implements RunPolicy, Closeable
         }
 
         return -1;
+    }
+
+    @Override
+    public boolean shouldRun(TableReference tableReference)
+    {
+        return getRejectionsForTable(tableReference) == -1L;
     }
 
     @Override

--- a/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/repair/RepairGroup.java
+++ b/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/repair/RepairGroup.java
@@ -121,15 +121,7 @@ public class RepairGroup extends ScheduledTask
 
     private boolean shouldContinue()
     {
-        for (TableRepairPolicy repairPolicy : myRepairPolicies)
-        {
-            if (!repairPolicy.shouldRun(myTableReference))
-            {
-                return false;
-            }
-        }
-
-        return true;
+        return myRepairPolicies.stream().allMatch(repairPolicy -> repairPolicy.shouldRun(myTableReference));
     }
 
     @Override

--- a/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/repair/RepairGroup.java
+++ b/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/repair/RepairGroup.java
@@ -27,12 +27,7 @@ import com.google.common.annotations.VisibleForTesting;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 public class RepairGroup extends ScheduledTask
 {
@@ -48,6 +43,7 @@ public class RepairGroup extends ScheduledTask
     private final TableRepairMetrics myTableRepairMetrics;
     private final RepairResourceFactory myRepairResourceFactory;
     private final RepairLockFactory myRepairLockFactory;
+    private final List<TableRepairPolicy> myRepairPolicies;
 
     public RepairGroup(int priority,
                        TableReference tableReference,
@@ -58,6 +54,20 @@ public class RepairGroup extends ScheduledTask
                        RepairResourceFactory repairResourceFactory,
                        RepairLockFactory repairLockFactory)
     {
+        this(priority, tableReference, repairConfiguration, replicaRepairGroup, jmxProxyFactory,
+                tableRepairMetrics, repairResourceFactory, repairLockFactory, Collections.emptyList());
+    }
+
+    public RepairGroup(int priority,
+            TableReference tableReference,
+            RepairConfiguration repairConfiguration,
+            ReplicaRepairGroup replicaRepairGroup,
+            JmxProxyFactory jmxProxyFactory,
+            TableRepairMetrics tableRepairMetrics,
+            RepairResourceFactory repairResourceFactory,
+            RepairLockFactory repairLockFactory,
+            List<TableRepairPolicy> tableRepairPolicies)
+    {
         super(priority);
 
         myTableReference = tableReference;
@@ -67,6 +77,7 @@ public class RepairGroup extends ScheduledTask
         myTableRepairMetrics = tableRepairMetrics;
         myRepairResourceFactory = repairResourceFactory;
         myRepairLockFactory = repairLockFactory;
+        myRepairPolicies = new ArrayList<>(tableRepairPolicies);
     }
 
     @Override
@@ -77,6 +88,13 @@ public class RepairGroup extends ScheduledTask
 
         for (RepairTask repairTask : getRepairTasks())
         {
+            if (!shouldContinue())
+            {
+                LOG.info("Repair of {} was stopped by policy, will continue later", this);
+                successful = false;
+                break;
+            }
+
             try
             {
                 repairTask.execute();
@@ -99,6 +117,19 @@ public class RepairGroup extends ScheduledTask
         }
 
         return successful;
+    }
+
+    private boolean shouldContinue()
+    {
+        for (TableRepairPolicy repairPolicy : myRepairPolicies)
+        {
+            if (!repairPolicy.shouldRun(myTableReference))
+            {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     @Override

--- a/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/repair/RepairSchedulerImpl.java
+++ b/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/repair/RepairSchedulerImpl.java
@@ -230,7 +230,7 @@ public class RepairSchedulerImpl implements RepairScheduler, Closeable
             return this;
         }
 
-        public Builder withRepairPolices(Collection<TableRepairPolicy> tableRepairPolicies)
+        public Builder withRepairPolicies(Collection<TableRepairPolicy> tableRepairPolicies)
         {
             myRepairPolicies.addAll(tableRepairPolicies);
             return this;

--- a/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/repair/RepairSchedulerImpl.java
+++ b/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/repair/RepairSchedulerImpl.java
@@ -15,8 +15,7 @@
 package com.ericsson.bss.cassandra.ecchronos.core.repair;
 
 import java.io.Closeable;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -51,6 +50,7 @@ public class RepairSchedulerImpl implements RepairScheduler, Closeable
     private final ScheduleManager myScheduleManager;
     private final RepairStateFactory myRepairStateFactory;
     private final RepairLockType myRepairLockType;
+    private final List<TableRepairPolicy> myRepairPolicies;
 
     private RepairSchedulerImpl(Builder builder)
     {
@@ -61,6 +61,7 @@ public class RepairSchedulerImpl implements RepairScheduler, Closeable
         myScheduleManager = builder.myScheduleManager;
         myRepairStateFactory = builder.myRepairStateFactory;
         myRepairLockType = builder.myRepairLockType;
+        myRepairPolicies = new ArrayList<>(builder.myRepairPolicies);
     }
 
     @Override
@@ -170,6 +171,7 @@ public class RepairSchedulerImpl implements RepairScheduler, Closeable
                 .withTableRepairMetrics(myTableRepairMetrics)
                 .withRepairConfiguration(repairConfiguration)
                 .withRepairLockType(myRepairLockType)
+                .withRepairPolices(myRepairPolicies)
                 .build();
 
         job.runnable();
@@ -190,6 +192,7 @@ public class RepairSchedulerImpl implements RepairScheduler, Closeable
         private ScheduleManager myScheduleManager;
         private RepairStateFactory myRepairStateFactory;
         private RepairLockType myRepairLockType;
+        private final List<TableRepairPolicy> myRepairPolicies = new ArrayList<>();
 
         public Builder withFaultReporter(RepairFaultReporter repairFaultReporter)
         {
@@ -224,6 +227,12 @@ public class RepairSchedulerImpl implements RepairScheduler, Closeable
         public Builder withRepairLockType(RepairLockType repairLockType)
         {
             myRepairLockType = repairLockType;
+            return this;
+        }
+
+        public Builder withRepairPolices(Collection<TableRepairPolicy> tableRepairPolicies)
+        {
+            myRepairPolicies.addAll(tableRepairPolicies);
             return this;
         }
 

--- a/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/repair/TableRepairJob.java
+++ b/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/repair/TableRepairJob.java
@@ -14,12 +14,7 @@
  */
 package com.ericsson.bss.cassandra.ecchronos.core.repair;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -56,6 +51,7 @@ public class TableRepairJob extends ScheduledJob
     private final RepairFaultReporter myFaultReporter;
     private final RepairConfiguration myRepairConfiguration;
     private final RepairLockType myRepairLockType;
+    private final List<TableRepairPolicy> myRepairPolicies;
 
     private final TableRepairMetrics myTableRepairMetrics;
 
@@ -72,6 +68,7 @@ public class TableRepairJob extends ScheduledJob
         myTableRepairMetrics = builder.tableRepairMetrics;
         myRepairConfiguration = builder.repairConfiguration;
         myRepairLockType = builder.repairLockType;
+        myRepairPolicies = builder.repairPolicies;
     }
 
     public TableReference getTableReference()
@@ -97,7 +94,7 @@ public class TableRepairJob extends ScheduledJob
                 taskList.add(new RepairGroup(getRealPriority(), myTableReference, myRepairConfiguration,
                         replicaRepairGroup, myJmxProxyFactory, myTableRepairMetrics,
                         myRepairLockType.getLockFactory(),
-                        new RepairLockFactoryImpl()));
+                        new RepairLockFactoryImpl(), myRepairPolicies));
             }
 
             return taskList.iterator();
@@ -226,6 +223,7 @@ public class TableRepairJob extends ScheduledJob
         private TableRepairMetrics tableRepairMetrics = null;
         private RepairConfiguration repairConfiguration = RepairConfiguration.DEFAULT;
         private RepairLockType repairLockType;
+        private final List<TableRepairPolicy> repairPolicies = new ArrayList<>();
 
         public Builder withConfiguration(Configuration configuration)
         {
@@ -272,6 +270,12 @@ public class TableRepairJob extends ScheduledJob
         public Builder withRepairLockType(RepairLockType repairLockType)
         {
             this.repairLockType = repairLockType;
+            return this;
+        }
+
+        public Builder withRepairPolices(Collection<TableRepairPolicy> tableRepairPolicies)
+        {
+            this.repairPolicies.addAll(tableRepairPolicies);
             return this;
         }
 

--- a/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/repair/TableRepairPolicy.java
+++ b/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/repair/TableRepairPolicy.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2020 Telefonaktiebolaget LM Ericsson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ericsson.bss.cassandra.ecchronos.core.repair;
+
+import com.ericsson.bss.cassandra.ecchronos.core.utils.TableReference;
+
+/**
+ * Interface for policies that can be used to control if repairs should continue to run.
+ */
+public interface TableRepairPolicy
+{
+    /**
+     * Check with the policy if a repair of the provided table should run now.
+     *
+     * @param tableReference The table to verify.
+     * @return True if the repair should continue.
+     */
+    boolean shouldRun(TableReference tableReference);
+}

--- a/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/repair/TableRepairPolicy.java
+++ b/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/repair/TableRepairPolicy.java
@@ -17,7 +17,7 @@ package com.ericsson.bss.cassandra.ecchronos.core.repair;
 import com.ericsson.bss.cassandra.ecchronos.core.utils.TableReference;
 
 /**
- * Interface for policies that can be used to control if repairs should continue to run.
+ * Interface for policies that can be used to control if repairs should run.
  */
 public interface TableRepairPolicy
 {

--- a/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/scheduling/ScheduleManagerImpl.java
+++ b/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/scheduling/ScheduleManagerImpl.java
@@ -162,6 +162,11 @@ public class ScheduleManagerImpl implements ScheduleManager, Closeable
 
             for (ScheduledTask task : next)
             {
+                if (!validate(next))
+                {
+                    LOG.info("Job {} was stopped, will continue later", next);
+                    break;
+                }
                 hasRun |= tryRunTask(next, task);
             }
 

--- a/core/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/TestTimeBasedRunPolicy.java
+++ b/core/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/TestTimeBasedRunPolicy.java
@@ -116,6 +116,7 @@ public class TestTimeBasedRunPolicy extends AbstractCassandraTest
 
         assertThat(delay).isLessThanOrEqualTo(expectedHighest);
         assertThat(delay).isGreaterThan(-1L);
+        assertThat(myRunPolicy.shouldRun(new TableReference(keyspace, table))).isFalse();
     }
 
     @Test
@@ -129,6 +130,7 @@ public class TestTimeBasedRunPolicy extends AbstractCassandraTest
         insertEntry(keyspace, table, now.minusHours(2), now.minusHours(1));
 
         assertThat(myRunPolicy.validate(myRepairJobMock)).isEqualTo(-1L);
+        assertThat(myRunPolicy.shouldRun(new TableReference(keyspace, table))).isTrue();
     }
 
     @Test
@@ -142,6 +144,7 @@ public class TestTimeBasedRunPolicy extends AbstractCassandraTest
         insertEntry(keyspace, table, now.plusHours(1), now.plusHours(2));
 
         assertThat(myRunPolicy.validate(myRepairJobMock)).isEqualTo(-1L);
+        assertThat(myRunPolicy.shouldRun(new TableReference(keyspace, table))).isTrue();
     }
 
     @Test
@@ -162,6 +165,7 @@ public class TestTimeBasedRunPolicy extends AbstractCassandraTest
 
         assertThat(delay).isLessThanOrEqualTo(expectedHighest);
         assertThat(delay).isGreaterThan(-1L);
+        assertThat(myRunPolicy.shouldRun(new TableReference(keyspace, table))).isFalse();
     }
 
     @Test
@@ -183,6 +187,7 @@ public class TestTimeBasedRunPolicy extends AbstractCassandraTest
 
         assertThat(delay).isLessThanOrEqualTo(expectedHighest);
         assertThat(delay).isGreaterThanOrEqualTo(expectedLowest);
+        assertThat(myRunPolicy.shouldRun(new TableReference(keyspace, table))).isFalse();
     }
 
     @Test
@@ -196,6 +201,7 @@ public class TestTimeBasedRunPolicy extends AbstractCassandraTest
         insertEntry(keyspace, table, now.plusHours(2), now.minusHours(1));
 
         assertThat(myRunPolicy.validate(myRepairJobMock)).isEqualTo(-1L);
+        assertThat(myRunPolicy.shouldRun(new TableReference(keyspace, table))).isTrue();
     }
 
     @Test
@@ -209,9 +215,11 @@ public class TestTimeBasedRunPolicy extends AbstractCassandraTest
         insertEntry("*", table, 0, 0, 0, 0);
 
         assertThat(myRunPolicy.validate(myRepairJobMock)).isEqualTo(DEFAULT_REJECT_TIME);
+        assertThat(myRunPolicy.shouldRun(new TableReference(keyspace1, table))).isFalse();
 
         when(myRepairJobMock.getTableReference()).thenReturn(new TableReference(keyspace2, table));
         assertThat(myRunPolicy.validate(myRepairJobMock)).isEqualTo(DEFAULT_REJECT_TIME);
+        assertThat(myRunPolicy.shouldRun(new TableReference(keyspace2, table))).isFalse();
     }
 
     @Test
@@ -224,6 +232,7 @@ public class TestTimeBasedRunPolicy extends AbstractCassandraTest
         insertEntry(keyspace, table, 0, 0, 0, 0);
 
         assertThat(myRunPolicy.validate(myRepairJobMock)).isEqualTo(DEFAULT_REJECT_TIME);
+        assertThat(myRunPolicy.shouldRun(new TableReference(keyspace, table))).isFalse();
     }
 
     @Test
@@ -236,6 +245,7 @@ public class TestTimeBasedRunPolicy extends AbstractCassandraTest
         insertEntry("*", "*", 0, 0, 0, 0);
 
         assertThat(myRunPolicy.validate(myRepairJobMock)).isEqualTo(DEFAULT_REJECT_TIME);
+        assertThat(myRunPolicy.shouldRun(new TableReference(keyspace, table))).isFalse();
     }
 
     @Test
@@ -248,15 +258,18 @@ public class TestTimeBasedRunPolicy extends AbstractCassandraTest
         insertEntry("*", "*", 0, 0, 0, 0);
 
         assertThat(myRunPolicy.validate(myRepairJobMock)).isEqualTo(DEFAULT_REJECT_TIME);
+        assertThat(myRunPolicy.shouldRun(new TableReference(keyspace, table))).isFalse();
 
         mySession.execute(String.format("DELETE FROM %s.%s WHERE keyspace_name = '*' AND table_name = '*'", myKeyspaceName, TABLE_REJECT_CONFIGURATION));
 
         assertThat(myRunPolicy.validate(myRepairJobMock)).isEqualTo(DEFAULT_REJECT_TIME);
+        assertThat(myRunPolicy.shouldRun(new TableReference(keyspace, table))).isFalse();
 
         // Cache expires after 1 sec
         await().pollInterval(500, TimeUnit.MILLISECONDS)
                 .atMost(2, TimeUnit.SECONDS)
                 .until(() -> myRunPolicy.validate(myRepairJobMock) == -1L);
+        assertThat(myRunPolicy.shouldRun(new TableReference(keyspace, table))).isTrue();
     }
 
     @Test

--- a/core/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/repair/TestRepairGroupTasks.java
+++ b/core/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/repair/TestRepairGroupTasks.java
@@ -1,0 +1,247 @@
+/*
+ * Copyright 2020 Telefonaktiebolaget LM Ericsson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ericsson.bss.cassandra.ecchronos.core.repair;
+
+import com.datastax.driver.core.Host;
+import com.ericsson.bss.cassandra.ecchronos.core.JmxProxy;
+import com.ericsson.bss.cassandra.ecchronos.core.JmxProxyFactory;
+import com.ericsson.bss.cassandra.ecchronos.core.metrics.TableRepairMetrics;
+import com.ericsson.bss.cassandra.ecchronos.core.repair.state.ReplicaRepairGroup;
+import com.ericsson.bss.cassandra.ecchronos.core.scheduling.DummyLock;
+import com.ericsson.bss.cassandra.ecchronos.core.scheduling.LockFactory;
+import com.ericsson.bss.cassandra.ecchronos.core.utils.LongTokenRange;
+import com.ericsson.bss.cassandra.ecchronos.core.utils.TableReference;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import javax.management.Notification;
+import javax.management.NotificationListener;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiConsumer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class TestRepairGroupTasks
+{
+    private static final String keyspaceName = "keyspace";
+    private static final String tableName = "table";
+    private static final TableReference tableReference = new TableReference(keyspaceName, tableName);
+    private static final int priority = 1;
+
+    private static final long RUN_INTERVAL_IN_DAYS = 1;
+    private static final long GC_GRACE_DAYS = 10;
+
+    @Mock
+    private LockFactory mockLockFactory;
+
+    @Mock
+    private JmxProxyFactory mockJmxProxyFactory;
+
+    @Mock
+    private TableRepairMetrics mockTableRepairMetrics;
+
+    @Mock
+    private RepairResourceFactory mockRepairResourceFactory;
+
+    @Mock
+    private RepairLockFactory mockRepairLockFactory;
+
+    private RepairConfiguration repairConfiguration;
+
+    @Before
+    public void init()
+    {
+        repairConfiguration = RepairConfiguration.newBuilder()
+                .withParallelism(RepairOptions.RepairParallelism.PARALLEL)
+                .withRepairWarningTime(RUN_INTERVAL_IN_DAYS * 2, TimeUnit.DAYS)
+                .withRepairErrorTime(GC_GRACE_DAYS, TimeUnit.DAYS)
+                .build();
+    }
+
+    @Test
+    public void testExecute() throws Exception
+    {
+        Map<String, String> metadata = new HashMap<>();
+        metadata.put("keyspace", keyspaceName);
+        metadata.put("table", tableName);
+        ReplicaRepairGroup replicaRepairGroup = new ReplicaRepairGroup(ImmutableSet.of(withHost("127.0.0.1")), ImmutableList.of(range(1, 2)));
+        Set<RepairResource> repairResources = Sets.newHashSet(new RepairResource("DC1", "my-resource"));
+
+        when(mockJmxProxyFactory.connect()).thenReturn(new CustomJmxProxy((notificationListener, i) -> progressAndComplete(notificationListener, range(1, 2))));
+
+        when(mockRepairResourceFactory.getRepairResources(eq(replicaRepairGroup))).thenReturn(repairResources);
+        when(mockRepairLockFactory.getLock(eq(mockLockFactory), eq(repairResources), eq(metadata), eq(priority))).thenReturn(new DummyLock());
+
+        RepairGroup repairGroup = new RepairGroup(priority, tableReference,
+                repairConfiguration, replicaRepairGroup, mockJmxProxyFactory, mockTableRepairMetrics,
+                mockRepairResourceFactory, mockRepairLockFactory);
+
+        assertThat(repairGroup.execute()).isTrue();
+    }
+
+    @Test (timeout = 1000L)
+    public void testExecuteWithPolicyStoppingSecondTask() throws Exception
+    {
+        Map<String, String> metadata = new HashMap<>();
+        metadata.put("keyspace", keyspaceName);
+        metadata.put("table", tableName);
+        ReplicaRepairGroup replicaRepairGroup = new ReplicaRepairGroup(ImmutableSet.of(withHost("127.0.0.1")), ImmutableList.of(range(1, 2), range(2, 3)));
+        Set<RepairResource> repairResources = Sets.newHashSet(new RepairResource("DC1", "my-resource"));
+        final AtomicBoolean shouldRun = new AtomicBoolean(true);
+
+        when(mockRepairResourceFactory.getRepairResources(eq(replicaRepairGroup))).thenReturn(repairResources);
+        when(mockRepairLockFactory.getLock(eq(mockLockFactory), eq(repairResources), eq(metadata), eq(priority))).thenReturn(new DummyLock());
+
+        TableRepairPolicy tableRepairPolicy = (tb) -> shouldRun.get();
+        when(mockJmxProxyFactory.connect()).thenReturn(new CustomJmxProxy((notificationListener, i) -> {
+            if (i == 1) // First repair
+            {
+                progressAndComplete(notificationListener, range(1, 2));
+            }
+            // After first repair task has completed we stop next task.
+            // If this doesn't work a timeout will occur as the repair task
+            // will be waiting for progress.
+            shouldRun.set(false);
+        }));
+
+        RepairGroup repairGroup = new RepairGroup(priority, tableReference,
+                repairConfiguration, replicaRepairGroup, mockJmxProxyFactory, mockTableRepairMetrics,
+                mockRepairResourceFactory, mockRepairLockFactory,
+                Collections.singletonList(tableRepairPolicy));
+
+        assertThat(repairGroup.execute()).isFalse();
+    }
+
+    private void progressAndComplete(NotificationListener notificationListener, LongTokenRange range)
+    {
+        // Normally the repair session id would be used here but
+        // since we run this before repairAsync has completed we
+        // have to use 0
+        String repairSession = "repair:0";
+
+        Notification notification = new Notification("progress", repairSession, 0, getRepairMessage(range));
+        notification.setUserData(getNotificationData(RepairTask.ProgressEventType.PROGRESS.ordinal(), 1, 1));
+        notificationListener.handleNotification(notification, null);
+
+        notification = new Notification("progress", repairSession, 2, "Done with repair");
+        notification.setUserData(getNotificationData(RepairTask.ProgressEventType.COMPLETE.ordinal(), 1, 1));
+        notificationListener.handleNotification(notification, null);
+    }
+
+    private LongTokenRange range(long start, long end)
+    {
+        return new LongTokenRange(start, end);
+    }
+
+    private Host withHost(String ip) throws UnknownHostException
+    {
+        Host host = mock(Host.class);
+
+        when(host.getBroadcastAddress()).thenReturn(InetAddress.getByName(ip));
+
+        return host;
+    }
+
+    private String getRepairMessage(LongTokenRange range)
+    {
+        return String.format("Repair session RepairSession for range %s finished", Collections.singletonList(range));
+    }
+
+    private Map<String, Integer> getNotificationData(int type, int progressCount, int total)
+    {
+        Map<String, Integer> data = new HashMap<>();
+        data.put("type", type);
+        data.put("progressCount", progressCount);
+        data.put("total", total);
+        return data;
+    }
+
+    class CustomJmxProxy implements JmxProxy
+    {
+        private final AtomicInteger repairCount = new AtomicInteger();
+        private final BiConsumer<NotificationListener, Integer> onRepair;
+
+        private AtomicReference<NotificationListener> notificationListener = new AtomicReference<>();
+
+        CustomJmxProxy(BiConsumer<NotificationListener, Integer> onRepair)
+        {
+            this.onRepair = onRepair;
+        }
+
+        @Override
+        public void addStorageServiceListener(NotificationListener listener)
+        {
+            assertThat(notificationListener.compareAndSet(null, listener)).isTrue();
+        }
+
+        @Override
+        public List<String> getLiveNodes()
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public List<String> getUnreachableNodes()
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public int repairAsync(String keyspace, Map<String, String> options)
+        {
+            int repair = repairCount.incrementAndGet();
+            onRepair.accept(notificationListener.get(), repair);
+            return repair;
+        }
+
+        @Override
+        public void forceTerminateAllRepairSessions()
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void removeStorageServiceListener(NotificationListener listener)
+        {
+            assertThat(notificationListener.compareAndSet(listener, null)).isTrue();
+        }
+
+        @Override
+        public long liveDiskSpaceUsed(TableReference tableReference)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void close()
+        {
+        }
+    }
+}

--- a/core/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/scheduling/TestScheduleManager.java
+++ b/core/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/scheduling/TestScheduleManager.java
@@ -105,6 +105,23 @@ public class TestScheduleManager
     }
 
     @Test
+    public void testRunningTwoTasksStoppedAfterFirstByPolicy() throws LockException
+    {
+        ShortRunningMultipleTasks job = new ShortRunningMultipleTasks(ScheduledJob.Priority.LOW, 2, () -> {
+            when(myRunPolicy.validate(any(ScheduledJob.class))).thenReturn(1L);
+        });
+        myScheduler.schedule(job);
+
+        when(myLockFactory.tryLock(anyString(), anyString(), anyInt(), anyMapOf(String.class, String.class))).thenReturn(new DummyLock());
+
+        myScheduler.run();
+
+        assertThat(job.getNumRuns()).isEqualTo(1);
+        assertThat(myScheduler.getQueueSize()).isEqualTo(1);
+        verify(myLockFactory, times(1)).tryLock(anyString(), anyString(), anyInt(), anyMapOf(String.class, String.class));
+    }
+
+    @Test
     public void testRunningJobWithThrowingRunPolicy()
     {
         DummyJob job = new DummyJob(ScheduledJob.Priority.LOW);
@@ -307,11 +324,18 @@ public class TestScheduleManager
     {
         private final AtomicInteger numRuns = new AtomicInteger();
         private final int numTasks;
+        private final Runnable onCompletion;
 
         public ShortRunningMultipleTasks(Priority priority, int numTasks)
         {
+            this(priority, numTasks, () -> {});
+        }
+
+        public ShortRunningMultipleTasks(Priority priority, int numTasks, Runnable onCompletion)
+        {
             super(new ConfigurationBuilder().withPriority(priority).withRunInterval(1, TimeUnit.SECONDS).build());
             this.numTasks = numTasks;
+            this.onCompletion = onCompletion;
         }
 
         public int getNumRuns()
@@ -326,7 +350,7 @@ public class TestScheduleManager
 
             for (int i = 0; i < numTasks; i++)
             {
-                tasks.add(new ShortRunningTask());
+                tasks.add(new ShortRunningTask(onCompletion));
             }
 
             return tasks.iterator();
@@ -334,9 +358,17 @@ public class TestScheduleManager
 
         private class ShortRunningTask extends ScheduledTask
         {
+            private final Runnable onCompletion;
+
+            public ShortRunningTask(Runnable onCompletion)
+            {
+                this.onCompletion = onCompletion;
+            }
+
             @Override
             public boolean execute()
             {
+                onCompletion.run();
                 numRuns.incrementAndGet();
                 return true;
             }


### PR DESCRIPTION
Add repair policy to TableRepairJob(RepairGroup) and check the policy
before running each RepairTask. Similar the policy will now be
consulted before running a ScheduledTask (RepairGroup) in order to
reduce the delay from policy activation to application.

Closes issue #117