### PR TITLE
Add repair-info

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Version 4.0.0
 
+* Add repair-info - Issue #327
 * Add config to skip schedules of tables with TWCS - Issue #151
 * Add metric for failed and succeeded repair tasks - Issue #295
 * Remove deprecated v1 REST interface

--- a/application/src/main/java/com/ericsson/bss/cassandra/ecchronos/application/spring/BeanConfigurator.java
+++ b/application/src/main/java/com/ericsson/bss/cassandra/ecchronos/application/spring/BeanConfigurator.java
@@ -28,6 +28,7 @@ import com.ericsson.bss.cassandra.ecchronos.connection.CertificateHandler;
 import com.ericsson.bss.cassandra.ecchronos.core.repair.DefaultRepairConfigurationProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.boot.convert.ApplicationConversionService;
 import org.springframework.boot.web.embedded.tomcat.TomcatServletWebServerFactory;
 import org.springframework.boot.web.servlet.ServletRegistrationBean;
 import org.springframework.boot.web.servlet.server.ConfigurableServletWebServerFactory;
@@ -53,6 +54,8 @@ import com.ericsson.bss.cassandra.ecchronos.fm.RepairFaultReporter;
 import io.prometheus.client.CollectorRegistry;
 import io.prometheus.client.dropwizard.DropwizardExports;
 import io.prometheus.client.exporter.MetricsServlet;
+import org.springframework.format.FormatterRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
 public class BeanConfigurator
@@ -244,5 +247,18 @@ public class BeanConfigurator
         CqlSession session = nativeConnectionProvider.getSession();
 
         return new ReplicationStateImpl(nodeResolver, session, node);
+    }
+
+    @Bean
+    public WebMvcConfigurer conversionConfigurer() //Add application converters to web so springboot can convert in REST
+    {
+        return new WebMvcConfigurer()
+        {
+            @Override
+            public void addFormatters(FormatterRegistry registry)
+            {
+                ApplicationConversionService.configure(registry);
+            }
+        };
     }
 }

--- a/application/src/main/java/com/ericsson/bss/cassandra/ecchronos/application/spring/ECChronos.java
+++ b/application/src/main/java/com/ericsson/bss/cassandra/ecchronos/application/spring/ECChronos.java
@@ -17,6 +17,9 @@ package com.ericsson.bss.cassandra.ecchronos.application.spring;
 import java.io.Closeable;
 import java.util.Collections;
 
+import com.ericsson.bss.cassandra.ecchronos.core.repair.state.VnodeRepairStateFactoryImpl;
+import com.ericsson.bss.cassandra.ecchronos.core.utils.RepairStatsProvider;
+import com.ericsson.bss.cassandra.ecchronos.core.utils.RepairStatsProviderImpl;
 import com.ericsson.bss.cassandra.ecchronos.core.utils.ReplicatedTableProvider;
 import com.datastax.oss.driver.api.core.CqlSession;
 import org.springframework.context.ApplicationContext;
@@ -49,6 +52,7 @@ public class ECChronos implements Closeable
     private final TimeBasedRunPolicy myTimeBasedRunPolicy;
     private final RepairSchedulerImpl myRepairSchedulerImpl;
     private final OnDemandRepairSchedulerImpl myOnDemandRepairSchedulerImpl;
+    private final RepairStatsProvider myRepairStatsProvider;
 
     public ECChronos(ApplicationContext applicationContext, Config configuration, // NOPMD
             RepairFaultReporter repairFaultReporter, NativeConnectionProvider nativeConnectionProvider,
@@ -109,6 +113,7 @@ public class ECChronos implements Closeable
                 .withRepairHistory(repairHistory)
                 .withOnDemandStatus(new OnDemandStatus(nativeConnectionProvider))
                 .build();
+        myRepairStatsProvider = new RepairStatsProviderImpl(new VnodeRepairStateFactoryImpl(replicationState, repairHistoryProvider, true));
         myECChronosInternals.addRunPolicy(myTimeBasedRunPolicy);
     }
 
@@ -134,6 +139,12 @@ public class ECChronos implements Closeable
     public ReplicatedTableProvider replicatedTableProvider()
     {
         return myECChronosInternals.getReplicatedTableProvider();
+    }
+
+    @Bean
+    public RepairStatsProvider repairStatsProvider()
+    {
+        return myRepairStatsProvider;
     }
 
     @Override

--- a/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/repair/state/NormalizedBaseRange.java
+++ b/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/repair/state/NormalizedBaseRange.java
@@ -80,7 +80,7 @@ public class NormalizedBaseRange
 
         BigInteger normalizedEnd = normalizedStart.add(subRange.getTokenRange().rangeSize());
 
-        return new NormalizedRange(this, normalizedStart, normalizedEnd, subRange.getStartedAt(), subRange.getFinishedAt());
+        return new NormalizedRange(this, normalizedStart, normalizedEnd, subRange.getStartedAt(), subRange.getFinishedAt(), subRange.getRepairTime());
     }
 
     /**
@@ -111,7 +111,7 @@ public class NormalizedBaseRange
             realEnd = realEnd.subtract(LongTokenRange.FULL_RANGE);
         }
 
-        return new VnodeRepairState(new LongTokenRange(realStart.longValueExact(), realEnd.longValueExact()), baseVnode.getReplicas(), range.getStartedAt(), range.getFinishedAt());
+        return new VnodeRepairState(new LongTokenRange(realStart.longValueExact(), realEnd.longValueExact()), baseVnode.getReplicas(), range.getStartedAt(), range.getFinishedAt(), range.getRepairTime());
     }
 
     @Override

--- a/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/repair/state/NormalizedRange.java
+++ b/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/repair/state/NormalizedRange.java
@@ -28,12 +28,24 @@ import java.util.Objects;
  */
 public class NormalizedRange implements Comparable<NormalizedRange>
 {
+    static final long UNKNOWN_REPAIR_TIME = 0L;
     private final NormalizedBaseRange base;
     private final BigInteger start;
     private final BigInteger end;
 
     private final long startedAt;
     private final long finishedAt;
+    private final long repairTime;
+
+    NormalizedRange(NormalizedBaseRange base, BigInteger start, BigInteger end, long startedAt, long finishedAt, long repairTime)
+    {
+        this.base = base;
+        this.start = start;
+        this.end = end;
+        this.startedAt = startedAt;
+        this.finishedAt = finishedAt;
+        this.repairTime = repairTime;
+    }
 
     NormalizedRange(NormalizedBaseRange base, BigInteger start, BigInteger end, long startedAt, long finishedAt)
     {
@@ -42,6 +54,12 @@ public class NormalizedRange implements Comparable<NormalizedRange>
         this.end = end;
         this.startedAt = startedAt;
         this.finishedAt = finishedAt;
+        long repairTime = UNKNOWN_REPAIR_TIME;
+        if (finishedAt > 0)
+        {
+            repairTime = finishedAt - startedAt;
+        }
+        this.repairTime = repairTime;
     }
 
     /**
@@ -84,6 +102,11 @@ public class NormalizedRange implements Comparable<NormalizedRange>
         return finishedAt;
     }
 
+    public long getRepairTime()
+    {
+        return repairTime;
+    }
+
     /**
      * Create a new normalized range based on this sub range with the provided start
      * and the current sub range end.
@@ -98,7 +121,7 @@ public class NormalizedRange implements Comparable<NormalizedRange>
             throw new IllegalArgumentException("Token " + newStart + " not in range " + base);
         }
 
-        return new NormalizedRange(base, newStart, end, startedAt, finishedAt);
+        return new NormalizedRange(base, newStart, end, startedAt, finishedAt, 0);
     }
 
     /**
@@ -115,7 +138,7 @@ public class NormalizedRange implements Comparable<NormalizedRange>
             throw new IllegalArgumentException("Token " + newEnd + " not in range " + base);
         }
 
-        return new NormalizedRange(base, start, newEnd, startedAt, finishedAt);
+        return new NormalizedRange(base, start, newEnd, startedAt, finishedAt, 0);
     }
 
     /**
@@ -139,7 +162,7 @@ public class NormalizedRange implements Comparable<NormalizedRange>
             throw new IllegalArgumentException("Cannot create range between " + this + " -> " + other);
         }
 
-        return new NormalizedRange(base, end, other.start, startedAt, finishedAt);
+        return new NormalizedRange(base, end, other.start, startedAt, finishedAt, 0);
     }
 
     /**
@@ -161,7 +184,7 @@ public class NormalizedRange implements Comparable<NormalizedRange>
 
         long startedAt = Math.max(this.startedAt, other.startedAt);
         long finishedAt = Math.min(this.finishedAt, other.finishedAt);
-        return new NormalizedRange(base, other.start, end, startedAt, finishedAt);
+        return new NormalizedRange(base, other.start, end, startedAt, finishedAt, 0);
     }
 
     /**
@@ -184,7 +207,7 @@ public class NormalizedRange implements Comparable<NormalizedRange>
 
         long startedAt = Math.min(this.startedAt, other.startedAt);
         long finishedAt = Math.max(this.finishedAt, other.finishedAt);
-        return new NormalizedRange(base, start, other.end, startedAt, finishedAt);
+        return new NormalizedRange(base, start, other.end, startedAt, finishedAt, repairTime + other.repairTime);
     }
 
     /**
@@ -230,6 +253,7 @@ public class NormalizedRange implements Comparable<NormalizedRange>
         NormalizedRange that = (NormalizedRange) o;
         return startedAt == that.startedAt &&
                 finishedAt == that.finishedAt &&
+                repairTime == that.repairTime &&
                 base.equals(that.base) &&
                 start.equals(that.start) &&
                 end.equals(that.end);
@@ -238,13 +262,13 @@ public class NormalizedRange implements Comparable<NormalizedRange>
     @Override
     public int hashCode()
     {
-        return Objects.hash(base, start, end, startedAt, finishedAt);
+        return Objects.hash(base, start, end, startedAt, finishedAt, repairTime);
     }
 
     @Override
     public String toString()
     {
-        return String.format("(%d, %d], %d-%d", start, end, startedAt, finishedAt);
+        return String.format("(%d, %d], %d-%d, repairtime: %d", start, end, startedAt, finishedAt, repairTime);
     }
 
 }

--- a/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/repair/state/RepairStateSnapshot.java
+++ b/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/repair/state/RepairStateSnapshot.java
@@ -42,18 +42,8 @@ public class RepairStateSnapshot
         myLastCompletedAt = builder.myLastCompletedAt;
         myReplicaRepairGroup = builder.myReplicaRepairGroup;
         myVnodeRepairStates = builder.myVnodeRepairStates;
-        myEstimatedRepairTime = calculateRepairTime();
+        myEstimatedRepairTime = myVnodeRepairStates.getRepairTime();
         canRepair = !myReplicaRepairGroup.isEmpty();
-    }
-
-    private long calculateRepairTime()
-    {
-        long sum = 0;
-        for (VnodeRepairState vnodeRepairState : myVnodeRepairStates.getVnodeRepairStates())
-        {
-            sum += getRepairTimeForVnode(vnodeRepairState);
-        }
-        return sum;
     }
 
     public long getRemainingRepairTime(long now, long repairIntervalMs)
@@ -63,20 +53,10 @@ public class RepairStateSnapshot
         {
             if(vnodeRepairState.lastRepairedAt() + (repairIntervalMs - myEstimatedRepairTime) <= now)
             {
-                sum += getRepairTimeForVnode(vnodeRepairState);
+                sum += vnodeRepairState.getRepairTime();
             }
         }
         return sum;
-    }
-
-    private long getRepairTimeForVnode(VnodeRepairState vnodeRepairState)
-    {
-        long finishedAt = vnodeRepairState.getFinishedAt();
-        if (finishedAt != VnodeRepairState.UNREPAIRED)
-        {
-            return finishedAt - vnodeRepairState.getStartedAt();
-        }
-        return 0L;
     }
 
     /**

--- a/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/repair/state/VnodeRepairState.java
+++ b/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/repair/state/VnodeRepairState.java
@@ -31,10 +31,20 @@ public class VnodeRepairState
     private final ImmutableSet<DriverNode> myReplicas;
     private final long myStartedAt;
     private final long myFinishedAt;
+    private final long myRepairTime;
 
     public VnodeRepairState(LongTokenRange tokenRange, ImmutableSet<DriverNode> replicas, long startedAt)
     {
         this(tokenRange, replicas, startedAt, UNREPAIRED);
+    }
+
+    public VnodeRepairState(LongTokenRange tokenRange, ImmutableSet<DriverNode> replicas, long startedAt, long finishedAt, long repairTime)
+    {
+        myTokenRange = tokenRange;
+        myReplicas = replicas;
+        myStartedAt = startedAt;
+        myFinishedAt = finishedAt;
+        myRepairTime = repairTime;
     }
 
     public VnodeRepairState(LongTokenRange tokenRange, ImmutableSet<DriverNode> replicas, long startedAt, long finishedAt)
@@ -43,6 +53,15 @@ public class VnodeRepairState
         myReplicas = replicas;
         myStartedAt = startedAt;
         myFinishedAt = finishedAt;
+        if (myFinishedAt != UNREPAIRED)
+        {
+            myRepairTime = myFinishedAt - myStartedAt;
+        }
+        else
+        {
+            myRepairTime = 0;
+        }
+
     }
 
     public LongTokenRange getTokenRange()
@@ -70,6 +89,11 @@ public class VnodeRepairState
         return myStartedAt;
     }
 
+    public long getRepairTime()
+    {
+        return myRepairTime;
+    }
+
     /**
      * Check if the vnodes are the same.
      *
@@ -91,6 +115,7 @@ public class VnodeRepairState
                 ", myReplicas=" + myReplicas +
                 ", myStartedAt=" + myStartedAt +
                 ", myFinishedAt=" + myFinishedAt +
+                ", myRepairTime=" + myRepairTime +
                 '}';
     }
 
@@ -102,6 +127,7 @@ public class VnodeRepairState
         VnodeRepairState that = (VnodeRepairState) o;
         return myStartedAt == that.myStartedAt &&
                 myFinishedAt == that.myFinishedAt &&
+                myRepairTime == that.myRepairTime &&
                 Objects.equals(myTokenRange, that.myTokenRange) &&
                 Objects.equals(myReplicas, that.myReplicas);
     }
@@ -109,6 +135,6 @@ public class VnodeRepairState
     @Override
     public int hashCode()
     {
-        return Objects.hash(myTokenRange, myReplicas, myStartedAt, myFinishedAt);
+        return Objects.hash(myTokenRange, myReplicas, myStartedAt, myFinishedAt, myRepairTime);
     }
 }

--- a/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/repair/state/VnodeRepairStateFactory.java
+++ b/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/repair/state/VnodeRepairStateFactory.java
@@ -31,4 +31,14 @@ public interface VnodeRepairStateFactory
      * @return The calculated repair state.
      */
     VnodeRepairStates calculateNewState(TableReference tableReference, RepairStateSnapshot previous);
+
+    /**
+     * Calculate the repair state for a time window.
+     *
+     * @param tableReference The table to calculate the repair state for vnodes.
+     * @param to Timestamp from when the repair state should start
+     * @param from Timestamp to when the repair state should stop
+     * @return The repair state during the specified time window.
+     */
+    VnodeRepairStates calculateState(TableReference tableReference, long to, long from);
 }

