### PR TITLE
Make keyspace and table optional for run repair

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Version 3.0.0
 
+* Add support for repairs without keyspace/table - Issue #158
 * Add Cassandra health indicator and enable probes - Issue #192
 * Add support for clusterwide repairs - Issue #299
 * Add custom HTML error page

--- a/application/src/main/java/com/ericsson/bss/cassandra/ecchronos/application/spring/ECChronos.java
+++ b/application/src/main/java/com/ericsson/bss/cassandra/ecchronos/application/spring/ECChronos.java
@@ -17,6 +17,7 @@ package com.ericsson.bss.cassandra.ecchronos.application.spring;
 import java.io.Closeable;
 import java.util.Collections;
 
+import com.ericsson.bss.cassandra.ecchronos.core.utils.ReplicatedTableProvider;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -131,6 +132,12 @@ public class ECChronos implements Closeable
     public RepairScheduler repairScheduler()
     {
         return myRepairSchedulerImpl;
+    }
+
+    @Bean
+    public ReplicatedTableProvider replicatedTableProvider()
+    {
+        return myECChronosInternals.getReplicatedTableProvider();
     }
 
     @Override

--- a/core.osgi/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/osgi/TableReferenceFactoryService.java
+++ b/core.osgi/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/osgi/TableReferenceFactoryService.java
@@ -17,10 +17,13 @@ package com.ericsson.bss.cassandra.ecchronos.core.osgi;
 import com.datastax.driver.core.Metadata;
 import com.datastax.driver.core.TableMetadata;
 import com.ericsson.bss.cassandra.ecchronos.connection.NativeConnectionProvider;
+import com.ericsson.bss.cassandra.ecchronos.core.exceptions.EcChronosException;
 import com.ericsson.bss.cassandra.ecchronos.core.utils.TableReference;
 import com.ericsson.bss.cassandra.ecchronos.core.utils.TableReferenceFactory;
 import com.ericsson.bss.cassandra.ecchronos.core.utils.TableReferenceFactoryImpl;
 import org.osgi.service.component.annotations.*;
+
+import java.util.Set;
 
 @Component(service = TableReferenceFactory.class)
 public class TableReferenceFactoryService implements TableReferenceFactory
@@ -48,5 +51,17 @@ public class TableReferenceFactoryService implements TableReferenceFactory
     public TableReference forTable(TableMetadata table)
     {
         return delegateTableReferenceFactory.forTable(table);
+    }
+
+    @Override
+    public Set<TableReference> forKeyspace(String keyspace) throws EcChronosException
+    {
+        return delegateTableReferenceFactory.forKeyspace(keyspace);
+    }
+
+    @Override
+    public Set<TableReference> forCluster()
+    {
+        return delegateTableReferenceFactory.forCluster();
     }
 }

--- a/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/repair/OnDemandStatus.java
+++ b/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/repair/OnDemandStatus.java
@@ -216,7 +216,10 @@ public class OnDemandStatus
     public void addNewJob(UUID host, UUID jobId, TableReference tableReference, int tokenMapHash, Set<LongTokenRange> repairedRanges)
     {
         Set<UDTValue> repairedRangesUDT = new HashSet<>();
-        repairedRanges.forEach(t -> repairedRangesUDT.add(createUDTTokenRangeValue(t.start, t.end)));
+        if (repairedRanges != null)
+        {
+            repairedRanges.forEach(t -> repairedRangesUDT.add(createUDTTokenRangeValue(t.start, t.end)));
+        }
         UDTValue uDTTableReference = myUDTTableReferenceType.newValue().setUUID(UDT_ID_NAME, tableReference.getId())
                 .setString(UDT_KEYSPACE_NAME, tableReference.getKeyspace())
                 .setString(UDT_TABLE_NAME, tableReference.getTable());

--- a/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/repair/OngoingJob.java
+++ b/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/repair/OngoingJob.java
@@ -142,8 +142,14 @@ public class OngoingJob
             Set<LongTokenRange> remainingRanges = replicaWithRanges.getValue();
             Set<LongTokenRange> repairedRanges = repairedRangesPerNode.get(node);
             Set<LongTokenRange> allTokensForNode = new HashSet<>();
-            allTokensForNode.addAll(remainingRanges);
-            allTokensForNode.addAll(repairedRanges);
+            if (remainingRanges != null)
+            {
+                allTokensForNode.addAll(remainingRanges);
+            }
+            if (repairedRanges != null)
+            {
+                allTokensForNode.addAll(repairedRanges);
+            }
             myOnDemandStatus.addNewJob(node.getId(), myJobId, myTableReference, allTokensForNode.hashCode(), repairedRanges);
         }
     }

