### PR TITLE
Add EndPointFactory

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@
 
 ## Version 2.0.4
 
-* Handle endpoints with changing IP addresses
+* Handle endpoints with changing IP addresses - Issue #243
 * Log exceptions during creation/deletion of schedules
 * Update gson to 2.8.9 - Issue #239
 * Update netty to 4.1.69.Final

--- a/connection.impl/pom.xml
+++ b/connection.impl/pom.xml
@@ -60,8 +60,26 @@
 
         <!-- Test -->
         <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/connection.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/connection/impl/ContactEndPoint.java
+++ b/connection.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/connection/impl/ContactEndPoint.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2021 Telefonaktiebolaget LM Ericsson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ericsson.bss.cassandra.ecchronos.connection.impl;
+
+import com.datastax.driver.core.EndPoint;
+
+import java.net.InetSocketAddress;
+import java.util.Objects;
+
+public class ContactEndPoint implements EndPoint
+{
+    private final String hostName;
+    private final int port;
+    private volatile InetSocketAddress lastResolvedAddress;
+
+    public ContactEndPoint(String hostName, int port)
+    {
+        this.hostName = hostName;
+        this.port = port;
+    }
+
+    @Override
+    public InetSocketAddress resolve()
+    {
+        lastResolvedAddress = new InetSocketAddress(hostName, port);
+        return lastResolvedAddress;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ContactEndPoint that = (ContactEndPoint) o;
+        return port == that.port && hostName.equals(that.hostName);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(hostName, port);
+    }
+
+    @Override
+    public String toString()
+    {
+        if (lastResolvedAddress != null)
+        {
+            return lastResolvedAddress.toString();
+        }
+        return String.format("%s:%d", hostName, port);
+    }
+}

--- a/connection.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/connection/impl/EccEndPointFactory.java
+++ b/connection.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/connection/impl/EccEndPointFactory.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright 2021 Telefonaktiebolaget LM Ericsson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ericsson.bss.cassandra.ecchronos.connection.impl;
+
+import java.net.InetSocketAddress;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.datastax.driver.core.Cluster;
+import com.datastax.driver.core.EndPoint;
+import com.datastax.driver.core.EndPointFactory;
+import com.datastax.driver.core.Host;
+import com.datastax.driver.core.Row;
+
+/**
+ * EndPointFactory that creates wrapped end points for remote hosts and always returns the same end point for the local
+ * host.
+ *
+ * The wrapped end points determine equality based on the host_id value of the row to allow for changing EndPoints.
+ */
+public class EccEndPointFactory implements EndPointFactory, Host.StateListener
+{
+    private static final Logger LOG = LoggerFactory.getLogger(EccEndPointFactory.class);
+
+    private final ConcurrentHashMap<UUID, HostIdEndPoint> hostIdEndPointMap = new ConcurrentHashMap<>();
+
+    private final EndPoint localEndpoint;
+    private final UUID localHost;
+    private final EndPointFactory delegateEndpointFactory;
+
+    public EccEndPointFactory(EndPoint localEndpoint, UUID localHost, EndPointFactory delegateEndpointFactory)
+    {
+        this.localEndpoint = localEndpoint;
+        this.localHost = localHost;
+        this.delegateEndpointFactory = delegateEndpointFactory;
+    }
+
+    @Override
+    public void init(Cluster cluster)
+    {
+        delegateEndpointFactory.init(cluster);
+    }
+
+    @Override
+    public EndPoint create(Row peersRow)
+    {
+        UUID hostId = peersRow.getUUID("host_id");
+        if (hostId == null)
+        {
+            return null;
+        }
+
+        if (localHost.equals(hostId))
+        {
+            return localEndpoint;
+        }
+
+        EndPoint endPoint = delegateEndpointFactory.create(peersRow);
+        if (endPoint != null)
+        {
+            // Retain the wrapping EndPoint object but replace the wrapped EndPoint as the driver
+            // reuses the old Host object if the EndPoints are equal.
+            return hostIdEndPointMap.compute(hostId, (uuid, old) -> {
+                if (old != null)
+                {
+                    old.setEndPoint(endPoint);
+                    return old;
+                }
+
+                return new HostIdEndPoint(endPoint, hostId);
+            });
+        }
+
+        return null;
+    }
+
+    @Override
+    public void onAdd(Host host)
+    {
+        // Do nothing
+    }
+
+    @Override
+    public void onUp(Host host)
+    {
+        // Do nothing
+    }
+
+    @Override
+    public void onDown(Host host)
+    {
+        // Do nothing
+    }
+
+    @Override
+    public void onRemove(Host host)
+    {
+        UUID hostId = host.getHostId();
+        if (hostId != null)
+        {
+            hostIdEndPointMap.remove(hostId);
+        }
+        else
+        {
+            LOG.warn("No host ID found for host {} while trying to remove cached EndPoint", host);
+        }
+    }
+
+    @Override
+    public void onRegister(Cluster cluster)
+    {
+        // Do nothing
+    }
+
+    @Override
+    public void onUnregister(Cluster cluster)
+    {
+        // Do nothing
+    }
+
+    static class HostIdEndPoint implements EndPoint
+    {
+        private final UUID hostId;
+        private volatile EndPoint wrapped;
+
+        HostIdEndPoint(EndPoint wrapped, UUID hostId)
+        {
+            this.wrapped = wrapped;
+            this.hostId = hostId;
+        }
+
+        void setEndPoint(EndPoint wrapped)
+        {
+            this.wrapped = wrapped;
+        }
+
+        @Override
+        public InetSocketAddress resolve()
+        {
+            return wrapped.resolve();
+        }
+
+        @Override
+        public boolean equals(Object o)
+        {
+            if (this == o)
+                return true;
+            if (o == null || getClass() != o.getClass())
+                return false;
+            HostIdEndPoint that = (HostIdEndPoint) o;
+            return hostId.equals(that.hostId);
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return Objects.hash(hostId);
+        }
+
+        @Override
+        public String toString()
+        {
+            return String.format("%s(%s)", hostId, wrapped);
+        }
+    }
+}

