### PR TITLE
Complete jobs after the job finishes and not after task finishes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,8 @@
 ## Version 2.0.2
 
 * Improve logging - Issue #191
+* Fix On Demand Repair Jobs always showing topology changed after restart
+* Fix reoccurring flag in ecc-status showing incorrect value
 
 ### Merged from 1.0
 

--- a/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/repair/OnDemandRepairJob.java
+++ b/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/repair/OnDemandRepairJob.java
@@ -197,6 +197,7 @@ public class OnDemandRepairJob extends ScheduledJob
             myOngoingJob.failJob();
             LOG.error("Failed On Demand Repair: {}", id);
         }
+        super.finishJob();
     }
 
     @Override

--- a/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/repair/OnDemandRepairJob.java
+++ b/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/repair/OnDemandRepairJob.java
@@ -177,20 +177,26 @@ public class OnDemandRepairJob extends ScheduledJob
             myOngoingJob.finishRanges(repairedTokenSet);
         }
 
+        super.postExecute(successful, task);
+    }
+
+    @Override
+    public void finishJob()
+    {
+        UUID id = getId();
         if (myTasks.isEmpty())
         {
-            myOnFinishedHook.accept(getId());
+            myOnFinishedHook.accept(id);
             myOngoingJob.finishJob();
-            LOG.info("Completed {}", task);
+            LOG.info("Completed On Demand Repair: {}", id);
         }
 
-        if(failed)
+        if (failed)
         {
             myOnFinishedHook.accept(getId());
             myOngoingJob.failJob();
+            LOG.error("Failed On Demand Repair: {}", id);
         }
-
-        super.postExecute(successful, task);
     }
 
     @Override

--- a/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/repair/OnDemandRepairJobView.java
+++ b/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/repair/OnDemandRepairJobView.java
@@ -43,6 +43,6 @@ public class OnDemandRepairJobView extends RepairJobView
     @Override
     public Boolean isRecurring()
     {
-        return true;
+        return false;
     }
 }

--- a/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/repair/OngoingJob.java
+++ b/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/repair/OngoingJob.java
@@ -102,7 +102,7 @@ public class OngoingJob
     public boolean hasTopologyChanged()
     {
     	return !myTokens.equals(myReplicationState.getTokenRangeToReplicas(myTableReference))
-                || (myTokenHash != null && (myTokenHash != myTokens.keySet().hashCode() || myTokenHash != myTokens.hashCode()));
+                || (myTokenHash != null && (myTokenHash != myTokens.keySet().hashCode() && myTokenHash != myTokens.hashCode()));
     }
 
     public void finishJob()

--- a/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/repair/ScheduledRepairJobView.java
+++ b/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/repair/ScheduledRepairJobView.java
@@ -42,6 +42,6 @@ public class ScheduledRepairJobView extends RepairJobView
     @Override
     public Boolean isRecurring()
     {
-        return false;
+        return true;
     }
 }

--- a/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/scheduling/ScheduledJob.java
+++ b/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/scheduling/ScheduledJob.java
@@ -68,6 +68,11 @@ public abstract class ScheduledJob implements Iterable<ScheduledTask>
     }
 
     /**
+     * This method gets run after the job is removed from the Queue. It will run whether the job fails or succeeds.
+     */
+    protected void finishJob() {}
+
+    /**
      * Set the job to be runnable again after the given delay has elapsed.
      *
      * @param delay

--- a/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/scheduling/ScheduledJobQueue.java
+++ b/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/scheduling/ScheduledJobQueue.java
@@ -138,14 +138,10 @@ public class ScheduledJobQueue implements Iterable<ScheduledJob>
                 ScheduledJob job = myBaseIterator.next();
 
                 ScheduledJob.State state = job.getState();
-                if (state == ScheduledJob.State.FAILED)
+                if (state == ScheduledJob.State.FAILED || state == ScheduledJob.State.FINISHED)
                 {
-                    LOG.error("{} failed, descheduling", job);
-                    ScheduledJobQueue.this.remove(job);
-                }
-                else if (state == ScheduledJob.State.FINISHED)
-                {
-                    LOG.debug("{} completed, descheduling", job);
+                    LOG.info("{}: {}, descheduling", job, state);
+                    job.finishJob();
                     ScheduledJobQueue.this.remove(job);
                 }
                 else if (state != ScheduledJob.State.PARKED)


### PR DESCRIPTION
* This fixes On Demand Repair Jobs always showing topology changed after restart
* Fix reoccurring flag in ecc-status showing incorrect value
* Clean up some logging