--- a/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/utils/TableReferenceFactory.java
+++ b/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/utils/TableReferenceFactory.java
@@ -15,9 +15,12 @@
 package com.ericsson.bss.cassandra.ecchronos.core.utils;
 
 import com.datastax.driver.core.TableMetadata;
+import com.ericsson.bss.cassandra.ecchronos.core.exceptions.EcChronosException;
+
+import java.util.Set;
 
 /**
- * A factory that generates table references based on keyspace and table name.
+ * A factory that generates table references
  */
 public interface TableReferenceFactory
 {
@@ -37,4 +40,20 @@ public interface TableReferenceFactory
      * @return A table reference for the provided keyspace/table pair.
      */
     TableReference forTable(TableMetadata table);
+
+    /**
+     * Get all table references in keyspace
+     *
+     * @param keyspace The keyspace name
+     * @throws com.ericsson.bss.cassandra.ecchronos.core.exceptions.EcChronosException if keyspace does not exist.
+     * @return A unique set of all table references for a specific keyspace.
+     */
+    Set<TableReference> forKeyspace(String keyspace) throws EcChronosException;
+
+    /**
+     * Get all table references for a cluster (all keyspaces, all tables)
+     *
+     * @return A unique set of all table references for the cluster.
+     */
+    Set<TableReference> forCluster();
 }

--- a/core/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/MockTableReferenceFactory.java
+++ b/core/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/MockTableReferenceFactory.java
@@ -14,12 +14,15 @@
  */
 package com.ericsson.bss.cassandra.ecchronos.core;
 
+import java.util.HashSet;
 import java.util.Objects;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
 import com.datastax.driver.core.TableMetadata;
+import com.ericsson.bss.cassandra.ecchronos.core.exceptions.EcChronosException;
 import com.ericsson.bss.cassandra.ecchronos.core.utils.TableReference;
 import com.ericsson.bss.cassandra.ecchronos.core.utils.TableReferenceFactory;
 
@@ -37,6 +40,28 @@ public class MockTableReferenceFactory implements TableReferenceFactory
     public TableReference forTable(TableMetadata table)
     {
         return tableReference(table);
+    }
+
+    @Override
+    public Set<TableReference> forKeyspace(String keyspace) throws EcChronosException
+    {
+        Set<TableReference> tableReferences = new HashSet<>();
+        tableReferences.add(tableReference(keyspace, "table1"));
+        tableReferences.add(tableReference(keyspace, "table2"));
+        tableReferences.add(tableReference(keyspace, "table3"));
+        return tableReferences;
+    }
+
+    @Override
+    public Set<TableReference> forCluster()
+    {
+        Set<TableReference> tableReferences = new HashSet<>();
+        tableReferences.add(tableReference("keyspace1", "table1"));
+        tableReferences.add(tableReference("keyspace1", "table2"));
+        tableReferences.add(tableReference("keyspace1", "table3"));
+        tableReferences.add(tableReference("keyspace2", "table4"));
+        tableReferences.add(tableReference("keyspace3", "table5"));
+        return tableReferences;
     }
 
     public static TableReference tableReference(String keyspace, String table)

--- a/docs/autogenerated/openapi.yaml
+++ b/docs/autogenerated/openapi.yaml
@@ -50,12 +50,12 @@ paths:
       parameters:
       - name: keyspace
         in: query
-        required: true
+        required: false
         schema:
           type: string
       - name: table
         in: query
-        required: true
+        required: false
         schema:
           type: string
       - name: isLocal

