### PR TITLE
Step maven-project-info-reports-plugin to 3.4.5

### DIFF
--- a/ecchronos-binary/pom.xml
+++ b/ecchronos-binary/pom.xml
@@ -69,7 +69,7 @@
 
             <plugin>
                 <artifactId>maven-project-info-reports-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.4.5</version>
                 <executions>
                     <execution>
                         <id>licenses</id>


### PR DESCRIPTION
The new version only logs a warning once without printing a stacktrace for "bundle" packaging. There's no "real" fix atm.