### PR TITLE
Fix Python3 issue in ecc-status command

### DIFF
--- a/ecchronos-binary/src/bin/ecc-status.py
+++ b/ecchronos-binary/src/bin/ecc-status.py
@@ -83,7 +83,7 @@ def convert_repair_job(repair_job):
     return entry
 
 def print_summary(repair_jobs):
-    status_list = map(lambda job: job.status, repair_jobs)
+    status_list = list(map(lambda job: job.status, repair_jobs))
     summary_format = "Summary: {0} completed, {1} in queue, {2} warning, {3} error"
     print(summary_format.format(status_list.count('COMPLETED'),
                                 status_list.count('IN_QUEUE'),


### PR DESCRIPTION
The ecc-status.py script uses the map() function to transform a list.
In Python2 map() returns a new list while in Python3 an iterator object is
returned. This causes an AttributeError.

Make sure the mapped status object is transformed into a new list before processing it.

Closes issue #168