--- a/connection.impl/src/test/java/com/ericsson/bss/cassandra/ecchronos/TestEccEndPointFactory.java
+++ b/connection.impl/src/test/java/com/ericsson/bss/cassandra/ecchronos/TestEccEndPointFactory.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2021 Telefonaktiebolaget LM Ericsson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ericsson.bss.cassandra.ecchronos;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.net.InetSocketAddress;
+import java.util.UUID;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import com.datastax.driver.core.EndPoint;
+import com.datastax.driver.core.EndPointFactory;
+import com.datastax.driver.core.Row;
+import com.ericsson.bss.cassandra.ecchronos.connection.impl.EccEndPointFactory;
+
+@RunWith(MockitoJUnitRunner.class)
+public class TestEccEndPointFactory
+{
+    private static final InetSocketAddress defaultSocketAddress = InetSocketAddress.createUnresolved("localhost", 9042);
+
+    private static final UUID localHostUuid = UUID.randomUUID();
+
+    @Mock
+    private EndPointFactory mockedEndPointFactory;
+
+    @Mock
+    private EndPoint localEndPoint;
+
+    private EccEndPointFactory eccEndPointFactory;
+
+    @Before
+    public void init()
+    {
+        localEndPoint = mockedEndPoint();
+        eccEndPointFactory = new EccEndPointFactory(localEndPoint, localHostUuid, mockedEndPointFactory);
+    }
+
+    @Test
+    public void testCreateForLocalEndPoint()
+    {
+        Row endPointRow = mockedEndPointRow(localHostUuid);
+
+        EndPoint endPoint = eccEndPointFactory.create(endPointRow);
+
+        assertThat(endPoint, is(localEndPoint));
+    }
+
+    @Test
+    public void testCreateWithNullHostId()
+    {
+        Row endPointRow = mockedEndPointRow(null);
+
+        EndPoint endPoint = eccEndPointFactory.create(endPointRow);
+
+        assertThat(endPoint, nullValue());
+    }
+
+    @Test
+    public void testCreateWithNullDelegate()
+    {
+        Row endPointRow = mockedEndPointRow(UUID.randomUUID());
+        when(mockedEndPointFactory.create(eq(endPointRow))).thenReturn(null);
+
+        EndPoint endPoint = eccEndPointFactory.create(endPointRow);
+
+        assertThat(endPoint, nullValue());
+    }
+
+    @Test
+    public void testSimpleWrappedEndPoint()
+    {
+        UUID hostId = UUID.randomUUID();
+        Row endPointRow = mockedEndPointRow(hostId);
+        EndPoint firstEndPoint = mockedEndPoint();
+        EndPoint secondEndPoint = mockedEndPoint();
+
+        when(mockedEndPointFactory.create(eq(endPointRow))).thenReturn(firstEndPoint);
+        EndPoint firstWrappedEndPoint = eccEndPointFactory.create(endPointRow);
+
+        // Make sure to create a new source EndPoint object to compare equality on host UUID
+        when(mockedEndPointFactory.create(eq(endPointRow))).thenReturn(secondEndPoint);
+        EndPoint secondWrappedEndPoint = eccEndPointFactory.create(endPointRow);
+
+        assertThat(firstEndPoint, not(firstWrappedEndPoint));
+        assertThat(secondEndPoint, not(secondWrappedEndPoint));
+        assertThat(firstWrappedEndPoint, is(secondWrappedEndPoint));
+        assertThat(firstWrappedEndPoint.hashCode(), equalTo(secondWrappedEndPoint.hashCode()));
+
+        // Make sure resolve call is delegated
+        assertThat(firstWrappedEndPoint.resolve(), equalTo(defaultSocketAddress));
+        verify(secondEndPoint).resolve();
+    }
+
+    private Row mockedEndPointRow(UUID uuid)
+    {
+        Row row = mock(Row.class);
+        when(row.getUUID(eq("host_id"))).thenReturn(uuid);
+        return row;
+    }
+
+    private EndPoint mockedEndPoint()
+    {
+        EndPoint endPoint = mock(EndPoint.class);
+        when(endPoint.resolve()).thenReturn(defaultSocketAddress);
+        return endPoint;
+    }
+}