--- a/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/repair/state/VnodeRepairStateFactoryImpl.java
+++ b/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/repair/state/VnodeRepairStateFactoryImpl.java
@@ -67,6 +67,15 @@ public class VnodeRepairStateFactoryImpl implements VnodeRepairStateFactory
         return generateVnodeRepairStates(lastRepairedAt, previous, repairEntryIterator, tokenRangeToReplicaMap);
     }
 
+    @Override
+    public VnodeRepairStates calculateState(TableReference tableReference, long to, long from)
+    {
+        Map<LongTokenRange, ImmutableSet<DriverNode>> tokenRangeToReplicaMap = myReplicationState.getTokenRangeToReplicas(tableReference);
+        Iterator<RepairEntry> repairEntryIterator = myRepairHistoryProvider.iterate(tableReference, to, from,
+                (repairEntry) -> acceptRepairEntries(repairEntry, tokenRangeToReplicaMap));
+        return generateVnodeRepairStates(VnodeRepairState.UNREPAIRED, null, repairEntryIterator, tokenRangeToReplicaMap);
+    }
+
     private VnodeRepairStates generateVnodeRepairStates(long lastRepairedAt, RepairStateSnapshot previous, Iterator<RepairEntry> repairEntryIterator, Map<LongTokenRange, ImmutableSet<DriverNode>> tokenRangeToReplicaMap)
     {
         List<VnodeRepairState> vnodeRepairStatesBase = new ArrayList<>();

--- a/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/repair/state/VnodeRepairStates.java
+++ b/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/repair/state/VnodeRepairStates.java
@@ -35,6 +35,21 @@ public interface VnodeRepairStates
      */
     VnodeRepairStates combineWithRepairedAt(long repairedAt);
 
+    /**
+     * Calculate the effective repair time (time for Cassandra to perform repair) for all the repaired vnodes
+     *
+     * @return The repair time in milliseconds
+     */
+    default long getRepairTime()
+    {
+        long sum = 0;
+        for (VnodeRepairState vnodeRepairState : getVnodeRepairStates())
+        {
+            sum += vnodeRepairState.getRepairTime();
+        }
+        return sum;
+    }
+
     interface Builder
     {
         /**

--- a/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/repair/types/RepairInfo.java
+++ b/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/repair/types/RepairInfo.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2022 Telefonaktiebolaget LM Ericsson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ericsson.bss.cassandra.ecchronos.core.repair.types;
+
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotBlank;
+import java.util.List;
+import java.util.Objects;
+
+public class RepairInfo
+{
+    @NotBlank
+    @Min(0)
+    public long sinceInMs;
+    @NotBlank
+    @Min(0)
+    public long toInMs;
+    @NotBlank
+    public List<RepairStats> repairStats;
+
+    public RepairInfo(long since, long to, List<RepairStats> repairStats)
+    {
+        this.sinceInMs = since;
+        this.toInMs = to;
+        this.repairStats = repairStats;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        RepairInfo that = (RepairInfo) o;
+        return sinceInMs == that.sinceInMs && toInMs == that.toInMs && repairStats.size() == that.repairStats.size() &&
+                repairStats.containsAll(that.repairStats);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(sinceInMs, toInMs, repairStats);
+    }
+}

--- a/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/repair/types/RepairStats.java
+++ b/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/repair/types/RepairStats.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2022 Telefonaktiebolaget LM Ericsson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ericsson.bss.cassandra.ecchronos.core.repair.types;
+
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotBlank;
+import java.util.Objects;
+
+public class RepairStats
+{
+    @NotBlank
+    public String keyspace;
+    @NotBlank
+    public String table;
+    @NotBlank
+    @Min(0)
+    @Max(1)
+    public double repairedRatio;
+    @NotBlank
+    @Min(0)
+    public long repairTimeTakenMs;
+
+    public RepairStats(String keyspace, String table, double repairedRatio, long repairTimeTakenMs)
+    {
+        this.keyspace = keyspace;
+        this.table = table;
+        this.repairedRatio = repairedRatio;
+        this.repairTimeTakenMs = repairTimeTakenMs;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        RepairStats that = (RepairStats) o;
+        return Double.compare(that.repairedRatio, repairedRatio) == 0
+                && repairTimeTakenMs == that.repairTimeTakenMs && keyspace.equals(that.keyspace) && table.equals(
+                that.table);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(keyspace, table, repairedRatio, repairTimeTakenMs);
+    }
+}

--- a/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/utils/RepairStatsProvider.java
+++ b/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/utils/RepairStatsProvider.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2022 Telefonaktiebolaget LM Ericsson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ericsson.bss.cassandra.ecchronos.core.utils;
+
+import com.ericsson.bss.cassandra.ecchronos.core.repair.types.RepairStats;
+
+public interface RepairStatsProvider
+{
+    RepairStats getRepairStats(TableReference tableReference, long since, long to);
+}

--- a/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/utils/RepairStatsProviderImpl.java
+++ b/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/utils/RepairStatsProviderImpl.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2022 Telefonaktiebolaget LM Ericsson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ericsson.bss.cassandra.ecchronos.core.utils;
+
+import com.ericsson.bss.cassandra.ecchronos.core.repair.state.VnodeRepairState;
+import com.ericsson.bss.cassandra.ecchronos.core.repair.state.VnodeRepairStateFactory;
+import com.ericsson.bss.cassandra.ecchronos.core.repair.state.VnodeRepairStates;
+import com.ericsson.bss.cassandra.ecchronos.core.repair.types.RepairStats;
+
+import java.util.Collection;
+import java.util.stream.Collectors;
+
+public class RepairStatsProviderImpl implements RepairStatsProvider
+{
+    private final VnodeRepairStateFactory myVnodeRepairStateFactory;
+
+    public RepairStatsProviderImpl(VnodeRepairStateFactory vnodeRepairStateFactory)
+    {
+        myVnodeRepairStateFactory = vnodeRepairStateFactory;
+    }
+
+    @Override
+    public RepairStats getRepairStats(TableReference tableReference, long since, long to)
+    {
+        VnodeRepairStates vnodeRepairStates = myVnodeRepairStateFactory.calculateState(tableReference, to, since);
+        Collection<VnodeRepairState> states = vnodeRepairStates.getVnodeRepairStates();
+        Collection<VnodeRepairState> repairedStates = states.stream().filter(s -> isRepaired(s, since, to)).collect(
+                Collectors.toList());
+        double repairedRatio = states.isEmpty() ? 0 : (double) repairedStates.size() / states.size();
+        return new RepairStats(tableReference.getKeyspace(), tableReference.getTable(), repairedRatio, getRepairTime(repairedStates));
+    }
+
+    private long getRepairTime(Collection<VnodeRepairState> repairedStates)
+    {
+        long totalRepairTime = 0L;
+        for (VnodeRepairState vnodeRepairState : repairedStates)
+        {
+            totalRepairTime += vnodeRepairState.getRepairTime();
+        }
+        return totalRepairTime;
+    }
+
+    private boolean isRepaired(VnodeRepairState state, long since, long to)
+    {
+        return state.getStartedAt() >= since && state.getFinishedAt() <= to;
+    }
+}

--- a/core/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/repair/state/TestNormalizedRange.java
+++ b/core/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/repair/state/TestNormalizedRange.java
@@ -25,6 +25,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 
 import java.math.BigInteger;
 
+import static com.ericsson.bss.cassandra.ecchronos.core.repair.state.NormalizedRange.UNKNOWN_REPAIR_TIME;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
@@ -47,6 +48,7 @@ public class TestNormalizedRange
         assertThat(withNewStart.end()).isEqualTo(bi(9L));
         assertThat(withNewStart.getStartedAt()).isEqualTo(1234L);
         assertThat(withNewStart.getFinishedAt()).isEqualTo(1235L);
+        assertThat(withNewStart.getRepairTime()).isEqualTo(UNKNOWN_REPAIR_TIME);
     }
 
     @Test
@@ -69,6 +71,7 @@ public class TestNormalizedRange
         assertThat(withNewEnd.end()).isEqualTo(bi(8L));
         assertThat(withNewEnd.getStartedAt()).isEqualTo(1234L);
         assertThat(withNewEnd.getFinishedAt()).isEqualTo(1235L);
+        assertThat(withNewEnd.getRepairTime()).isEqualTo(UNKNOWN_REPAIR_TIME);
     }
 
     @Test
@@ -92,6 +95,7 @@ public class TestNormalizedRange
         assertThat(between.end()).isEqualTo(bi(13L));
         assertThat(between.getStartedAt()).isEqualTo(1236L);
         assertThat(between.getFinishedAt()).isEqualTo(1237L);
+        assertThat(between.getRepairTime()).isEqualTo(UNKNOWN_REPAIR_TIME);
     }
 
     @Test
@@ -132,11 +136,12 @@ public class TestNormalizedRange
         NormalizedRange firstRange = new NormalizedRange(normalizedBaseRange, START, bi(13L), 1234L, 1235L);
         NormalizedRange secondRange = new NormalizedRange(normalizedBaseRange, bi(9L), bi(15L), 1235L, 1236L);
 
-        NormalizedRange between = firstRange.splitEnd(secondRange);
-        assertThat(between.start()).isEqualTo(bi(9L));
-        assertThat(between.end()).isEqualTo(bi(13L));
-        assertThat(between.getStartedAt()).isEqualTo(1235L);
-        assertThat(between.getFinishedAt()).isEqualTo(1235L);
+        NormalizedRange splitted = firstRange.splitEnd(secondRange);
+        assertThat(splitted.start()).isEqualTo(bi(9L));
+        assertThat(splitted.end()).isEqualTo(bi(13L));
+        assertThat(splitted.getStartedAt()).isEqualTo(1235L);
+        assertThat(splitted.getFinishedAt()).isEqualTo(1235L);
+        assertThat(splitted.getRepairTime()).isEqualTo(UNKNOWN_REPAIR_TIME);
     }
 
     @Test
@@ -177,11 +182,12 @@ public class TestNormalizedRange
         NormalizedRange firstRange = new NormalizedRange(normalizedBaseRange, START, bi(13L), 1234L, 1235L);
         NormalizedRange secondRange = new NormalizedRange(normalizedBaseRange, bi(13L), bi(15L), 1235L, 1236L);
 
-        NormalizedRange between = firstRange.combine(secondRange);
-        assertThat(between.start()).isEqualTo(START);
-        assertThat(between.end()).isEqualTo(bi(15L));
-        assertThat(between.getStartedAt()).isEqualTo(1234L);
-        assertThat(between.getFinishedAt()).isEqualTo(1236L);
+        NormalizedRange combined = firstRange.combine(secondRange);
+        assertThat(combined.start()).isEqualTo(START);
+        assertThat(combined.end()).isEqualTo(bi(15L));
+        assertThat(combined.getStartedAt()).isEqualTo(1234L);
+        assertThat(combined.getFinishedAt()).isEqualTo(1236L);
+        assertThat(combined.getRepairTime()).isEqualTo(2L);
     }
 
     @Test

--- a/core/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/repair/types/TestRepairInfo.java
+++ b/core/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/repair/types/TestRepairInfo.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2022 Telefonaktiebolaget LM Ericsson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ericsson.bss.cassandra.ecchronos.core.repair.types;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+public class TestRepairInfo
+{
+    @Test
+    public void testRepairInfo()
+    {
+        long since = 1234L;
+        long to = 12345L;
+        List<RepairStats> repairStatsList = Collections.singletonList(mock(RepairStats.class));
+        RepairInfo repairInfo = new RepairInfo(since, to, repairStatsList);
+        assertThat(repairInfo.sinceInMs).isEqualTo(since);
+        assertThat(repairInfo.toInMs).isEqualTo(to);
+        assertThat(repairInfo.repairStats).isEqualTo(repairStatsList);
+    }
+
+    @Test
+    public void testEquals()
+    {
+        EqualsVerifier.simple().forClass(RepairInfo.class).usingGetClass()
+                .withNonnullFields("sinceInMs", "toInMs", "repairStats")
+                .verify();
+    }
+}

--- a/core/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/repair/types/TestRepairStats.java
+++ b/core/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/repair/types/TestRepairStats.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2022 Telefonaktiebolaget LM Ericsson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ericsson.bss.cassandra.ecchronos.core.repair.types;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestRepairStats
+{
+    @Test
+    public void testRepairStats()
+    {
+        String keyspace = "foo";
+        String table = "bar";
+        Double ratio = 1.0;
+        long repairTimeTaken = 123L;
+        RepairStats repairStats = new RepairStats(keyspace, table, ratio, repairTimeTaken);
+        assertThat(repairStats.keyspace).isEqualTo(keyspace);
+        assertThat(repairStats.table).isEqualTo(table);
+        assertThat(repairStats.repairedRatio).isEqualTo(ratio);
+        assertThat(repairStats.repairTimeTakenMs).isEqualTo(repairTimeTaken);
+    }
+
+    @Test
+    public void testEquals()
+    {
+        EqualsVerifier.simple().forClass(RepairStats.class).usingGetClass()
+                .withNonnullFields("keyspace", "table", "repairedRatio", "repairTimeTakenMs")
+                .verify();
+    }
+}

--- a/core/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/utils/TestRepairStatsProviderImpl.java
+++ b/core/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/utils/TestRepairStatsProviderImpl.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2022 Telefonaktiebolaget LM Ericsson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ericsson.bss.cassandra.ecchronos.core.utils;
+
+import com.ericsson.bss.cassandra.ecchronos.core.repair.state.VnodeRepairState;
+import com.ericsson.bss.cassandra.ecchronos.core.repair.state.VnodeRepairStateFactory;
+import com.ericsson.bss.cassandra.ecchronos.core.repair.state.VnodeRepairStates;
+import com.ericsson.bss.cassandra.ecchronos.core.repair.state.VnodeRepairStatesImpl;
+import com.ericsson.bss.cassandra.ecchronos.core.repair.types.RepairStats;
+import com.google.common.collect.ImmutableSet;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static com.ericsson.bss.cassandra.ecchronos.core.MockTableReferenceFactory.tableReference;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.Silent.class)
+public class TestRepairStatsProviderImpl
+{
+    private static final String KEYSPACE_NAME = "keyspace";
+    private static final String TABLE_NAME = "table";
+    private static final TableReference TABLE_REFERENCE = tableReference(KEYSPACE_NAME, TABLE_NAME);
+
+    @Mock
+    private VnodeRepairStateFactory vnodeRepairStateFactoryMock;
+
+    @Test
+    public void TestGetRepairStatsAllUnrepaired()
+    {
+        long since = 1234L;
+        long to = 1237L;
+        DriverNode node = mockNode("DC1");
+        VnodeRepairState vnodeRepairState = new VnodeRepairState(new LongTokenRange(1, 2), ImmutableSet.of(node), VnodeRepairState.UNREPAIRED);
+        VnodeRepairStates vnodeRepairStates = VnodeRepairStatesImpl.newBuilder(Collections.singletonList(vnodeRepairState))
+                .build();
+        when(vnodeRepairStateFactoryMock.calculateState(eq(TABLE_REFERENCE), eq(to), eq(since))).thenReturn(vnodeRepairStates);
+        RepairStatsProvider repairStatsProvider = new RepairStatsProviderImpl(vnodeRepairStateFactoryMock);
+        RepairStats repairStats = repairStatsProvider.getRepairStats(TABLE_REFERENCE, since, to);
+        assertThat(repairStats.repairedRatio).isEqualTo(0);
+        assertThat(repairStats.repairTimeTakenMs).isEqualTo(0);
+        assertThat(repairStats.keyspace).isEqualTo(KEYSPACE_NAME);
+        assertThat(repairStats.table).isEqualTo(TABLE_NAME);
+    }
+
+    @Test
+    public void TestGetRepairStatsAllRepaired()
+    {
+        long since = 1234L;
+        long to = 1237L;
+        long range1StartedAt = 1235L;
+        long range1FinishedAt = 1236L;
+        long range2StartedAt = 1236L;
+        long range2FinishedAt = 1237L;
+        DriverNode node = mockNode("DC1");
+        VnodeRepairState vnodeRepairState = new VnodeRepairState(new LongTokenRange(1, 2), ImmutableSet.of(node), range1StartedAt, range1FinishedAt);
+        VnodeRepairState vnodeRepairState2 = new VnodeRepairState(new LongTokenRange(2, 3), ImmutableSet.of(node), range2StartedAt, range2FinishedAt);
+        List<VnodeRepairState> repairStates = new ArrayList<>();
+        repairStates.add(vnodeRepairState);
+        repairStates.add(vnodeRepairState2);
+        VnodeRepairStates vnodeRepairStates = VnodeRepairStatesImpl.newBuilder(repairStates)
+                .build();
+        when(vnodeRepairStateFactoryMock.calculateState(eq(TABLE_REFERENCE), eq(to), eq(since))).thenReturn(vnodeRepairStates);
+        RepairStatsProvider repairStatsProvider = new RepairStatsProviderImpl(vnodeRepairStateFactoryMock);
+        RepairStats repairStats = repairStatsProvider.getRepairStats(TABLE_REFERENCE, since, to);
+        assertThat(repairStats.repairedRatio).isEqualTo(1);
+        assertThat(repairStats.repairTimeTakenMs).isEqualTo(vnodeRepairState.getRepairTime() + vnodeRepairState2.getRepairTime());
+        assertThat(repairStats.keyspace).isEqualTo(KEYSPACE_NAME);
+        assertThat(repairStats.table).isEqualTo(TABLE_NAME);
+    }
+
+    @Test
+    public void TestGetRepairStatsSomeRepairedSomeUnrepaired()
+    {
+        long range1StartedAt = 1234L;
+        long range1FinishedAt = 1235L;
+        long since = 1235L;
+        long to = 1237L;
+        long range2StartedAt = 1235L;
+        long range2FinishedAt = 1236L;
+        DriverNode node = mockNode("DC1");
+        VnodeRepairState vnodeRepairState = new VnodeRepairState(new LongTokenRange(1, 2), ImmutableSet.of(node), range1StartedAt, range1FinishedAt);
+        VnodeRepairState vnodeRepairState2 = new VnodeRepairState(new LongTokenRange(2, 3), ImmutableSet.of(node), range2StartedAt, range2FinishedAt);
+        List<VnodeRepairState> repairStates = new ArrayList<>();
+        repairStates.add(vnodeRepairState);
+        repairStates.add(vnodeRepairState2);
+        VnodeRepairStates vnodeRepairStates = VnodeRepairStatesImpl.newBuilder(repairStates)
+                .build();
+        when(vnodeRepairStateFactoryMock.calculateState(eq(TABLE_REFERENCE), eq(to), eq(since))).thenReturn(vnodeRepairStates);
+        RepairStatsProvider repairStatsProvider = new RepairStatsProviderImpl(vnodeRepairStateFactoryMock);
+        RepairStats repairStats = repairStatsProvider.getRepairStats(TABLE_REFERENCE, since, to);
+        assertThat(repairStats.repairedRatio).isEqualTo(0.5);
+        assertThat(repairStats.repairTimeTakenMs).isEqualTo(vnodeRepairState2.getRepairTime());
+        assertThat(repairStats.keyspace).isEqualTo(KEYSPACE_NAME);
+        assertThat(repairStats.table).isEqualTo(TABLE_NAME);
+    }
+
+    private DriverNode mockNode(String dataCenter)
+    {
+        DriverNode node = mock(DriverNode.class);
+        when(node.getDatacenter()).thenReturn(dataCenter);
+        return node;
+    }
+}

--- a/docs/ECCTOOL.md
+++ b/docs/ECCTOOL.md
@@ -6,14 +6,15 @@ Standalone ecChronos includes a commandline utlity (ecctool) to check status, st
 
 The following subcommands are available:
 
-| Command                                                             | Description                           |
-|---------------------------------------------------------------------|---------------------------------------|
-| `ecctool repairs`                                                   | Repair status overview                |
-| `ecctool schedules`                                                 | Status of schedules                   |
-| `ecctool run-repair`                                                | Trigger a single repair               |
-| `ecctool start`                                                     | Start ecChronos service               |
-| `ecctool stop`                                                      | Stop ecChronos service                |
-| `ecctool status`                                                    | Show status of ecChronos service      |
+| Command               | Description                              |
+|-----------------------|------------------------------------------|
+| `ecctool repairs`     | Repair status overview                   |
+| `ecctool schedules`   | Status of schedules                      |
+| `ecctool run-repair`  | Trigger a single repair                  |
+| `ecctool repair-info` | Show information about repairs per table |
+| `ecctool start`       | Start ecChronos service                  |
+| `ecctool stop`        | Stop ecChronos service                   |
+| `ecctool status`      | Show status of ecChronos service         |
 
 ### Flags
 

--- a/docs/autogenerated/openapi.yaml
+++ b/docs/autogenerated/openapi.yaml
@@ -145,6 +145,43 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/OnDemandRepair'
+  /repair-management/v2/repairInfo:
+    get:
+      tags:
+      - repair-management
+      operationId: get-repair-info
+      parameters:
+      - name: keyspace
+        in: query
+        required: false
+        schema:
+          type: string
+      - name: table
+        in: query
+        required: false
+        schema:
+          type: string
+      - name: since
+        in: query
+        description: "Since time, can be specified as ISO8601 date or as milliseconds\
+          \ since epoch"
+        required: false
+        schema:
+          type: string
+      - name: duration
+        in: query
+        description: "Duration, can be specified as either a simple duration like\
+          \ '30s' or as ISO8601 duration 'pt30s'"
+        required: false
+        schema:
+          type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RepairInfo'
 components:
   schemas:
     OnDemandRepair:
@@ -286,3 +323,43 @@ components:
           format: int64
         repaired:
           type: boolean
+    RepairInfo:
+      required:
+      - repairStats
+      - sinceInMs
+      - toInMs
+      type: object
+      properties:
+        sinceInMs:
+          minimum: 0
+          type: integer
+          format: int64
+        toInMs:
+          minimum: 0
+          type: integer
+          format: int64
+        repairStats:
+          type: array
+          items:
+            $ref: '#/components/schemas/RepairStats'
+    RepairStats:
+      required:
+      - keyspace
+      - repairTimeTakenMs
+      - repairedRatio
+      - table
+      type: object
+      properties:
+        keyspace:
+          type: string
+        table:
+          type: string
+        repairedRatio:
+          maximum: 1
+          minimum: 0
+          type: number
+          format: double
+        repairTimeTakenMs:
+          minimum: 0
+          type: integer
+          format: int64

--- a/ecchronos-binary/src/bin/ecctool.py
+++ b/ecchronos-binary/src/bin/ecctool.py
@@ -45,6 +45,7 @@ def parse_arguments():
     add_repairs_subcommand(sub_parsers)
     add_schedules_subcommand(sub_parsers)
     add_run_repair_subcommand(sub_parsers)
+    add_repair_info_subcommand(sub_parsers)
     add_start_subcommand(sub_parsers)
     add_stop_subcommand(sub_parsers)
     add_status_subcommand(sub_parsers)
@@ -104,6 +105,33 @@ def add_run_repair_subcommand(sub_parsers):
                                help="Keyspace where the repair should be triggered", required=False)
     required_args.add_argument("-t", "--table", type=str,
                                help="Table where the repair should be triggered", required=False)
+
+
+def add_repair_info_subcommand(sub_parsers):
+    parser_repair_info = sub_parsers.add_parser("repair-info",
+                                                description="Show information about repairs per table")
+    parser_repair_info.add_argument("-k", "--keyspace", type=str,
+                                    help="Print status(es) for a specific keyspace")
+    parser_repair_info.add_argument("-t", "--table", type=str,
+                                    help="Print status(es) for a specific table (Must be specified with keyspace)")
+    parser_repair_info.add_argument("-s", "--since", type=str,
+                                    help="Since date in ISO8601 format. Example: '2022-08-22T12:00:00.0+02:00'",
+                                    default=None)
+    parser_repair_info.add_argument("-d", "--duration", type=str,
+                                    help="Duration in seconds/minutes/hours/days. " +
+                                    "Can be specified in a simple or ISO8601 format without '+' and '-'. " +
+                                    "Simple format examples: '30s', '30m', '1h', '1d'. " +
+                                    "ISO8601 format examples: 'pt30s', 'pt30m', 'pt1h', 'p1d'. " +
+                                    "If '--since' is provided, the time-window will be from 'since' to " +
+                                    "'since+duration'. If only '--duration' is provided, " +
+                                    "the time-window will be from 'now-duration' to 'now'.",
+                                    default=None)
+    parser_repair_info.add_argument("-u", "--url", type=str,
+                                    help="The host to connect to with the format (http://<host>:port)",
+                                    default=None)
+    parser_repair_info.add_argument("-l", "--limit", type=int,
+                                    help="Limit the number of tables (-1 to disable)",
+                                    default=-1)
 
 
 def add_start_subcommand(sub_parsers):
@@ -202,6 +230,28 @@ def run_repair(arguments):
         print(result.format_exception())
 
 
+def repair_info(arguments):
+    request = rest.V2RepairSchedulerRequest(base_url=arguments.url)
+    if not arguments.keyspace and arguments.table:
+        print("--keyspace must be specified if table is specified")
+        sys.exit(1)
+    if not arguments.duration and not arguments.since:
+        print("Either --duration or --since or both must be provided")
+        sys.exit(1)
+    duration = None
+    if arguments.duration:
+        if arguments.duration[0] == "+" or arguments.duration[0] == "-":
+            print("'+' and '-' is not allowed in duration, check help for more information")
+            sys.exit(1)
+        duration = arguments.duration.upper()
+    result = request.get_repair_info(keyspace=arguments.keyspace, table=arguments.table,
+                                     since=arguments.since, duration=duration)
+    if result.is_successful():
+        table_printer.print_repair_info(result.data)
+    else:
+        print(result.format_exception())
+
+
 def start(arguments):
     script_dir = os.path.dirname(os.path.realpath(__file__))
     ecchronos_home_dir = os.path.join(script_dir, "..")
@@ -284,6 +334,9 @@ def run_subcommand(arguments):
     elif arguments.subcommand == "run-repair":
         status(arguments)
         run_repair(arguments)
+    elif arguments.subcommand == "repair-info":
+        status(arguments)
+        repair_info(arguments)
     elif arguments.subcommand == "start":
         start(arguments)
     elif arguments.subcommand == "stop":

--- a/ecchronos-binary/src/pylib/ecchronoslib/table_printer.py
+++ b/ecchronos-binary/src/pylib/ecchronoslib/table_printer.py
@@ -129,3 +129,26 @@ def _convert_schedule(schedule):
              schedule.get_repair_percentage(), schedule.get_last_repaired_at(), schedule.get_next_repair()]
 
     return entry
+
+
+def print_repair_info(repair_info, max_lines=-1):
+    print("Time window between '{0}' and '{1}'".format(repair_info.get_since(), repair_info.get_to()))
+    print_repair_stats(repair_info.repair_stats, max_lines)
+
+
+def print_repair_stats(repair_stats, max_lines=-1):
+    repair_stats_table = [["Keyspace", "Table", "Repaired (%)",
+                           "Repair time taken"]]
+    sorted_repair_stats = sorted(repair_stats, key=lambda x: (x.keyspace, x.table), reverse=False)
+    if max_lines > -1:
+        sorted_repair_stats = sorted_repair_stats[:max_lines]
+
+    for repair_stat in sorted_repair_stats:
+        repair_stats_table.append(_convert_repair_stat(repair_stat))
+    table_formatter.format_table(repair_stats_table)
+
+
+def _convert_repair_stat(repair_stat):
+    entry = [repair_stat.keyspace, repair_stat.table, repair_stat.get_repaired_percentage(),
+             repair_stat.get_repair_time_taken()]
+    return entry

--- a/ecchronos-binary/src/test/behave/features/ecc-rest-repair-info.feature
+++ b/ecchronos-binary/src/test/behave/features/ecc-rest-repair-info.feature
@@ -1,0 +1,36 @@
+Feature: API for repair info
+
+  Scenario: Get repair info for table test1.table1 in the last 5 minutes
+    Given I have a json schema in repair_info.json
+    And I use the url http://localhost:8080/repair-management/v2/repairInfo?keyspace=test&table=table1&duration=5m
+    When I send a GET request
+    Then the response is successful
+    And the response matches the json repair_info
+
+  Scenario: Get repair info for keyspace test1 in the last 5 minutes
+    Given I have a json schema in repair_info.json
+    And I use the url http://localhost:8080/repair-management/v2/repairInfo?keyspace=test&duration=5m
+    When I send a GET request
+    Then the response is successful
+    And the response matches the json repair_info
+
+  Scenario: Get repair info for all tables in the last 5 minutes
+    Given I have a json schema in repair_info.json
+    And I use the url http://localhost:8080/repair-management/v2/repairInfo?duration=5m
+    When I send a GET request
+    Then the response is successful
+    And the response matches the json repair_info
+
+  Scenario: Get repair info for all tables since epoch
+    Given I have a json schema in repair_info.json
+    And I use the url http://localhost:8080/repair-management/v2/repairInfo?since=0
+    When I send a GET request
+    Then the response is successful
+    And the response matches the json repair_info
+
+  Scenario: Get repair info for all tables between epoch and epoch+5 minutes
+    Given I have a json schema in repair_info.json
+    And I use the url http://localhost:8080/repair-management/v2/repairInfo?since=0&duration=5m
+    When I send a GET request
+    Then the response is successful
+    And the response matches the json repair_info

--- a/ecchronos-binary/src/test/behave/features/ecctool-repair-info.feature
+++ b/ecchronos-binary/src/test/behave/features/ecctool-repair-info.feature
@@ -1,0 +1,96 @@
+Feature: ecctool repair-info
+
+  Scenario: Get repair-info for all tables with duration
+    Given we have access to ecctool
+    When we get repair-info with duration 5m
+    Then the output should contain a valid repair-info header
+    And the output should contain a repair-info row for test.table1
+    And the output should contain a repair-info row for test.table2
+    And the output should contain a repair-info row for test2.table1
+    And the output should contain a repair-info row for test2.table2
+    And the output should not contain more rows
+
+  Scenario: Get repair-info for all tables with ISO8601 duration
+    Given we have access to ecctool
+    When we get repair-info with duration pt5m
+    Then the output should contain a valid repair-info header
+    And the output should contain a repair-info row for test.table1
+    And the output should contain a repair-info row for test.table2
+    And the output should contain a repair-info row for test2.table1
+    And the output should contain a repair-info row for test2.table2
+    And the output should not contain more rows
+
+  Scenario: Get repair-info for all tables with since
+    Given we have access to ecctool
+    When we get repair-info with since 0
+    Then the output should contain a valid repair-info header
+    And the output should contain a repair-info row for test.table1
+    And the output should contain a repair-info row for test.table2
+    And the output should contain a repair-info row for test2.table1
+    And the output should contain a repair-info row for test2.table2
+    And the output should not contain more rows
+
+  Scenario: Get repair-info for all tables with since ISO8601 date
+    Given we have access to ecctool
+    When we get repair-info with since 2022-08-25T12:00:00.0+02:00
+    Then the output should contain a valid repair-info header
+    And the output should contain a repair-info row for test.table1
+    And the output should contain a repair-info row for test.table2
+    And the output should contain a repair-info row for test2.table1
+    And the output should contain a repair-info row for test2.table2
+    And the output should not contain more rows
+
+  Scenario: Get repair-info for all tables with since and duration
+    Given we have access to ecctool
+    When we get repair-info with since 0 and duration 0
+    Then the output should contain a valid repair-info header
+    And the output should contain a repair-info row for test.table1
+    And the output should contain a repair-info row for test.table2
+    And the output should contain a repair-info row for test2.table1
+    And the output should contain a repair-info row for test2.table2
+    And the output should not contain more rows
+
+  Scenario: Get repair-info for keyspace test with duration
+    Given we have access to ecctool
+    When we get repair-info for keyspace test with duration 5m
+    Then the output should contain a valid repair-info header
+    And the output should contain a repair-info row for test.table1
+    And the output should contain a repair-info row for test.table2
+    And the output should not contain more rows
+
+  Scenario: Get repair-info for keyspace test with since
+    Given we have access to ecctool
+    When we get repair-info for keyspace test with since 0
+    Then the output should contain a valid repair-info header
+    And the output should contain a repair-info row for test.table1
+    And the output should contain a repair-info row for test.table2
+    And the output should not contain more rows
+
+  Scenario: Get repair-info for keyspace test with since and duration
+    Given we have access to ecctool
+    When we get repair-info for keyspace test with since 0 and duration 5m
+    Then the output should contain a valid repair-info header
+    And the output should contain a repair-info row for test.table1
+    And the output should contain a repair-info row for test.table2
+    And the output should not contain more rows
+
+  Scenario: Get repair-info for table test.table1 with duration
+    Given we have access to ecctool
+    When we get repair-info for table test.table1 with duration 5m
+    Then the output should contain a valid repair-info header
+    And the output should contain a repair-info row for test.table1
+    And the output should not contain more rows
+
+  Scenario: Get repair-info for table test.table1 with duration
+    Given we have access to ecctool
+    When we get repair-info for table test.table1 with since 0
+    Then the output should contain a valid repair-info header
+    And the output should contain a repair-info row for test.table1
+    And the output should not contain more rows
+
+  Scenario: Get repair-info for table test.table1 with duration and duration
+    Given we have access to ecctool
+    When we get repair-info for table test.table1 with since 0 and duration 5m
+    Then the output should contain a valid repair-info header
+    And the output should contain a repair-info row for test.table1
+    And the output should not contain more rows

--- a/ecchronos-binary/src/test/behave/features/repair_info.json
+++ b/ecchronos-binary/src/test/behave/features/repair_info.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Repair info",
+  "description": "Repair info and repair stats",
+  "type": "object",
+  "properties": {
+    "sinceInMs": {
+      "type": "integer"
+    },
+    "toInMs": {
+      "type": "integer"
+    },
+    "repairStats": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "keyspace": {
+            "type": "string"
+          },
+          "table": {
+            "type": "string"
+          },
+          "repairedRatio": {
+            "type": "number",
+            "description": "Ratio of how much of the table that has been repaired"
+          },
+          "repairTimeTakenMs": {
+            "type": "integer",
+            "description": "Repair time taken in millis"
+          }
+        },
+        "required": [
+          "keyspace",
+          "table",
+          "repairedRatio",
+          "repairTimeTakenMs"
+        ]
+      }
+    }
+  },
+  "required": [
+    "sinceInMs",
+    "toInMs",
+    "repairStats"
+  ]
+}

--- a/ecchronos-binary/src/test/behave/features/steps/ecctool_get_repair_info_steps.py
+++ b/ecchronos-binary/src/test/behave/features/steps/ecctool_get_repair_info_steps.py
@@ -1,0 +1,104 @@
+#
+# Copyright 2022 Telefonaktiebolaget LM Ericsson
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from subprocess import Popen, PIPE
+from behave import when, then  # pylint: disable=no-name-in-module
+from ecc_step_library.common_steps import match_and_remove_row, validate_header
+
+
+REPAIR_INFO_HEADER = r'| Keyspace | Table | Repaired (%) | Repair time taken |'
+REPAIR_INFO_ROW_FORMAT_PATTERN = r'\| {0} \| {1} \| \d+[.]\d+ \| .* \|'
+
+
+def run_ecc_repair_info(context, params):
+    cmd = [context.config.userdata.get("ecctool")] + ["repair-info"] + params
+    context.proc = Popen(cmd, stdout=PIPE, stderr=PIPE) # pylint: disable=consider-using-with
+    (context.out, context.err) = context.proc.communicate()
+
+
+def table_row(keyspace, table):
+    return REPAIR_INFO_ROW_FORMAT_PATTERN.format(keyspace, table)
+
+
+def handle_repair_info_output(context):
+    output_data = context.out.decode('ascii').lstrip().rstrip().split('\n')
+    context.time_window = output_data[0:1]
+    context.header = output_data[1:4]
+    context.rows = output_data[4:]
+
+
+@when(u'we get repair-info with since {since} and duration {duration}')
+def step_get_repair_info_with_since_and_duration(context, since, duration):
+    run_ecc_repair_info(context, ['--since', since, '--duration', duration])
+    handle_repair_info_output(context)
+
+
+@when(u'we get repair-info with duration {duration}')
+def step_get_repair_info_with_duration(context, duration):
+    run_ecc_repair_info(context, ['--duration', duration])
+    handle_repair_info_output(context)
+
+
+@when(u'we get repair-info with since {since}')
+def step_get_repair_info_with_since(context, since):
+    run_ecc_repair_info(context, ['--since', since])
+    handle_repair_info_output(context)
+
+
+@when(u'we get repair-info for keyspace {keyspace} with since {since} and duration {duration}')
+def step_get_repair_info_for_keyspace_with_since_and_duration(context, keyspace, since, duration):
+    run_ecc_repair_info(context, ['--keyspace', keyspace, '--since', since, '--duration', duration])
+    handle_repair_info_output(context)
+
+
+@when(u'we get repair-info for keyspace {keyspace} with duration {duration}')
+def step_get_repair_info_for_keyspace_with_duration(context, keyspace, duration):
+    run_ecc_repair_info(context, ['--keyspace', keyspace, '--duration', duration])
+    handle_repair_info_output(context)
+
+
+@when(u'we get repair-info for keyspace {keyspace} with since {since}')
+def step_get_repair_info_for_keyspace_with_since(context, keyspace, since):
+    run_ecc_repair_info(context, ['--keyspace', keyspace, '--since', since])
+    handle_repair_info_output(context)
+
+
+@when(u'we get repair-info for table {keyspace}.{table} with since {since} and duration {duration}')
+def step_get_repair_info_for_table_with_since_and_duration(context, keyspace, table, since, duration):
+    run_ecc_repair_info(context, ['--keyspace', keyspace, '--table', table, '--since', since, '--duration', duration])
+    handle_repair_info_output(context)
+
+
+@when(u'we get repair-info for table {keyspace}.{table} with duration {duration}')
+def step_get_repair_info_for_table_with_duration(context, keyspace, table, duration):
+    run_ecc_repair_info(context, ['--keyspace', keyspace, '--table', table, '--duration', duration])
+    handle_repair_info_output(context)
+
+
+@when(u'we get repair-info for table {keyspace}.{table} with since {since}')
+def step_get_repair_info_for_table_with_since(context, keyspace, table, since):
+    run_ecc_repair_info(context, ['--keyspace', keyspace, '--table', table, '--since', since])
+    handle_repair_info_output(context)
+
+
+@then(u'the output should contain a valid repair-info header')
+def step_validate_repair_info_header(context):
+    validate_header(context.header, REPAIR_INFO_HEADER)
+
+
+@then(u'the output should contain a repair-info row for {keyspace}.{table}')
+def step_validate_repair_info_row(context, keyspace, table):
+    expected_row = table_row(keyspace, table)
+    match_and_remove_row(context.rows, expected_row)

--- a/rest.osgi/src/main/java/com/ericsson/bss/cassandra/ecchronos/rest/osgi/RepairManagementRESTComponent.java
+++ b/rest.osgi/src/main/java/com/ericsson/bss/cassandra/ecchronos/rest/osgi/RepairManagementRESTComponent.java
@@ -17,7 +17,9 @@ package com.ericsson.bss.cassandra.ecchronos.rest.osgi;
 import com.ericsson.bss.cassandra.ecchronos.core.repair.OnDemandRepairScheduler;
 import com.ericsson.bss.cassandra.ecchronos.core.repair.RepairScheduler;
 import com.ericsson.bss.cassandra.ecchronos.core.repair.types.OnDemandRepair;
+import com.ericsson.bss.cassandra.ecchronos.core.repair.types.RepairInfo;
 import com.ericsson.bss.cassandra.ecchronos.core.repair.types.Schedule;
+import com.ericsson.bss.cassandra.ecchronos.core.utils.RepairStatsProvider;
 import com.ericsson.bss.cassandra.ecchronos.core.utils.ReplicatedTableProvider;
 import com.ericsson.bss.cassandra.ecchronos.core.utils.TableReferenceFactory;
 import com.ericsson.bss.cassandra.ecchronos.rest.RepairManagementREST;
@@ -29,6 +31,7 @@ import org.osgi.service.component.annotations.ReferenceCardinality;
 import org.osgi.service.component.annotations.ReferencePolicy;
 import org.springframework.http.ResponseEntity;
 
+import java.time.Duration;
 import java.util.List;
 
 /**
@@ -49,13 +52,16 @@ public class RepairManagementRESTComponent implements RepairManagementREST
     @Reference(service = ReplicatedTableProvider.class, cardinality = ReferenceCardinality.MANDATORY, policy = ReferencePolicy.STATIC)
     private volatile ReplicatedTableProvider myReplicatedTableProvider;
 
+    @Reference(service = RepairStatsProvider.class, cardinality = ReferenceCardinality.MANDATORY, policy = ReferencePolicy.STATIC)
+    private volatile RepairStatsProvider myRepairStatsProvider;
+
     private volatile RepairManagementRESTImpl myDelegateRESTImpl;
 
     @Activate
     public synchronized void activate()
     {
         myDelegateRESTImpl = new RepairManagementRESTImpl(myRepairScheduler, myOnDemandRepairScheduler,
-                myTableReferenceFactory, myReplicatedTableProvider);
+                myTableReferenceFactory, myReplicatedTableProvider, myRepairStatsProvider);
     }
 
     @Override
@@ -86,5 +92,11 @@ public class RepairManagementRESTComponent implements RepairManagementREST
     public ResponseEntity<List<OnDemandRepair>> triggerRepair(String keyspace, String table, boolean isLocal)
     {
         return myDelegateRESTImpl.triggerRepair(keyspace, table, isLocal);
+    }
+
+    @Override
+    public ResponseEntity<RepairInfo> getRepairInfo(String keyspace, String table, Long since, Duration duration)
+    {
+        return myDelegateRESTImpl.getRepairInfo(keyspace, table, since, duration);
     }
 }

--- a/rest/src/main/java/com/ericsson/bss/cassandra/ecchronos/rest/RepairManagementREST.java
+++ b/rest/src/main/java/com/ericsson/bss/cassandra/ecchronos/rest/RepairManagementREST.java
@@ -15,9 +15,11 @@
 package com.ericsson.bss.cassandra.ecchronos.rest;
 
 import com.ericsson.bss.cassandra.ecchronos.core.repair.types.OnDemandRepair;
+import com.ericsson.bss.cassandra.ecchronos.core.repair.types.RepairInfo;
 import com.ericsson.bss.cassandra.ecchronos.core.repair.types.Schedule;
 import org.springframework.http.ResponseEntity;
 
+import java.time.Duration;
 import java.util.List;
 
 /**
@@ -72,4 +74,6 @@ public interface RepairManagementREST
      * @return A JSON representation of {@link OnDemandRepair}
      */
     ResponseEntity<List<OnDemandRepair>> triggerRepair(String keyspace, String table, boolean isLocal);
+
+    ResponseEntity<RepairInfo> getRepairInfo(String keyspace, String table, Long since, Duration duration);
 }

--- a/rest/src/main/java/com/ericsson/bss/cassandra/ecchronos/rest/RepairManagementRESTImpl.java
+++ b/rest/src/main/java/com/ericsson/bss/cassandra/ecchronos/rest/RepairManagementRESTImpl.java
@@ -19,31 +19,39 @@ import com.ericsson.bss.cassandra.ecchronos.core.repair.OnDemandRepairScheduler;
 import com.ericsson.bss.cassandra.ecchronos.core.repair.RepairJobView;
 import com.ericsson.bss.cassandra.ecchronos.core.repair.RepairScheduler;
 import com.ericsson.bss.cassandra.ecchronos.core.repair.types.OnDemandRepair;
+import com.ericsson.bss.cassandra.ecchronos.core.repair.types.RepairInfo;
+import com.ericsson.bss.cassandra.ecchronos.core.repair.types.RepairStats;
 import com.ericsson.bss.cassandra.ecchronos.core.repair.types.Schedule;
+import com.ericsson.bss.cassandra.ecchronos.core.utils.RepairStatsProvider;
 import com.ericsson.bss.cassandra.ecchronos.core.utils.ReplicatedTableProvider;
 import com.ericsson.bss.cassandra.ecchronos.core.utils.TableReference;
 import com.ericsson.bss.cassandra.ecchronos.core.utils.TableReferenceFactory;
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.info.Info;
 import io.swagger.v3.oas.annotations.info.License;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
@@ -62,6 +70,7 @@ import static org.springframework.http.HttpStatus.NOT_FOUND;
                 name = "Apache 2.0",
                 url = "https://www.apache.org/licenses/LICENSE-2.0"),
         version = "1.0.0"))
