### PR TITLE
Exclude virtual keyspaces from tokenmap

### DIFF
--- a/connection.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/connection/impl/LocalNativeConnectionProvider.java
+++ b/connection.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/connection/impl/LocalNativeConnectionProvider.java
@@ -41,7 +41,7 @@ import java.util.UUID;
 public class LocalNativeConnectionProvider implements NativeConnectionProvider
 {
     private static final List<String> SCHEMA_REFRESHED_KEYSPACES = ImmutableList.of("/.*/", "!system",
-            "!system_distributed", "!system_schema", "!system_traces");
+            "!system_distributed", "!system_schema", "!system_traces", "!system_views", "!system_virtual_schema");
     private static final Logger LOG = LoggerFactory.getLogger(LocalNativeConnectionProvider.class);
     private static final List<String> NODE_METRICS = Arrays.asList(DefaultNodeMetric.OPEN_CONNECTIONS.getPath(),
             DefaultNodeMetric.AVAILABLE_STREAMS.getPath(), DefaultNodeMetric.IN_FLIGHT.getPath(),


### PR DESCRIPTION
system_views and system_virtual_schema are virtual keyspaces and does
not need to be repaired, therefore there's no point in having them in
the token map.