--- a/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/repair/RepairSchedulerImpl.java
+++ b/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/repair/RepairSchedulerImpl.java
@@ -128,9 +128,16 @@ public class RepairSchedulerImpl implements RepairScheduler, Closeable
     {
         synchronized (myLock)
         {
-            if (configurationHasChanged(tableReference, repairConfiguration))
+            try
             {
-                createTableSchedule(tableReference, repairConfiguration);
+                if (configurationHasChanged(tableReference, repairConfiguration))
+                {
+                    createTableSchedule(tableReference, repairConfiguration);
+                }
+            }
+            catch (Exception e)
+            {
+                LOG.error("Error during Schedule change of {}:", tableReference, e);
             }
         }
     }

--- a/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/repair/RepairSchedulerImpl.java
+++ b/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/repair/RepairSchedulerImpl.java
@@ -128,16 +128,9 @@ public class RepairSchedulerImpl implements RepairScheduler, Closeable
     {
         synchronized (myLock)
         {
-            try
+            if (configurationHasChanged(tableReference, repairConfiguration))
             {
-                if (configurationHasChanged(tableReference, repairConfiguration))
-                {
-                    createTableSchedule(tableReference, repairConfiguration);
-                }
-            }
-            catch (Exception e)
-            {
-                LOG.error("Error during Schedule change of {}:", tableReference, e);
+                createTableSchedule(tableReference, repairConfiguration);
             }
         }
     }

--- a/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/repair/state/ReplicationStateImpl.java
+++ b/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/repair/state/ReplicationStateImpl.java
@@ -18,7 +18,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.slf4j.Logger;

--- a/core/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/repair/state/TestReplicationStateImpl.java
+++ b/core/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/repair/state/TestReplicationStateImpl.java
@@ -61,9 +61,6 @@ public class TestReplicationStateImpl
     private Host mockReplica3;
 
     @Mock
-    private Host mockReplica4;
-
-    @Mock
     private Node mockNode1;
 
     @Mock
@@ -83,12 +80,6 @@ public class TestReplicationStateImpl
         when(mockReplica2.getBroadcastAddress()).thenReturn(address2);
         when(mockReplica3.getBroadcastAddress()).thenReturn(address3);
 
-        UUID uuid = UUID.randomUUID();
-		when(mockReplica1.getHostId()).thenReturn(uuid);
-		when(mockReplica2.getHostId()).thenReturn(UUID.randomUUID());
-		when(mockReplica3.getHostId()).thenReturn(UUID.randomUUID());
-        when(mockReplica4.getHostId()).thenReturn(uuid);
-
         when(mockNodeResolver.fromIp(eq(address1))).thenReturn(Optional.of(mockNode1));
         when(mockNodeResolver.fromIp(eq(address2))).thenReturn(Optional.of(mockNode2));
         when(mockNodeResolver.fromIp(eq(address3))).thenReturn(Optional.of(mockNode3));
@@ -106,30 +97,6 @@ public class TestReplicationStateImpl
         doReturn(Sets.newHashSet(mockReplica1, mockReplica2, mockReplica3)).when(mockMetadata).getReplicas(eq("ks"), eq(tokenRange));
 
         ReplicationState replicationState = new ReplicationStateImpl(mockNodeResolver, mockMetadata, mockReplica1);
