### PR TITLE
Make http errors (404 and 400) return with body

### DIFF
--- a/rest/src/main/java/com/ericsson/bss/cassandra/ecchronos/rest/RepairManagementRESTImpl.java
+++ b/rest/src/main/java/com/ericsson/bss/cassandra/ecchronos/rest/RepairManagementRESTImpl.java
@@ -29,6 +29,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.util.List;
 import java.util.Optional;
@@ -36,6 +37,9 @@ import java.util.UUID;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
 
 /**
  * When updating the path it should also be updated in the OSGi component.
@@ -101,12 +105,12 @@ public class RepairManagementRESTImpl implements RepairManagementREST
         catch (IllegalArgumentException e)
         {
             //BAD REQUEST makes most sense here (UUID cannot be parsed)
-            return ResponseEntity.badRequest().build();
+            throw new ResponseStatusException(BAD_REQUEST);
         }
         Optional<RepairJobView> repairJobView = getCompleteRepairJob(uuid);
         if (!repairJobView.isPresent())
         {
-            return ResponseEntity.notFound().build();
+            throw new ResponseStatusException(NOT_FOUND);
         }
         return ResponseEntity.ok(new CompleteRepairJob(repairJobView.get()));
     }
@@ -149,12 +153,12 @@ public class RepairManagementRESTImpl implements RepairManagementREST
         catch (IllegalArgumentException e)
         {
             //BAD REQUEST makes most sense here (UUID cannot be parsed)
-            return ResponseEntity.badRequest().build();
+            throw new ResponseStatusException(BAD_REQUEST);
         }
         Optional<RepairJobView> repairJobView = getCompleteRepairJob(uuid);
         if (!repairJobView.isPresent())
         {
-            return ResponseEntity.notFound().build();
+            throw new ResponseStatusException(NOT_FOUND);
         }
         return ResponseEntity.ok(new TableRepairConfig(repairJobView.get()));
     }
@@ -171,7 +175,7 @@ public class RepairManagementRESTImpl implements RepairManagementREST
         }
         catch (EcChronosException e)
         {
-            return ResponseEntity.notFound().build();
+            throw new ResponseStatusException(NOT_FOUND);
         }
     }
 

--- a/rest/src/main/java/com/ericsson/bss/cassandra/ecchronos/rest/RepairManagementRESTImpl.java
+++ b/rest/src/main/java/com/ericsson/bss/cassandra/ecchronos/rest/RepairManagementRESTImpl.java
@@ -105,7 +105,7 @@ public class RepairManagementRESTImpl implements RepairManagementREST
         catch (IllegalArgumentException e)
         {
             //BAD REQUEST makes most sense here (UUID cannot be parsed)
-            throw new ResponseStatusException(BAD_REQUEST);
+            throw new ResponseStatusException(BAD_REQUEST, BAD_REQUEST.getReasonPhrase(), e);
         }
         Optional<RepairJobView> repairJobView = getCompleteRepairJob(uuid);
         if (!repairJobView.isPresent())
@@ -153,7 +153,7 @@ public class RepairManagementRESTImpl implements RepairManagementREST
         catch (IllegalArgumentException e)
         {
             //BAD REQUEST makes most sense here (UUID cannot be parsed)
-            throw new ResponseStatusException(BAD_REQUEST);
+            throw new ResponseStatusException(BAD_REQUEST, BAD_REQUEST.getReasonPhrase(), e);
         }
         Optional<RepairJobView> repairJobView = getCompleteRepairJob(uuid);
         if (!repairJobView.isPresent())
@@ -175,7 +175,7 @@ public class RepairManagementRESTImpl implements RepairManagementREST
         }
         catch (EcChronosException e)
         {
-            throw new ResponseStatusException(NOT_FOUND);
+            throw new ResponseStatusException(NOT_FOUND, NOT_FOUND.getReasonPhrase(), e);
         }
     }
 

--- a/rest/src/test/java/com/ericsson/bss/cassandra/ecchronos/rest/TestRepairManagementRESTImpl.java
+++ b/rest/src/test/java/com/ericsson/bss/cassandra/ecchronos/rest/TestRepairManagementRESTImpl.java
@@ -39,6 +39,7 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
@@ -53,6 +54,8 @@ import java.util.stream.Collectors;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
 
 @RunWith(MockitoJUnitRunner.Silent.class)
 public class TestRepairManagementRESTImpl
@@ -396,32 +399,51 @@ public class TestRepairManagementRESTImpl
 
         when(myRepairScheduler.getCurrentRepairJobs()).thenReturn(repairJobViews);
 
-        ResponseEntity<CompleteRepairJob> response = repairManagementREST.jobStatus(UUID.randomUUID().toString());
-
-        assertThat(response.getBody()).isNull();
-        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+        ResponseEntity<CompleteRepairJob> response = null;
+        String uuid = UUID.randomUUID().toString();
+        try
+        {
+            response =  repairManagementREST.jobStatus(uuid);
+        }
+        catch(ResponseStatusException e)
+        {
+            assertThat(e.getRawStatusCode()).isEqualTo(NOT_FOUND.value());
+        }
+        assertThat(response).isNull();
     }
 
     @Test
     public void testIdEntryEmpty()
     {
         when(myRepairScheduler.getCurrentRepairJobs()).thenReturn(Collections.emptyList());
-
-        ResponseEntity<CompleteRepairJob> response = repairManagementREST.jobStatus(UUID.randomUUID().toString());
-
-        assertThat(response.getBody()).isNull();
-        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+        ResponseEntity<CompleteRepairJob> response = null;
+        String uuid = UUID.randomUUID().toString();
+        try
+        {
+            response = repairManagementREST.jobStatus(uuid);
+        }
+        catch(ResponseStatusException e)
+        {
+            assertThat(e.getRawStatusCode()).isEqualTo(NOT_FOUND.value());
+        }
+        assertThat(response).isNull();
     }
 
     @Test
     public void testIdInvalidUUID()
     {
         when(myRepairScheduler.getCurrentRepairJobs()).thenReturn(Collections.emptyList());
-
-        ResponseEntity<CompleteRepairJob> response = repairManagementREST.jobStatus("123");
-
-        assertThat(response.getBody()).isNull();
-        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        String uuid = "123";
+        ResponseEntity<CompleteRepairJob> response = null;
+        try
+        {
+            response = repairManagementREST.jobStatus(uuid);
+        }
+        catch(ResponseStatusException e)
+        {
+            assertThat(e.getRawStatusCode()).isEqualTo(BAD_REQUEST.value());
+        }
+        assertThat(response).isNull();
     }
 
     @Test
@@ -671,10 +693,17 @@ public class TestRepairManagementRESTImpl
 
         when(myRepairScheduler.getCurrentRepairJobs()).thenReturn(repairJobViews);
 
-        ResponseEntity<TableRepairConfig> response = repairManagementREST.jobConfig(UUID.randomUUID().toString());
-
-        assertThat(response.getBody()).isNull();
-        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+        String uuid = UUID.randomUUID().toString();
+        ResponseEntity<TableRepairConfig> response = null;
+        try
+        {
+            response = repairManagementREST.jobConfig(uuid);
+        }
+        catch(ResponseStatusException e)
+        {
+            assertThat(e.getRawStatusCode()).isEqualTo(NOT_FOUND.value());
+        }
+        assertThat(response).isNull();
     }
 
     @Test
@@ -682,10 +711,17 @@ public class TestRepairManagementRESTImpl
     {
         when(myRepairScheduler.getCurrentRepairJobs()).thenReturn(Collections.emptyList());
 
-        ResponseEntity<TableRepairConfig> response = repairManagementREST.jobConfig(UUID.randomUUID().toString());
-
-        assertThat(response.getBody()).isNull();
-        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+        String uuid = UUID.randomUUID().toString();
+        ResponseEntity<TableRepairConfig> response = null;
+        try
+        {
+            response = repairManagementREST.jobConfig(uuid);
+        }
+        catch(ResponseStatusException e)
+        {
+            assertThat(e.getRawStatusCode()).isEqualTo(NOT_FOUND.value());
+        }
+        assertThat(response).isNull();
     }
 
     @Test
@@ -693,10 +729,17 @@ public class TestRepairManagementRESTImpl
     {
         when(myRepairScheduler.getCurrentRepairJobs()).thenReturn(Collections.emptyList());
 
-        ResponseEntity<TableRepairConfig> response = repairManagementREST.jobConfig("123");
-
-        assertThat(response.getBody()).isNull();
-        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        String uuid = "123";
+        ResponseEntity<TableRepairConfig> response = null;
+        try
+        {
+            response = repairManagementREST.jobConfig(uuid);
+        }
+        catch(ResponseStatusException e)
+        {
+            assertThat(e.getRawStatusCode()).isEqualTo(BAD_REQUEST.value());
+        }
+        assertThat(response).isNull();
     }
 
     @Test


### PR DESCRIPTION
This was wrongly removed in JSON refactoring patch.