### PR TITLE
Fix maven timeout issues in github builds

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -5,6 +5,9 @@ on:
   pull_request:
   push:
 
+env:
+  MAVEN_OPTS: -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3 -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
+
 jobs:
   tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR configures HTTP flags used by maven, should fix random maven timeouts.
For more reference refer to https://github.com/actions/virtual-environments/issues/1499#issuecomment-689467080