-
-        Map<LongTokenRange, ImmutableSet<Node>> tokenRangeToReplicas = replicationState.getTokenRangeToReplicas(tableReference);
-
-        assertThat(tokenRangeToReplicas.keySet()).containsExactlyInAnyOrder(range1);
-        assertThat(tokenRangeToReplicas.get(range1)).containsExactlyInAnyOrder(mockNode1, mockNode2, mockNode3);
-
-        assertThat(replicationState.getNodes(tableReference, range1)).isSameAs(tokenRangeToReplicas.get(range1));
-    }
-
-    @Test
-    public void testGetTokenRangeToReplicaWhenLocalHostSwitchIP() throws Exception
-    {
-        LongTokenRange range1 = new LongTokenRange(1, 2);
-        TableReference tableReference = tableReference("ks", "tb");
-
-        TokenRange tokenRange = TokenUtil.getRange(1, 2);
-
-        doReturn(Sets.newHashSet()).when(mockMetadata).getTokenRanges(eq("ks"), eq(mockReplica4));
-        doReturn(Sets.newHashSet(mockReplica1, mockReplica2, mockReplica3)).when(mockMetadata).getReplicas(eq("ks"), eq(tokenRange));
-        doReturn(Sets.newHashSet(mockReplica1, mockReplica2, mockReplica3)).when(mockMetadata).getAllHosts();
-
-        doReturn(Sets.newHashSet(tokenRange)).when(mockMetadata).getTokenRanges(eq("ks"), eq(mockReplica1));
-
-        ReplicationState replicationState = new ReplicationStateImpl(mockNodeResolver, mockMetadata, mockReplica4);
 
         Map<LongTokenRange, ImmutableSet<Node>> tokenRangeToReplicas = replicationState.getTokenRangeToReplicas(tableReference);
 
@@ -208,32 +175,6 @@ public class TestReplicationStateImpl
 
         assertThat(tokenRangeToReplicas.keySet()).containsExactlyInAnyOrder(range1);
         assertThat(tokenRangeToReplicas.get(range1)).containsExactlyInAnyOrder(mockNode1, mockNode2, mockNode3);
-
-        assertThat(replicationState.getTokenRangeToReplicas(tableReference)).isSameAs(tokenRangeToReplicas);
-
-        assertThat(replicationState.getNodes(tableReference, range1)).isSameAs(tokenRangeToReplicas.get(range1));
-    }
-
-    @Test
-    public void testGetTokenRangeToReplicaRturnsCachedValueWhenLocalHostIsMissing() throws Exception
-    {
-        LongTokenRange range1 = new LongTokenRange(1, 2);
-        TableReference tableReference = tableReference("ks", "tb");
-
-        TokenRange tokenRange = TokenUtil.getRange(1, 2);
-
-        doReturn(Sets.newHashSet(tokenRange)).when(mockMetadata).getTokenRanges(eq("ks"), eq(mockReplica1));
-        doReturn(Sets.newHashSet(mockReplica1, mockReplica2, mockReplica3)).when(mockMetadata).getReplicas(eq("ks"), eq(tokenRange));
-
-        ReplicationState replicationState = new ReplicationStateImpl(mockNodeResolver, mockMetadata, mockReplica1);
-
-        Map<LongTokenRange, ImmutableSet<Node>> tokenRangeToReplicas = replicationState.getTokenRangeToReplicas(tableReference);
-
-        assertThat(tokenRangeToReplicas.keySet()).containsExactlyInAnyOrder(range1);
-        assertThat(tokenRangeToReplicas.get(range1)).containsExactlyInAnyOrder(mockNode1, mockNode2, mockNode3);
-
-        doReturn(Sets.newHashSet()).when(mockMetadata).getTokenRanges(eq("ks"), eq(mockReplica1));
-        doReturn(Sets.newHashSet(mockReplica2, mockReplica3)).when(mockMetadata).getAllHosts();
 
         assertThat(replicationState.getTokenRangeToReplicas(tableReference)).isSameAs(tokenRangeToReplicas);
 


### PR DESCRIPTION
* Treat endpoints as the same endpoint regardless of IP as long
  as the host UUID is the same.
* Add a contact endpoint for the case when a resolvable hostname
  is used for the local node. This will resolve to the specified
  hostname and always return the same endpoint object when the
  factory asks for it.