+@SuppressWarnings("PMD.GodClass") // We might want to refactor
 public class RepairManagementRESTImpl implements RepairManagementREST
 {
     private static final String ROOT = "/repair-management/";
@@ -80,13 +89,18 @@ public class RepairManagementRESTImpl implements RepairManagementREST
     @Autowired
     private final ReplicatedTableProvider myReplicatedTableProvider;
 
+    @Autowired
+    private final RepairStatsProvider myRepairStatsProvider;
+
     public RepairManagementRESTImpl(RepairScheduler repairScheduler, OnDemandRepairScheduler demandRepairScheduler,
-            TableReferenceFactory tableReferenceFactory, ReplicatedTableProvider replicatedTableProvider)
+            TableReferenceFactory tableReferenceFactory, ReplicatedTableProvider replicatedTableProvider,
+            RepairStatsProvider repairStatsProvider)
     {
         myRepairScheduler = repairScheduler;
         myOnDemandRepairScheduler = demandRepairScheduler;
         myTableReferenceFactory = tableReferenceFactory;
         myReplicatedTableProvider = replicatedTableProvider;
+        myRepairStatsProvider = repairStatsProvider;
     }
 
     @Override
@@ -271,6 +285,92 @@ public class RepairManagementRESTImpl implements RepairManagementREST
         {
             throw new ResponseStatusException(NOT_FOUND, NOT_FOUND.getReasonPhrase(), e);
         }