--- a/ecchronos-binary/src/bin/ecctool.py
+++ b/ecchronos-binary/src/bin/ecctool.py
@@ -141,9 +141,9 @@ def add_run_repair_subcommand(sub_parsers):
                                        help='repair will run for the local node, disabled by default', default=False)
     required_args = parser_trigger_repair.add_argument_group("required arguments")
     required_args.add_argument("-k", "--keyspace", type=str,
-                               help="Keyspace where the repair should be triggered", required=True)
+                               help="Keyspace where the repair should be triggered", required=False)
     required_args.add_argument("-t", "--table", type=str,
-                               help="Table where the repair should be triggered", required=True)
+                               help="Table where the repair should be triggered", required=False)
 
 def add_start_subcommand(sub_parsers):
     parser_config = sub_parsers.add_parser("start",
@@ -273,6 +273,9 @@ def repair_config(arguments):
 def run_repair(arguments):
     request = rest.V2RepairSchedulerRequest(base_url=arguments.url)
     printer = table_printer_v2
+    if not arguments.keyspace and arguments.table:
+        print("--keyspace must be specified if table is specified")
+        sys.exit(1)
     result = request.post(keyspace=arguments.keyspace, table=arguments.table, local=arguments.local)
     if result.is_successful():
         printer.print_repairs(result.data)

--- a/ecchronos-binary/src/pylib/ecchronoslib/rest.py
+++ b/ecchronos-binary/src/pylib/ecchronoslib/rest.py
@@ -145,7 +145,7 @@ class V2RepairSchedulerRequest(RestRequest):
     v2_repair_status_url = REPAIRS
     v2_repair_id_status_url = REPAIRS + '/{0}'
 
-    v2_repair_trigger_url = REPAIRS + '?keyspace={0}&table={1}'
+    v2_repair_trigger_url = REPAIRS
 
     def __init__(self, base_url=None):
         RestRequest.__init__(self, base_url)
@@ -206,9 +206,16 @@ class V2RepairSchedulerRequest(RestRequest):
         return result
 
     def post(self, keyspace=None, table=None, local=False):
-        request_url = V2RepairSchedulerRequest.v2_repair_trigger_url.format(keyspace, table)
+        request_url = V2RepairSchedulerRequest.v2_repair_trigger_url
+        if keyspace:
+            request_url += "?keyspace=" + keyspace
+            if table:
+                request_url += "&table=" + table
         if local:
-            request_url += "&isLocal=true"
+            if keyspace:
+                request_url += "&isLocal=true"
+            else:
+                request_url += "?isLocal=true"
         result = self.request(request_url, 'POST')
         if result.is_successful():
             result = result.transform_with_data(new_data=[Repair(x) for x in result.data])

--- a/ecchronos-binary/src/test/behave/features/ecctool-run-repair.feature
+++ b/ecchronos-binary/src/test/behave/features/ecctool-run-repair.feature
@@ -8,11 +8,57 @@ Feature: ecctool run-repair
     And the repair output should not contain more rows
     And the output should contain summary
 
+  Scenario: Run local repair for keyspace test2
+    Given we have access to ecctool
+    When we run local repair for keyspace test2
+    Then the repair output should contain a valid header
+    And the repair output should contain a valid repair row for test2.table2
+    And the repair output should contain a valid repair row for test2.table1
+    And the repair output should not contain more rows
+    And the output should contain summary
+
+  Scenario: Run local repair for all keyspaces and tables
+    Given we have access to ecctool
+    When we run local repair
+    Then the repair output should contain a valid header
+    And the repair output should contain a valid repair row for test2.table2
+    And the repair output should contain a valid repair row for test2.table1
+    And the repair output should contain a valid repair row for test.table2
+    And the repair output should contain a valid repair row for test.table1
+    And the repair output should not contain more rows
+    And the output should contain summary
+
   Scenario: Run cluster-wide repair for keyspace test2 and table table2
     Given we have access to ecctool
     When we run repair for keyspace test2 and table table2
     Then the repair output should contain a valid header
     And the repair output should contain a valid repair row for test2.table2
     And the repair output should contain a valid repair row for test2.table2
+    And the repair output should not contain more rows
+    And the output should contain summary
+
+  Scenario: Run cluster-wide repair for keyspace test2
+    Given we have access to ecctool
+    When we run repair for keyspace test2
+    Then the repair output should contain a valid header
+    And the repair output should contain a valid repair row for test2.table2
+    And the repair output should contain a valid repair row for test2.table2
+    And the repair output should contain a valid repair row for test2.table1
+    And the repair output should contain a valid repair row for test2.table1
+    And the repair output should not contain more rows
+    And the output should contain summary
+
+  Scenario: Run cluster-wide repair for all keyspaces and tables
+    Given we have access to ecctool
+    When we run repair
+    Then the repair output should contain a valid header
+    And the repair output should contain a valid repair row for test.table2
+    And the repair output should contain a valid repair row for test.table2
+    And the repair output should contain a valid repair row for test.table1
+    And the repair output should contain a valid repair row for test.table1
+    And the repair output should contain a valid repair row for test2.table2
+    And the repair output should contain a valid repair row for test2.table2
+    And the repair output should contain a valid repair row for test2.table1
+    And the repair output should contain a valid repair row for test2.table1
     And the repair output should not contain more rows
     And the output should contain summary

--- a/ecchronos-binary/src/test/behave/features/steps/ecctool_run_repair_steps.py
+++ b/ecchronos-binary/src/test/behave/features/steps/ecctool_run_repair_steps.py
@@ -37,9 +37,44 @@ def step_run_repair(context, keyspace, table):
     context.rows = output_data[3:-1]
     context.summary = output_data[-1:]
 
+@when(u'we run repair for keyspace {keyspace}')
+def step_run_repair_keyspace(context, keyspace):
+    run_ecc_run_repair(context, ['--keyspace', keyspace])
+
+    output_data = context.out.decode('ascii').lstrip().rstrip().split('\n')
+    context.header = output_data[0:3]
+    context.rows = output_data[3:-1]
+    context.summary = output_data[-1:]
+
+@when(u'we run repair')
+def step_run_repair_cluster(context):
+    run_ecc_run_repair(context, [])
+
+    output_data = context.out.decode('ascii').lstrip().rstrip().split('\n')
+    context.header = output_data[0:3]
+    context.rows = output_data[3:-1]
+    print context.out.decode('ascii')
+    context.summary = output_data[-1:]
+
 @when(u'we run local repair for keyspace {keyspace} and table {table}')
 def step_run_local_repair(context, keyspace, table):
     run_ecc_run_repair(context, ['--keyspace', keyspace, '--table', table, '--local'])
+    output_data = context.out.decode('ascii').lstrip().rstrip().split('\n')
+    context.header = output_data[0:3]
+    context.rows = output_data[3:-1]
+    context.summary = output_data[-1:]
+
+@when(u'we run local repair for keyspace {keyspace}')
+def step_run_local_repair_for_keyspace(context, keyspace):
+    run_ecc_run_repair(context, ['--keyspace', keyspace, '--local'])
+    output_data = context.out.decode('ascii').lstrip().rstrip().split('\n')
+    context.header = output_data[0:3]
+    context.rows = output_data[3:-1]
+    context.summary = output_data[-1:]
+
+@when(u'we run local repair')
+def step_run_local_repair_cluster(context):
+    run_ecc_run_repair(context, ['--local'])
     output_data = context.out.decode('ascii').lstrip().rstrip().split('\n')
     context.header = output_data[0:3]
     context.rows = output_data[3:-1]

--- a/ecchronos-binary/src/test/behave/features/steps/ecctool_run_repair_steps.py
+++ b/ecchronos-binary/src/test/behave/features/steps/ecctool_run_repair_steps.py
@@ -53,12 +53,12 @@ def step_run_repair_cluster(context):
     output_data = context.out.decode('ascii').lstrip().rstrip().split('\n')
     context.header = output_data[0:3]
     context.rows = output_data[3:-1]
-    print context.out.decode('ascii')
     context.summary = output_data[-1:]
 
 @when(u'we run local repair for keyspace {keyspace} and table {table}')
 def step_run_local_repair(context, keyspace, table):
     run_ecc_run_repair(context, ['--keyspace', keyspace, '--table', table, '--local'])
+
     output_data = context.out.decode('ascii').lstrip().rstrip().split('\n')
     context.header = output_data[0:3]
     context.rows = output_data[3:-1]
@@ -67,6 +67,7 @@ def step_run_local_repair(context, keyspace, table):
 @when(u'we run local repair for keyspace {keyspace}')
 def step_run_local_repair_for_keyspace(context, keyspace):
     run_ecc_run_repair(context, ['--keyspace', keyspace, '--local'])
+
     output_data = context.out.decode('ascii').lstrip().rstrip().split('\n')
     context.header = output_data[0:3]
     context.rows = output_data[3:-1]
@@ -75,6 +76,7 @@ def step_run_local_repair_for_keyspace(context, keyspace):
 @when(u'we run local repair')
 def step_run_local_repair_cluster(context):
     run_ecc_run_repair(context, ['--local'])
+
     output_data = context.out.decode('ascii').lstrip().rstrip().split('\n')
     context.header = output_data[0:3]
     context.rows = output_data[3:-1]

--- a/ecchronos-binary/src/test/behave/features/steps/ecctool_run_repair_steps.py
+++ b/ecchronos-binary/src/test/behave/features/steps/ecctool_run_repair_steps.py
@@ -20,76 +20,70 @@ from ecc_step_library.common_steps import match_and_remove_row, validate_header,
 TABLE_ROW_FORMAT_PATTERN = r'\| .* \| .* \| {0} \| {1} \| (COMPLETED|IN_QUEUE|WARNING|ERROR) \| \d+[.]\d+ \| .* \|'
 TABLE_HEADER = r'| Id | Host Id | Keyspace | Table | Status | Repaired(%) | Completed at |'
 
+
 def run_ecc_run_repair(context, params):
     cmd = [context.config.userdata.get("ecctool")] + ["run-repair"] + params
     context.proc = Popen(cmd, stdout=PIPE, stderr=PIPE) # pylint: disable=consider-using-with
     (context.out, context.err) = context.proc.communicate()
 
+
 def repair_row(keyspace, table):
     return TABLE_ROW_FORMAT_PATTERN.format(keyspace, table)
+
 
 @when(u'we run repair for keyspace {keyspace} and table {table}')
 def step_run_repair(context, keyspace, table):
     run_ecc_run_repair(context, ['--keyspace', keyspace, '--table', table])
+    split_output(context)
 
-    output_data = context.out.decode('ascii').lstrip().rstrip().split('\n')
-    context.header = output_data[0:3]
-    context.rows = output_data[3:-1]
-    context.summary = output_data[-1:]
 
 @when(u'we run repair for keyspace {keyspace}')
 def step_run_repair_keyspace(context, keyspace):
     run_ecc_run_repair(context, ['--keyspace', keyspace])
+    split_output(context)
 
-    output_data = context.out.decode('ascii').lstrip().rstrip().split('\n')
-    context.header = output_data[0:3]
-    context.rows = output_data[3:-1]
-    context.summary = output_data[-1:]
 
 @when(u'we run repair')
 def step_run_repair_cluster(context):
     run_ecc_run_repair(context, [])
+    split_output(context)
 
-    output_data = context.out.decode('ascii').lstrip().rstrip().split('\n')
-    context.header = output_data[0:3]
-    context.rows = output_data[3:-1]
-    context.summary = output_data[-1:]
 
 @when(u'we run local repair for keyspace {keyspace} and table {table}')
 def step_run_local_repair(context, keyspace, table):
     run_ecc_run_repair(context, ['--keyspace', keyspace, '--table', table, '--local'])
+    split_output(context)
 
-    output_data = context.out.decode('ascii').lstrip().rstrip().split('\n')
-    context.header = output_data[0:3]
-    context.rows = output_data[3:-1]
-    context.summary = output_data[-1:]
 
 @when(u'we run local repair for keyspace {keyspace}')
 def step_run_local_repair_for_keyspace(context, keyspace):
     run_ecc_run_repair(context, ['--keyspace', keyspace, '--local'])
+    split_output(context)
 
-    output_data = context.out.decode('ascii').lstrip().rstrip().split('\n')
-    context.header = output_data[0:3]
-    context.rows = output_data[3:-1]
-    context.summary = output_data[-1:]
 
 @when(u'we run local repair')
 def step_run_local_repair_cluster(context):
     run_ecc_run_repair(context, ['--local'])
+    split_output(context)
 
+
+def split_output(context):
     output_data = context.out.decode('ascii').lstrip().rstrip().split('\n')
     context.header = output_data[0:3]
     context.rows = output_data[3:-1]
     context.summary = output_data[-1:]
+
 
 @then(u'the repair output should contain a valid header')
 def step_validate_tables_header(context):
     validate_header(context.header, TABLE_HEADER)
 
+
 @then(u'the repair output should contain a valid repair row for {keyspace}.{table}')
 def step_validate_repair_row(context, keyspace, table):
     expected_row = repair_row(keyspace, table)
     match_and_remove_row(context.rows, expected_row)
+
 
 @then(u'the repair output should not contain more rows')
 def step_validate_list_rows_clear(context):

--- a/rest.osgi/src/main/java/com/ericsson/bss/cassandra/ecchronos/rest/osgi/RepairManagementRESTComponent.java
+++ b/rest.osgi/src/main/java/com/ericsson/bss/cassandra/ecchronos/rest/osgi/RepairManagementRESTComponent.java
@@ -21,6 +21,7 @@ import com.ericsson.bss.cassandra.ecchronos.core.repair.types.OnDemandRepair;
 import com.ericsson.bss.cassandra.ecchronos.core.repair.types.Schedule;
 import com.ericsson.bss.cassandra.ecchronos.core.repair.types.ScheduledRepairJob;
 import com.ericsson.bss.cassandra.ecchronos.core.repair.types.TableRepairConfig;
+import com.ericsson.bss.cassandra.ecchronos.core.utils.ReplicatedTableProvider;
 import com.ericsson.bss.cassandra.ecchronos.core.utils.TableReferenceFactory;
 import com.ericsson.bss.cassandra.ecchronos.rest.RepairManagementREST;
 import com.ericsson.bss.cassandra.ecchronos.rest.RepairManagementRESTImpl;
@@ -48,13 +49,16 @@ public class RepairManagementRESTComponent implements RepairManagementREST
     @Reference(service = TableReferenceFactory.class, cardinality = ReferenceCardinality.MANDATORY, policy = ReferencePolicy.STATIC)
     private volatile TableReferenceFactory myTableReferenceFactory;
 
+    @Reference(service = ReplicatedTableProvider.class, cardinality = ReferenceCardinality.MANDATORY, policy = ReferencePolicy.STATIC)
+    private volatile ReplicatedTableProvider myReplicatedTableProvider;
+
     private volatile RepairManagementRESTImpl myDelegateRESTImpl;
 
     @Activate
     public synchronized void activate()
     {
         myDelegateRESTImpl = new RepairManagementRESTImpl(myRepairScheduler, myOnDemandRepairScheduler,
-                myTableReferenceFactory);
+                myTableReferenceFactory, myReplicatedTableProvider);
     }
 
     @Override

