### PR TITLE
Add missing test annotation for TableRepairJob

### DIFF
--- a/core/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/repair/TestTableRepairJob.java
+++ b/core/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/repair/TestTableRepairJob.java
@@ -727,6 +727,7 @@ public class TestTableRepairJob
         }
     }
 
+    @Test
     public void testGetRealPriority()
     {
         long lastRepaired = System.currentTimeMillis();


### PR DESCRIPTION
The annotation was mistakenly removed in a merge commit 9c21d90456115e73ac59cb672e535103619ee099