+    }
+
+    @Override
+    @GetMapping(value = ENDPOINT_PREFIX + "/repairInfo",
+            produces = MediaType.APPLICATION_JSON_VALUE)
+    @Operation(operationId = "get-repair-info")
+    public ResponseEntity<RepairInfo> getRepairInfo(@RequestParam(required = false) String keyspace,
+            @RequestParam(required = false) String table,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+            @Parameter(
+                    description = "Since time, can be specified as ISO8601 date or as milliseconds since epoch",
+                    schema = @Schema(type = "string")) Long since,
+            @RequestParam(required = false) @Parameter(
+                    description = "Duration, can be specified as either a simple duration like '30s' or as ISO8601 duration 'pt30s'",
+                    schema = @Schema(type = "string"))
+                    Duration duration)
+    {
+        try
+        {
+            RepairInfo repairInfo;
+            if (keyspace != null)
+            {
+                if (table != null)
+                {
+                    TableReference tableReference = myTableReferenceFactory.forTable(keyspace, table);
+                    if (tableReference == null)
+                    {
+                        throw new ResponseStatusException(NOT_FOUND,
+                                "Table " + keyspace + "." + table + " does not exist");
+                    }
+                    repairInfo = getRepairInfo(Collections.singleton(tableReference), since, duration);
+                }
+                else
+                {
+                    repairInfo = getRepairInfo(myTableReferenceFactory.forKeyspace(keyspace), since, duration);
+                }
+            }
+            else
+            {
+                if (table != null)
+                {
+                    throw new ResponseStatusException(BAD_REQUEST, "Keyspace must be provided if table is provided");
+                }
+                repairInfo = getRepairInfo(myTableReferenceFactory.forCluster(), since, duration);
+            }
+            return ResponseEntity.ok(repairInfo);
+        }
+        catch (EcChronosException e)
+        {
+            throw new ResponseStatusException(NOT_FOUND, NOT_FOUND.getReasonPhrase(), e);
+        }
+    }
+
+    private RepairInfo getRepairInfo(Set<TableReference> tables, Long since, Duration duration)
+    {
+        long toTime = System.currentTimeMillis();
+        long sinceTime;
+        if (since != null)
+        {
+            sinceTime = since.longValue();
+            if (duration != null)
+            {
+                toTime = sinceTime + TimeUnit.SECONDS.toMillis(duration.getSeconds());
+            }
+        }
+        else if(duration != null)
+        {
+            sinceTime = toTime - TimeUnit.SECONDS.toMillis(duration.getSeconds());
+        }
+        else
+        {
+            throw new ResponseStatusException(BAD_REQUEST, "Since or duration or both must be specified");
+        }
+        if (toTime < sinceTime)
+        {
+            throw new ResponseStatusException(BAD_REQUEST, "'to' (" + toTime + ") is before 'since' (" + sinceTime + ")");
+        }
+        List<RepairStats> repairStats = new ArrayList<>();
+        for (TableReference table : tables)
+        {
+            if (myReplicatedTableProvider.accept(table.getKeyspace()))
+            {
+                repairStats.add(myRepairStatsProvider.getRepairStats(table, sinceTime, toTime));
+            }
+        }
+        return new RepairInfo(sinceTime, toTime, repairStats);
     }
 
     private List<OnDemandRepair> runLocalOrCluster(boolean isLocal, Set<TableReference> tables)

