### PR TITLE
Build Ecchronos with Java 11 - Issue #616

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Version 5.0.0 (Not yet released)
 
+* Build Ecchronos with Java 11 - Issue 616
 * Bump logback from 1.2.10 to 1.2.13 (CVE-2023-6378) - Issue #622
 * Progress for on demand repair jobs is either 0% or 100% - Issue #593
 * Make priority granularity configurable - Issue #599

--- a/connection/pom.xml
+++ b/connection/pom.xml
@@ -76,8 +76,8 @@
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>11</source>
+                    <target>11</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/ecchronos-binary/pom.xml
+++ b/ecchronos-binary/pom.xml
@@ -62,6 +62,7 @@
                             </descriptors>
                             <skipAssembly>false</skipAssembly>
                             <appendAssemblyId>false</appendAssemblyId>
+                            <tarLongFileMode>posix</tarLongFileMode>
                         </configuration>
                     </execution>
                 </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,7 @@
         <org.apache.maven.plugins.maven-install-plugin.version>2.5.2</org.apache.maven.plugins.maven-install-plugin.version>
         <org.apache.maven.plugins.maven-surefire-plugin.version>2.22.1</org.apache.maven.plugins.maven-surefire-plugin.version>
         <org.apache.maven.plugins.maven-failsafe-plugin.version>2.22.1</org.apache.maven.plugins.maven-failsafe-plugin.version>
-        <org.apache.maven.plugins.maven-assembly-plugin.version>3.1.0</org.apache.maven.plugins.maven-assembly-plugin.version>
+        <org.apache.maven.plugins.maven-assembly-plugin.version>3.6.0</org.apache.maven.plugins.maven-assembly-plugin.version>
         <org.apache.maven.plugins-maven-checkstyle-plugin.version>3.2.0</org.apache.maven.plugins-maven-checkstyle-plugin.version>
         <org.apache.maven.plugins-maven-pmd-plugin.version>3.14.0</org.apache.maven.plugins-maven-pmd-plugin.version>
         <org.apache.maven.plugin.maven-jxr-plugin.version>3.0.0</org.apache.maven.plugin.maven-jxr-plugin.version>


### PR DESCRIPTION
In order to provide support for Java 11 in EcChronos, identify the minimal changes necessary for the project to compile and run with Java 11. Additionally, implement these changes and any necessary updates to Maven packages.

Closes #616