### PR TITLE
 Progress for on demand repair jobs is either 0% or 100% #593 

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Version 5.0.0 (Not yet released)
 
+* Progress for on demand repair jobs is either 0% or 100% - Issue #593
 * Make priority granularity configurable - Issue #599
 * Bump springboot from 2.7.12 to 2.7.17 - Issue #604
 * Bump io.micrometer from 1.9.2 to 1.9.16 - Issue #604


### PR DESCRIPTION
 * Calculates the progress of the ongoing repair job.
 * The progress is determined based on the number of repaired tokens compared to the total number of tokens.
 * If there are no tokens to repair (myTotalTokens is zero), the progress is reported as zero.
 * Once the repair job reaches the 'finished' status, progress is reported as 100% (1.0).
 * Otherwise, the progress is calculated as the ratio of the number of repaired tokens to the total number of tokens.