### PR TITLE
Uplift springframework to mitigate security vuln

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,7 +6,8 @@
 * Fix On Demand Repair Jobs always showing topology changed after restart
 * Fix reoccurring flag in ecc-status showing incorrect value
 * Update Netty io version to 4.1.62.Final
-* Update commons-io to 2.7 
+* Update commons-io to 2.7
+* Update spring-boot-dependencies to 2.5.3 - Issue #223
 
 ### Merged from 1.0
 

--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@
         <jcip.version>1.0</jcip.version>
         <junitparams.version>1.1.1</junitparams.version>
         <equalsverifier.version>3.5</equalsverifier.version>
-        <org.springframework.boot.version>2.4.4</org.springframework.boot.version>
+        <org.springframework.boot.version>2.5.3</org.springframework.boot.version>
 
         <!-- Plugin versions -->
         <org.apache.maven.plugins.maven-compiler-plugin.version>3.8.0</org.apache.maven.plugins.maven-compiler-plugin.version>


### PR DESCRIPTION
Vendor solution for mitigating CVE-2021-22118 is to be at atleast 5.3.7
of Spring Framework. By uplifting to 2.5.3 of Spring Boot the Spring
Framework is 5.3.9, which is not vulnerable.

Fixes #223