### PR TITLE
Fix blinking test case for cert expiry

### DIFF
--- a/application/src/test/java/com/ericsson/bss/cassandra/ecchronos/application/spring/TestTomcatWebServerCustomizer.java
+++ b/application/src/test/java/com/ericsson/bss/cassandra/ecchronos/application/spring/TestTomcatWebServerCustomizer.java
@@ -27,7 +27,7 @@ import java.security.GeneralSecurityException;
 import java.util.concurrent.TimeUnit;
 
 import javax.net.ssl.SSLContext;
-import javax.net.ssl.SSLHandshakeException;
+import javax.net.ssl.SSLException;
 
 import com.ericsson.bss.cassandra.ecchronos.connection.JmxConnectionProvider;
 import com.ericsson.bss.cassandra.ecchronos.connection.NativeConnectionProvider;
@@ -121,9 +121,8 @@ public class TestTomcatWebServerCustomizer
     public void testExceptionWhenExpiredCertificate() throws IOException, GeneralSecurityException
     {
         HttpClient httpClient = configureHttpClient(CLIENT_EXPIRED_PATH);
-        assertThatExceptionOfType(SSLHandshakeException.class)
-                .isThrownBy(() -> httpClient.execute(new HttpGet(httpsUrl)))
-                .withMessageContaining("Received fatal alert: certificate_unknown");
+        assertThatExceptionOfType(SSLException.class)
+                .isThrownBy(() -> httpClient.execute(new HttpGet(httpsUrl)));
     }
 
     private HttpClient configureHttpClient(String storePath) throws IOException, GeneralSecurityException


### PR DESCRIPTION
I suspect that the server cancels the HTTP request before the client does, causing a different exception to occur than the usual SSLHandshakeException.

`Suppressed: java.net.SocketException: Broken pipe (Write failed)
		at java.net.SocketOutputStream.socketWrite0(Native Method)
		at java.net.SocketOutputStream.socketWrite(SocketOutputStream.java:111)
		at java.net.SocketOutputStream.write(SocketOutputStream.java:155)
		at sun.security.ssl.SSLSocketOutputRecord.encodeAlert(SSLSocketOutputRecord.java:83)
		at sun.security.ssl.TransportContext.fatal(TransportContext.java:384)
		at sun.security.ssl.TransportContext.fatal(TransportContext.java:296)
		at sun.security.ssl.SSLSocketImpl.startHandshake(SSLSocketImpl.java:411)
		... 49 more
Caused by: java.net.SocketException: Connection reset`