### PR TITLE
Bump logback from 1.2.10 to 1.2.13 (CVE-2023-6378)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Version 5.0.0 (Not yet released)
 
+* Bump logback from 1.2.10 to 1.2.13 (CVE-2023-6378) - Issue #622
 * Progress for on demand repair jobs is either 0% or 100% - Issue #593
 * Make priority granularity configurable - Issue #599
 * Bump springboot from 2.7.12 to 2.7.17 - Issue #604

--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
         <com.typesafe.config.version>1.4.2</com.typesafe.config.version>
         <org.hdrhistogram.version>2.1.12</org.hdrhistogram.version>
         <slf4j.version>1.7.30</slf4j.version>
-        <logback.version>1.2.10</logback.version>
+        <logback.version>1.2.13</logback.version>
         <cassandra.version>4.0.10</cassandra.version>
         <osgi.version>1.3.0</osgi.version>
         <mockito.core.version>3.3.3</mockito.core.version>


### PR DESCRIPTION
Closes #622 