### PR TITLE
Remove default limit of ecc-status

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Version 2.0.1
 
+* Add possibilities to only take local locks - Issue #175
+* Remove default limit of ecc-status
 * Process hangs on timeout - Issue #190
 
 ## Version 2.0.0

--- a/ecchronos-binary/src/bin/ecc-status.py
+++ b/ecchronos-binary/src/bin/ecc-status.py
@@ -116,7 +116,7 @@ def parse_arguments():
                         help='Print verbose status for a specific job')
     parser.add_argument('-l', '--limit', type=int,
                         help='Limit the number of tables or virtual nodes printed (-1 to disable)',
-                        default=15)
+                        default=-1)
     parser.add_argument('-u', '--url', type=str,
                         help='The host to connect to with the format (http://<host>:port)',
                         default=None)


### PR DESCRIPTION
Having a default limit can be confusing to the user