--- a/rest/src/test/java/com/ericsson/bss/cassandra/ecchronos/rest/TestRepairManagementRESTImpl.java
+++ b/rest/src/test/java/com/ericsson/bss/cassandra/ecchronos/rest/TestRepairManagementRESTImpl.java
@@ -22,8 +22,11 @@ import com.ericsson.bss.cassandra.ecchronos.core.repair.RepairScheduler;
 import com.ericsson.bss.cassandra.ecchronos.core.repair.TestUtils;
 import com.ericsson.bss.cassandra.ecchronos.core.repair.state.VnodeRepairState;
 import com.ericsson.bss.cassandra.ecchronos.core.repair.types.OnDemandRepair;
+import com.ericsson.bss.cassandra.ecchronos.core.repair.types.RepairInfo;
+import com.ericsson.bss.cassandra.ecchronos.core.repair.types.RepairStats;
 import com.ericsson.bss.cassandra.ecchronos.core.repair.types.Schedule;
 import com.ericsson.bss.cassandra.ecchronos.core.utils.DriverNode;
+import com.ericsson.bss.cassandra.ecchronos.core.utils.RepairStatsProvider;
 import com.ericsson.bss.cassandra.ecchronos.core.utils.ReplicatedTableProvider;
 import com.ericsson.bss.cassandra.ecchronos.core.utils.TableReferenceFactory;
 import com.google.common.collect.ImmutableSet;
