### PR TITLE
Update SETUP.md to close #456

### DIFF
--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -56,6 +56,20 @@ CREATE TABLE IF NOT EXISTS ecchronos.on_demand_repair_status (
     PRIMARY KEY(host_id, job_id))
     WITH default_time_to_live = 2592000
     AND gc_grace_seconds = 0;
+    
+    CREATE TABLE IF NOT EXISTS ecchronos.repair_history(
+    table_id uuid, 
+	node_id uuid, 
+	repair_id timeuuid, 
+	job_id uuid, 
+	coordinator_id uuid, 
+	range_begin text, 
+	range_end text, 
+	participants set<uuid>, 
+	status text, 
+	started_at timestamp, 
+	finished_at timestamp, 
+	PRIMARY KEY((table_id,node_id), repair_id)) WITH compaction = {'class': 'TimeWindowCompactionStrategy'} AND default_time_to_live = 2592000 AND CLUSTERING ORDER BY (repair_id DESC);
 ```
 
 A sample file is located in `conf/create_keyspace_sample.cql` which can be executed by running `cqlsh -f conf/create_keyspace_sample.cql`.


### PR DESCRIPTION
ecChronos process failed to initialize ecc post installation in VM (Cassandra 4.0.7 in Ubuntu) due to unavailability of the table ecchronos.repair_history. Creation of this table is required as prerequisite and this will close the issue  #456