--- a/rest/src/test/java/com/ericsson/bss/cassandra/ecchronos/rest/TestRepairManagementRESTImpl.java
+++ b/rest/src/test/java/com/ericsson/bss/cassandra/ecchronos/rest/TestRepairManagementRESTImpl.java
@@ -299,13 +299,130 @@ public class TestRepairManagementRESTImpl
     @Test
     public void testTriggerRepairOnlyKeyspace() throws EcChronosException
     {
-        //TODO
+        UUID id = UUID.randomUUID();
+        UUID hostId = UUID.randomUUID();
+        long completedAt = 1234L;
+        RepairJobView repairJobView1 = new TestUtils.OnDemandRepairJobBuilder()
+                .withId(id)
+                .withHostId(hostId)
+                .withKeyspace("ks")
+                .withTable("table1")
+                .withCompletedAt(completedAt)
+                .build();
+        RepairJobView repairJobView2 = new TestUtils.OnDemandRepairJobBuilder()
+                .withId(id)
+                .withHostId(hostId)
+                .withKeyspace("ks")
+                .withTable("table2")
+                .withCompletedAt(completedAt)
+                .build();
+        RepairJobView repairJobView3 = new TestUtils.OnDemandRepairJobBuilder()
+                .withId(id)
+                .withHostId(hostId)
+                .withKeyspace("ks")
+                .withTable("table3")
+                .withCompletedAt(completedAt)
+                .build();
+
+        List<OnDemandRepair> expectedResponse = new ArrayList<>();
+        expectedResponse.add(new OnDemandRepair(repairJobView1));
+        expectedResponse.add(new OnDemandRepair(repairJobView2));
+        expectedResponse.add(new OnDemandRepair(repairJobView3));
+
+        when(myOnDemandRepairScheduler.scheduleJob(myTableReferenceFactory.forTable("ks", "table1"))).thenReturn(
+                repairJobView1);
+        when(myOnDemandRepairScheduler.scheduleJob(myTableReferenceFactory.forTable("ks", "table2"))).thenReturn(
+                repairJobView2);
+        when(myOnDemandRepairScheduler.scheduleJob(myTableReferenceFactory.forTable("ks", "table3"))).thenReturn(
+                repairJobView3);
+        when(myReplicatedTableProvider.accept("ks")).thenReturn(true);
+        ResponseEntity<List<OnDemandRepair>> response = repairManagementREST.triggerRepair("ks", null, true);
+
+        assertThat(response.getBody()).containsAll(expectedResponse);
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
     }
 
     @Test
     public void testTriggerRepairNoKeyspaceNoTable() throws EcChronosException
     {
-        //TODO
+        UUID id = UUID.randomUUID();
+        UUID hostId = UUID.randomUUID();
+        long completedAt = 1234L;
+        RepairJobView repairJobView1 = new TestUtils.OnDemandRepairJobBuilder()
+                .withId(id)
+                .withHostId(hostId)
+                .withKeyspace("keyspace1")
+                .withTable("table1")
+                .withCompletedAt(completedAt)
+                .build();
+        RepairJobView repairJobView2 = new TestUtils.OnDemandRepairJobBuilder()
+                .withId(id)
+                .withHostId(hostId)
+                .withKeyspace("keyspace1")
+                .withTable("table2")
+                .withCompletedAt(completedAt)
+                .build();
+        RepairJobView repairJobView3 = new TestUtils.OnDemandRepairJobBuilder()
+                .withId(id)
+                .withHostId(hostId)
+                .withKeyspace("keyspace1")
+                .withTable("table3")
+                .withCompletedAt(completedAt)
+                .build();
+        RepairJobView repairJobView4 = new TestUtils.OnDemandRepairJobBuilder()
+                .withId(id)
+                .withHostId(hostId)
+                .withKeyspace("keyspace2")
+                .withTable("table4")
+                .withCompletedAt(completedAt)
+                .build();
+        RepairJobView repairJobView5 = new TestUtils.OnDemandRepairJobBuilder()
+                .withId(id)
+                .withHostId(hostId)
+                .withKeyspace("keyspace3")
+                .withTable("table5")
+                .withCompletedAt(completedAt)
+                .build();
+
+        List<OnDemandRepair> expectedResponse = new ArrayList<>();
+        expectedResponse.add(new OnDemandRepair(repairJobView1));
+        expectedResponse.add(new OnDemandRepair(repairJobView2));
+        expectedResponse.add(new OnDemandRepair(repairJobView3));
+        expectedResponse.add(new OnDemandRepair(repairJobView4));
+        expectedResponse.add(new OnDemandRepair(repairJobView5));
+
+        when(myOnDemandRepairScheduler.scheduleJob(myTableReferenceFactory.forTable("keyspace1", "table1"))).thenReturn(
+                repairJobView1);
+        when(myOnDemandRepairScheduler.scheduleJob(myTableReferenceFactory.forTable("keyspace1", "table2"))).thenReturn(
+                repairJobView2);
+        when(myOnDemandRepairScheduler.scheduleJob(myTableReferenceFactory.forTable("keyspace1", "table3"))).thenReturn(
+                repairJobView3);
+        when(myOnDemandRepairScheduler.scheduleJob(myTableReferenceFactory.forTable("keyspace2", "table4"))).thenReturn(
+                repairJobView4);
+        when(myOnDemandRepairScheduler.scheduleJob(myTableReferenceFactory.forTable("keyspace3", "table5"))).thenReturn(
+                repairJobView5);
+        when(myReplicatedTableProvider.accept("keyspace1")).thenReturn(true);
+        when(myReplicatedTableProvider.accept("keyspace2")).thenReturn(true);
+        when(myReplicatedTableProvider.accept("keyspace3")).thenReturn(true);
+        ResponseEntity<List<OnDemandRepair>> response = repairManagementREST.triggerRepair(null, null, true);
+
+        assertThat(response.getBody()).containsAll(expectedResponse);
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    }
+
+    @Test
+    public void testTriggerRepairNoKeyspaceWithTable()
+    {
+        ResponseEntity<List<OnDemandRepair>> response = null;
+        try
+        {
+            response = repairManagementREST.triggerRepair(null, "table1", true);
+        }
+        catch(ResponseStatusException e)
+        {
+            assertThat(e.getRawStatusCode()).isEqualTo(BAD_REQUEST.value());
+        }
+        assertThat(response).isNull();
     }
 
     @Test

