### PR TITLE
Fix a flaky test in TestRepairStateImpl.java caused by indeterminate order in comparsion

### DIFF
--- a/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/repair/state/VnodeRepairStates.java
+++ b/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/repair/state/VnodeRepairStates.java
@@ -18,7 +18,7 @@ import com.ericsson.bss.cassandra.ecchronos.core.utils.LongTokenRange;
 import com.google.common.collect.ImmutableList;
 
 import java.util.Collection;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
 
@@ -88,7 +88,7 @@ public class VnodeRepairStates
 
     public static class Builder
     {
-        private final Map<LongTokenRange, VnodeRepairState> myVnodeRepairStates = new HashMap<>();
+        private final Map<LongTokenRange, VnodeRepairState> myVnodeRepairStates = new LinkedHashMap<>();
 
         public Builder(Collection<VnodeRepairState> vnodeRepairStates)
         {


### PR DESCRIPTION
**Description**
The test `testUpdateRepaired()` can pass or fail nondeterministically when running in different JVMs. The flakiness is found using the command `mvn edu.illinois:nondex-maven-plugin:1.1.2:nondex -Dtest=TestRepairStateImpl#testPartiallyRepaired` under the `core` directory after building dependencies. The test occasionally fails as line 80 in `TestRepairState.java` throws an inequality.

**Sample Failure**
```
[ERROR] testPartiallyRepaired  Time elapsed: 1.495 s  <<< FAILURE!
org.opentest4j.AssertionFailedError:

Expecting:
 <[VnodeRepairState{myTokenRange=(1,2], myReplicas=[Mock for Node, hashCode: 1640612861], myStartedAt=1649584071405, myFinishedAt=-1}, VnodeRepairState{myTokenRange=(2,3], myReplicas=[Mock for Node, hashCode: 1640612861], myStartedAt=1649587671089, myFinishedAt=1649587671089}]>
to be equal to:
 <[VnodeRepairState{myTokenRange=(2,3], myReplicas=[Mock for Node, hashCode: 1640612861], myStartedAt=1649587671089, myFinishedAt=1649587671089}, VnodeRepairState{myTokenRange=(1,2], myReplicas=[Mock for Node, hashCode: 1640612861], myStartedAt=1649584071405, myFinishedAt=-1}]>
but was not.
```

**Reason for Flakiness**
In `testUpdateRepaired()`, the test calls the helper function `assertRepairStateSnapshot()` that does an equality test between `VnodeRepairStates`. Specifically, the code goes through the constructor of `VnodeRepairStates`. The constructor implements `myVnodeRepairStatuses` of type `ImmutableList<VnodeRepairState>` by calling `copyOf()`, invoking the default iterator of a Collection output from the `values()` method of `HashMap`. However, a common `HashMap` does not preserve element orders. As an ImmutableList is sensible of orderings, different possible ordering patterns when iterating through the same unordered Collection can produce unequal lists.

**Proposed Fix**
Use `LinkedHashMap` for `myVnodeRepairStates` to ensure insertion order. 
