### PR TITLE
Bump springboot from 2.5.6 to 2.6.3

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 
 * Add ecc-schedule command - Issue #158
 * Consolidate all scripts into single script with subcommands - Issue #170
+* Bump springboot from 2.5.6 to 2.6.3 (CVE-2021-22060)
 
 ## Version 2.0.5
 

--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
         <assertj.version>3.16.1</assertj.version>
         <junit.version>5.7.0</junit.version>
         <org.apache.commons.io.version>2.7</org.apache.commons.io.version>
-        <com.fasterxml.jackson.version>2.12.3</com.fasterxml.jackson.version>
+        <com.fasterxml.jackson.version>2.13.1</com.fasterxml.jackson.version>
         <org.apache.logging.log4j.version>2.15.0</org.apache.logging.log4j.version>
 
         <pax-exam.version>4.13.1</pax-exam.version>
@@ -84,7 +84,7 @@
         <jcip.version>1.0</jcip.version>
         <junitparams.version>1.1.1</junitparams.version>
         <equalsverifier.version>3.5</equalsverifier.version>
-        <org.springframework.boot.version>2.5.6</org.springframework.boot.version> <!-- Remove direct dependency towards log4j-api when updating version -->
+        <org.springframework.boot.version>2.6.3</org.springframework.boot.version>
         <io.prometheus.simpleclient>0.10.0</io.prometheus.simpleclient>
 
         <!-- Plugin versions -->
@@ -250,12 +250,6 @@
             </dependency>
 
             <!-- Log4j dependency -->
-            <dependency>
-                <groupId>org.apache.logging.log4j</groupId>
-                <artifactId>log4j-api</artifactId>
-                <version>${org.apache.logging.log4j.version}</version>
-            </dependency>
-
             <dependency>
                 <groupId>org.apache.logging.log4j</groupId>
                 <artifactId>log4j-to-slf4j</artifactId>


### PR DESCRIPTION
To fix CVE-2021-22060. Also jackson had to be stepped because
springboot required the new version.