--- a/rest/src/test/java/com/ericsson/bss/cassandra/ecchronos/rest/TestRepairManagementRESTImpl.java
+++ b/rest/src/test/java/com/ericsson/bss/cassandra/ecchronos/rest/TestRepairManagementRESTImpl.java
@@ -32,6 +32,7 @@ import com.ericsson.bss.cassandra.ecchronos.core.repair.types.Schedule;
 import com.ericsson.bss.cassandra.ecchronos.core.repair.types.ScheduledRepairJob;
 import com.ericsson.bss.cassandra.ecchronos.core.repair.types.TableRepairConfig;
 import com.ericsson.bss.cassandra.ecchronos.core.utils.Node;
+import com.ericsson.bss.cassandra.ecchronos.core.utils.ReplicatedTableProvider;
 import com.ericsson.bss.cassandra.ecchronos.core.utils.TableReferenceFactory;
 import com.google.common.collect.ImmutableSet;
 import org.junit.Before;
@@ -68,6 +69,9 @@ public class TestRepairManagementRESTImpl
     @Mock
     private OnDemandRepairScheduler myOnDemandRepairScheduler;
 
+    @Mock
+    private ReplicatedTableProvider myReplicatedTableProvider;
+
     private TableReferenceFactory myTableReferenceFactory = new MockTableReferenceFactory();
 
     private RepairManagementREST repairManagementREST;
