### PR TITLE
Pin python cassandra-driver to 3.26.0 for tests

### DIFF
--- a/ecchronos-binary/src/test/bin/codestyle.sh
+++ b/ecchronos-binary/src/test/bin/codestyle.sh
@@ -34,7 +34,7 @@ echo "Installing behave dependencies"
 pip install behave
 pip install requests
 pip install jsonschema
-pip install cassandra-driver
+pip install cassandra-driver==3.26.0
 
 for directory in "$@"
 do

--- a/ecchronos-binary/src/test/bin/pytests.sh
+++ b/ecchronos-binary/src/test/bin/pytests.sh
@@ -30,7 +30,7 @@ echo "Installing behave"
 pip install behave
 pip install requests
 pip install jsonschema
-pip install cassandra-driver
+pip install cassandra-driver==3.26.0
 
 BASE_DIR="$TEST_DIR"/ecchronos-binary-${project.version}
 CONF_DIR="$BASE_DIR"/conf


### PR DESCRIPTION
The latest python cassandra-driver(3.27.0) is broken atm.