@@ -38,6 +41,7 @@ import org.springframework.web.server.ResponseStatusException;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -46,6 +50,8 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
@@ -63,6 +69,9 @@ public class TestRepairManagementRESTImpl
     @Mock
     private ReplicatedTableProvider myReplicatedTableProvider;
 
+    @Mock
+    private RepairStatsProvider myRepairStatsProvider;
+
     private TableReferenceFactory myTableReferenceFactory = new MockTableReferenceFactory();
 
     private RepairManagementREST repairManagementREST;
@@ -71,7 +80,7 @@ public class TestRepairManagementRESTImpl
     public void setupMocks()
     {
         repairManagementREST = new RepairManagementRESTImpl(myRepairScheduler, myOnDemandRepairScheduler,
-                myTableReferenceFactory, myReplicatedTableProvider);
+                myTableReferenceFactory, myReplicatedTableProvider, myRepairStatsProvider);
     }
 
     @Test
@@ -588,5 +597,218 @@ public class TestRepairManagementRESTImpl
         assertThat(response.getBody()).isEqualTo(expectedResponseFull.get(0));
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         assertThat(response.getBody().virtualNodeStates).isNotEmpty();
+    }
+
+    @Test
+    public void testGetRepairInfo()
+    {
+        long since = 1245L;
+        long durationInMs = 1000L;
+        Duration duration = Duration.ofMillis(durationInMs);
+        long to = since + durationInMs;
+        RepairStats repairStats1 = new RepairStats("keyspace1", "table1", 0.0, 0);
+        when(myRepairStatsProvider.getRepairStats(myTableReferenceFactory.forTable("keyspace1", "table1"), since,
+                to)).thenReturn(repairStats1);
+        RepairStats repairStats2 = new RepairStats("keyspace1", "table2", 0.0, 0);
+        when(myRepairStatsProvider.getRepairStats(myTableReferenceFactory.forTable("keyspace1", "table2"), since,
+                to)).thenReturn(repairStats2);
+        RepairStats repairStats3 = new RepairStats("keyspace1", "table3", 0.0, 0);
+        when(myRepairStatsProvider.getRepairStats(myTableReferenceFactory.forTable("keyspace1", "table3"), since,
+                to)).thenReturn(repairStats3);
+        RepairStats repairStats4 = new RepairStats("keyspace2", "table4", 0.0, 0);
+        when(myRepairStatsProvider.getRepairStats(myTableReferenceFactory.forTable("keyspace2", "table4"), since,
+                to)).thenReturn(repairStats4);
+        RepairStats repairStats5 = new RepairStats("keyspace3", "table5", 0.0, 0);
+        when(myRepairStatsProvider.getRepairStats(myTableReferenceFactory.forTable("keyspace3", "table5"), since,
+                to)).thenReturn(repairStats5);
+        when(myReplicatedTableProvider.accept("keyspace1")).thenReturn(true);
+        when(myReplicatedTableProvider.accept("keyspace2")).thenReturn(true);
+        when(myReplicatedTableProvider.accept("keyspace3")).thenReturn(true);
+        List<RepairStats> repairStats = new ArrayList<>();
+        repairStats.add(repairStats1);
+        repairStats.add(repairStats2);
+        repairStats.add(repairStats3);
+        repairStats.add(repairStats4);
+        repairStats.add(repairStats5);
+        RepairInfo expectedResponse = new RepairInfo(since, to, repairStats);
+        ResponseEntity<RepairInfo> response = repairManagementREST.getRepairInfo(null, null, since, duration);
+
+        RepairInfo returnedRepairInfo = response.getBody();
+        assertThat(returnedRepairInfo).isEqualTo(expectedResponse);
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    }
+
+    @Test
+    public void testGetRepairInfoOnlySince()
+    {
+        long since = 1245L;
+        RepairStats repairStats1 = new RepairStats("keyspace1", "table1", 0.0, 0);
+        when(myRepairStatsProvider.getRepairStats(eq(myTableReferenceFactory.forTable("keyspace1", "table1")), eq(since),
+                any(long.class))).thenReturn(repairStats1);
+        RepairStats repairStats2 = new RepairStats("keyspace1", "table2", 0.0, 0);
+        when(myRepairStatsProvider.getRepairStats(eq(myTableReferenceFactory.forTable("keyspace1", "table2")), eq(since),
+                any(long.class))).thenReturn(repairStats2);
+        RepairStats repairStats3 = new RepairStats("keyspace1", "table3", 0.0, 0);
+        when(myRepairStatsProvider.getRepairStats(eq(myTableReferenceFactory.forTable("keyspace1", "table3")), eq(since),
+                any(long.class))).thenReturn(repairStats3);
+        RepairStats repairStats4 = new RepairStats("keyspace2", "table4", 0.0, 0);
+        when(myRepairStatsProvider.getRepairStats(eq(myTableReferenceFactory.forTable("keyspace2", "table4")), eq(since),
+                any(long.class))).thenReturn(repairStats4);
+        RepairStats repairStats5 = new RepairStats("keyspace3", "table5", 0.0, 0);
+        when(myRepairStatsProvider.getRepairStats(eq(myTableReferenceFactory.forTable("keyspace3", "table5")), eq(since),
+                any(long.class))).thenReturn(repairStats5);
+        when(myReplicatedTableProvider.accept("keyspace1")).thenReturn(true);
+        when(myReplicatedTableProvider.accept("keyspace2")).thenReturn(true);
+        when(myReplicatedTableProvider.accept("keyspace3")).thenReturn(true);
+        List<RepairStats> repairStats = new ArrayList<>();
+        repairStats.add(repairStats1);
+        repairStats.add(repairStats2);
+        repairStats.add(repairStats3);
+        repairStats.add(repairStats4);
+        repairStats.add(repairStats5);
+        RepairInfo expectedResponse = new RepairInfo(since, 0L, repairStats);
+        ResponseEntity<RepairInfo> response = repairManagementREST.getRepairInfo(null, null, since, null);
+
+        RepairInfo returnedRepairInfo = response.getBody();
+        assertThat(returnedRepairInfo.repairStats).containsExactlyInAnyOrderElementsOf(expectedResponse.repairStats);
+        assertThat(returnedRepairInfo.sinceInMs).isEqualTo(expectedResponse.sinceInMs);
+        assertThat(returnedRepairInfo.toInMs).isGreaterThan(since);
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    }
+
+    @Test
+    public void testGetRepairInfoOnlyDuration()
+    {
+        long durationInMs = 1000L;
+        Duration duration = Duration.ofMillis(durationInMs);
+        RepairStats repairStats1 = new RepairStats("keyspace1", "table1", 0.0, 0);
+        when(myRepairStatsProvider.getRepairStats(eq(myTableReferenceFactory.forTable("keyspace1", "table1")), any(long.class),
+                any(long.class))).thenReturn(repairStats1);
+        RepairStats repairStats2 = new RepairStats("keyspace1", "table2", 0.0, 0);
+        when(myRepairStatsProvider.getRepairStats(eq(myTableReferenceFactory.forTable("keyspace1", "table2")), any(long.class),
+                any(long.class))).thenReturn(repairStats2);
+        RepairStats repairStats3 = new RepairStats("keyspace1", "table3", 0.0, 0);
+        when(myRepairStatsProvider.getRepairStats(eq(myTableReferenceFactory.forTable("keyspace1", "table3")), any(long.class),
+                any(long.class))).thenReturn(repairStats3);
+        RepairStats repairStats4 = new RepairStats("keyspace2", "table4", 0.0, 0);
+        when(myRepairStatsProvider.getRepairStats(eq(myTableReferenceFactory.forTable("keyspace2", "table4")), any(long.class),
+                any(long.class))).thenReturn(repairStats4);
+        RepairStats repairStats5 = new RepairStats("keyspace3", "table5", 0.0, 0);
+        when(myRepairStatsProvider.getRepairStats(eq(myTableReferenceFactory.forTable("keyspace3", "table5")), any(long.class),
+                any(long.class))).thenReturn(repairStats5);
+        when(myReplicatedTableProvider.accept("keyspace1")).thenReturn(true);
+        when(myReplicatedTableProvider.accept("keyspace2")).thenReturn(true);
+        when(myReplicatedTableProvider.accept("keyspace3")).thenReturn(true);
+        List<RepairStats> repairStats = new ArrayList<>();
+        repairStats.add(repairStats1);
+        repairStats.add(repairStats2);
+        repairStats.add(repairStats3);
+        repairStats.add(repairStats4);
+        repairStats.add(repairStats5);
+        ResponseEntity<RepairInfo> response = repairManagementREST.getRepairInfo(null, null, null, duration);
+
+        RepairInfo returnedRepairInfo = response.getBody();
+        assertThat(returnedRepairInfo.repairStats).containsExactlyInAnyOrderElementsOf(repairStats);
+        assertThat(returnedRepairInfo.sinceInMs).isEqualTo(returnedRepairInfo.toInMs - durationInMs);
+        assertThat(returnedRepairInfo.toInMs).isEqualTo(returnedRepairInfo.sinceInMs + durationInMs);
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    }
+
+    @Test
+    public void testGetRepairInfoOnlyKeyspace()
+    {
+        long since = 1245L;
+        long durationInMs = 1000L;
+        Duration duration = Duration.ofMillis(durationInMs);
+        long to = since + durationInMs;
+        RepairStats repairStats1 = new RepairStats("keyspace1", "table1", 0.0, 0);
+        when(myRepairStatsProvider.getRepairStats(myTableReferenceFactory.forTable("keyspace1", "table1"), since,
+                to)).thenReturn(repairStats1);
+        RepairStats repairStats2 = new RepairStats("keyspace1", "table2", 0.0, 0);
+        when(myRepairStatsProvider.getRepairStats(myTableReferenceFactory.forTable("keyspace1", "table2"), since,
+                to)).thenReturn(repairStats2);
+        RepairStats repairStats3 = new RepairStats("keyspace1", "table3", 0.0, 0);
+        when(myRepairStatsProvider.getRepairStats(myTableReferenceFactory.forTable("keyspace1", "table3"), since,
+                to)).thenReturn(repairStats3);
+        when(myReplicatedTableProvider.accept("keyspace1")).thenReturn(true);
+        List<RepairStats> repairStats = new ArrayList<>();
+        repairStats.add(repairStats1);
+        repairStats.add(repairStats2);
+        repairStats.add(repairStats3);
+        RepairInfo expectedResponse = new RepairInfo(since, to, repairStats);
+        ResponseEntity<RepairInfo> response = repairManagementREST.getRepairInfo("keyspace1", null, since, duration);
+
+        RepairInfo returnedRepairInfo = response.getBody();
+        assertThat(returnedRepairInfo).isEqualTo(expectedResponse);
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    }
+
+    @Test
+    public void testGetRepairInfoKeyspaceAndTable()
+    {
+        long since = 1245L;
+        long durationInMs = 1000L;
+        Duration duration = Duration.ofMillis(durationInMs);
+        long to = since + durationInMs;
+        RepairStats repairStats1 = new RepairStats("keyspace1", "table1", 0.0, 0);
+        when(myRepairStatsProvider.getRepairStats(myTableReferenceFactory.forTable("keyspace1", "table1"), since,
+                to)).thenReturn(repairStats1);
+        when(myReplicatedTableProvider.accept("keyspace1")).thenReturn(true);
+        List<RepairStats> repairStats = new ArrayList<>();
+        repairStats.add(repairStats1);
+        RepairInfo expectedResponse = new RepairInfo(since, to, repairStats);
+        ResponseEntity<RepairInfo> response = repairManagementREST.getRepairInfo("keyspace1", "table1", since, duration);
+
+        RepairInfo returnedRepairInfo = response.getBody();
+        assertThat(returnedRepairInfo).isEqualTo(expectedResponse);
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    }
+
+    @Test
+    public void testGetRepairInfoOnlyTable()
+    {
+        long since = 1245L;
+        long durationInMs = 1000L;
+        Duration duration = Duration.ofMillis(durationInMs);
+        ResponseEntity<RepairInfo> response = null;
+        try
+        {
+            response = repairManagementREST.getRepairInfo(null, "table1", since, duration);
+        }
+        catch(ResponseStatusException e)
+        {
+            assertThat(e.getRawStatusCode()).isEqualTo(BAD_REQUEST.value());
+        }
+        assertThat(response).isNull();
+    }
+
+    @Test
+    public void testGetRepairInfoNoSinceOrDuration()
+    {
+        ResponseEntity<RepairInfo> response = null;
+        try
+        {
+            response = repairManagementREST.getRepairInfo("keyspace1", "table1", null, null);
+        }
+        catch(ResponseStatusException e)
+        {
+            assertThat(e.getRawStatusCode()).isEqualTo(BAD_REQUEST.value());
+        }
+        assertThat(response).isNull();
+    }
+
+    @Test
+    public void testGetRepairInfoSinceBiggerThanSincePlusDuration()
+    {
+        ResponseEntity<RepairInfo> response = null;
+        try
+        {
+            response = repairManagementREST.getRepairInfo("keyspace1", "table1", 0L, Duration.ofMillis(-1000));
+        }
+        catch(ResponseStatusException e)
+        {
+            assertThat(e.getRawStatusCode()).isEqualTo(BAD_REQUEST.value());
+        }
+        assertThat(response).isNull();
     }
 }