@@ -76,7 +80,7 @@ public class TestRepairManagementRESTImpl
     public void setupMocks()
     {
         repairManagementREST = new RepairManagementRESTImpl(myRepairScheduler, myOnDemandRepairScheduler,
-                myTableReferenceFactory);
+                myTableReferenceFactory, myReplicatedTableProvider);
     }
 
     @Test
@@ -269,6 +273,7 @@ public class TestRepairManagementRESTImpl
 
         when(myOnDemandRepairScheduler.scheduleJob(myTableReferenceFactory.forTable("ks", "tb"))).thenReturn(
                 localRepairJobView);
+        when(myReplicatedTableProvider.accept("ks")).thenReturn(true);
         ResponseEntity<List<OnDemandRepair>> response = repairManagementREST.triggerRepair("ks", "tb", true);
 
         assertThat(response.getBody()).isEqualTo(localExpectedResponse);
@@ -289,6 +294,18 @@ public class TestRepairManagementRESTImpl
 
         assertThat(response.getBody()).isEqualTo(expectedResponse);
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    }
+
+    @Test
+    public void testTriggerRepairOnlyKeyspace() throws EcChronosException
+    {
+        //TODO
+    }
+
+    @Test
+    public void testTriggerRepairNoKeyspaceNoTable() throws EcChronosException
+    {
+        //TODO
     }
 
     @Test


### PR DESCRIPTION
With this it will be possible for user to run one command/send one REST request to trigger repair for all tables that the local node is a replica for.

Closes #158