### PR TITLE
Bump java driver from 4.14.1 to 4.17.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Version 5.0.0
 
+* Bump java driver from 4.14.1 to 4.17.0
 * Bump guava from 31.1 to 32.0.1 (CVE-2023-2976)
 * Fix shebang in ecctool - Issue #504
 * Bump springboot from 2.7.5 to 2.7.12 - Issue #500

--- a/karaf-feature/pom.xml
+++ b/karaf-feature/pom.xml
@@ -75,6 +75,11 @@
 
         <dependency>
             <groupId>io.netty</groupId>
+            <artifactId>netty-transport-native-unix-common</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.netty</groupId>
             <artifactId>netty-resolver</artifactId>
         </dependency>
 

--- a/karaf-feature/src/main/feature/feature.xml
+++ b/karaf-feature/src/main/feature/feature.xml
@@ -9,6 +9,7 @@
         <bundle>mvn:com.ericsson.bss.cassandra.ecchronos/core.osgi/${project.version}</bundle>
         <bundle>mvn:io.netty/netty-common/${io.netty.version}</bundle>
         <bundle>mvn:io.netty/netty-transport/${io.netty.version}</bundle>
+        <bundle>mvn:io.netty/netty-transport-native-unix-common/${io.netty.version}</bundle>
         <bundle>mvn:io.netty/netty-buffer/${io.netty.version}</bundle>
         <bundle>mvn:io.netty/netty-handler/${io.netty.version}</bundle>
         <bundle>mvn:io.netty/netty-codec/${io.netty.version}</bundle>

--- a/pom.xml
+++ b/pom.xml
@@ -58,10 +58,10 @@
         <bundle.namespace>${project.groupId}.${project.artifactId}</bundle.namespace>
 
         <!-- Dependency versions -->
-        <io.netty.version>4.1.69.Final</io.netty.version>
+        <io.netty.version>4.1.94.Final</io.netty.version>
         <io.micrometer.version>1.9.2</io.micrometer.version>
         <io.dropwizard.metrics.version>4.2.10</io.dropwizard.metrics.version>
-        <cassandra.driver.core.version>4.14.1</cassandra.driver.core.version>
+        <cassandra.driver.core.version>4.17.0</cassandra.driver.core.version>
         <guava.version>32.0.1-jre</guava.version>
         <failureaccess.version>1.0.1</failureaccess.version>
         <cassandra.driver.protocol.version>1.5.0</cassandra.driver.protocol.version>
@@ -146,6 +146,12 @@
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-transport</artifactId>
+                <version>${io.netty.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-transport-native-unix-common</artifactId>
                 <version>${io.netty.version}</version>
             </dependency>
 


### PR DESCRIPTION
Netty was stepped as well to make sure we follow the same version as driver.