### PR DESCRIPTION
Closes #327

Some examples:

Duration:
```
ecctool-node1 repair-info --duration 30s
Time window between '2022-08-29 08:13:52' and '2022-08-29 08:14:22'
--------------------------------------------------------------------------
| Keyspace  | Table                   | Repaired (%) | Repair time taken | 
--------------------------------------------------------------------------
| ecchronos | lock                    | 0.00         | -                 | 
| ecchronos | lock_priority           | 100.00       | < 1 second        | 
| ecchronos | on_demand_repair_status | 100.00       | < 1 second        | 
| ecchronos | reject_configuration    | 100.00       | < 1 second        | 
| ecchronos | repair_history          | 100.00       | 1 second          | 
| test2     | table2                  | 0.00         | -                 | 
| test2     | table22                 | 0.00         | -                 | 
| test3     | table3                  | 0.00         | -                 | 
| test3     | table33                 | 0.00         | -                 | 
--------------------------------------------------------------------------
```

Since
```
ecctool-node1 repair-info --since 2022-08-29T08:12:00.0+02:00
Time window between '2022-08-29 08:12:00' and '2022-08-29 08:13:53'
--------------------------------------------------------------------------
| Keyspace  | Table                   | Repaired (%) | Repair time taken | 
--------------------------------------------------------------------------
| ecchronos | lock                    | 100.00       | < 1 second        | 
| ecchronos | lock_priority           | 67.92        | < 1 second        | 
| ecchronos | on_demand_repair_status | 0.00         | -                 | 
| ecchronos | reject_configuration    | 0.00         | -                 | 
| ecchronos | repair_history          | 100.00       | 1 second          | 
| test2     | table2                  | 100.00       | < 1 second        | 
| test2     | table22                 | 100.00       | < 1 second        | 
| test3     | table3                  | 100.00       | < 1 second        | 
| test3     | table33                 | 100.00       | < 1 second        | 
--------------------------------------------------------------------------
```

Since&duration
```
ecctool-node1 repair-info --since 2022-08-29T08:12:00.0+02:00 --duration 1m
Time window between '2022-08-29 08:12:00' and '2022-08-29 08:13:00'
--------------------------------------------------------------------------
| Keyspace  | Table                   | Repaired (%) | Repair time taken | 
--------------------------------------------------------------------------
| ecchronos | lock                    | 0.00         | -                 | 
| ecchronos | lock_priority           | 0.00         | -                 | 
| ecchronos | on_demand_repair_status | 0.00         | -                 | 
| ecchronos | reject_configuration    | 0.00         | -                 | 
| ecchronos | repair_history          | 100.00       | 1 second          | 
| test2     | table2                  | 0.00         | -                 | 
| test2     | table22                 | 0.00         | -                 | 
| test3     | table3                  | 0.00         | -                 | 
| test3     | table33                 | 0.00         | -                 | 
--------------------------------------------------------------------------
```