### PR TITLE
Speed up start time of first cassandra container for tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -766,7 +766,7 @@ limitations under the License.
                                                         </bind>
                                                     </volumes>
                                                     <wait>
-                                                        <time>60000</time>
+                                                        <time>120000</time>
                                                         <tcp>
                                                             <ports>
                                                                 <port>9042</port>

--- a/pom.xml
+++ b/pom.xml
@@ -757,7 +757,7 @@ limitations under the License.
                                                     <env>
                                                         <LOCAL_JMX>no</LOCAL_JMX>
                                                         <JVM_OPTS>-Xmx${it.cassandra.heap} -Xms${it.cassandra.heap} -Xmn100M</JVM_OPTS>
-                                                        <JVM_EXTRA_OPTS>-Dcom.sun.management.jmxremote.authenticate=false -Dcassandra.superuser_setup_delay_ms=0</JVM_EXTRA_OPTS>
+                                                        <JVM_EXTRA_OPTS>-Dcom.sun.management.jmxremote.authenticate=false -Dcassandra.superuser_setup_delay_ms=0 -Dcassandra.skip_wait_for_gossip_to_settle=0 -Dcassandra.ring_delay_ms=0</JVM_EXTRA_OPTS>
                                                     </env>
                                                     <exposedPropertyKey>seed</exposedPropertyKey>
                                                     <volumes>
@@ -766,7 +766,7 @@ limitations under the License.
                                                         </bind>
                                                     </volumes>
                                                     <wait>
-                                                        <time>120000</time>
+                                                        <time>60000</time>
                                                         <tcp>
                                                             <ports>
                                                                 <port>9042</port>


### PR DESCRIPTION
We speed up the start time by disabling waiting for gossip and ring. Since it's the first node, there's no need to wait for any of those.