### PR TITLE
Improve hang preventing task #544

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Changes
 
+## Version 5.0.1 (Not yet released)
+
+* Improve hang preventing task - Issue #544
+
 ## Version 5.0.0 (Not yet released)
 
 * Make priority granularity configurable - Issue #599

--- a/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/JmxProxy.java
+++ b/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/JmxProxy.java
@@ -109,5 +109,12 @@ public interface JmxProxy extends Closeable
      */
     double getPercentRepaired(TableReference tableReference);
 
-    String getNodeStatus() ;
+    /**
+     * Retrieves the current operational status of the local Cassandra node via JMX.
+     * Returns a string indicating the node's state (e.g., "NORMAL", "JOINING", "LEAVING", "MOVING")
+     * or "Unknown" if the status is undeterminable.
+     *
+     * @return A string representing the node's status.
+     */
+    String getNodeStatus();
 }

--- a/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/JmxProxy.java
+++ b/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/JmxProxy.java
@@ -108,4 +108,6 @@ public interface JmxProxy extends Closeable
      * @return The repaired ratio or 0 if it cannot be determined.
      */
     double getPercentRepaired(TableReference tableReference);
+
+    String getNodeStatus() ;
 }

--- a/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/JmxProxyFactoryImpl.java
+++ b/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/JmxProxyFactoryImpl.java
@@ -308,6 +308,20 @@ public class JmxProxyFactoryImpl implements JmxProxyFactory
             }
             return 0.0;
         }
+
+        @Override
+        public String getNodeStatus()
+        {
+            try
+            {
+                return (String) myMbeanServerConnection.getAttribute(myStorageServiceObject, "OperationMode");
+            }
+            catch (Exception e)
+            {
+                LOG.error("Unable to retrieve node status {}", e.getMessage());
+                return "Unknown";
+            }
+        }
     }
 
     public static Builder builder()

--- a/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/repair/RepairTask.java
+++ b/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/repair/RepairTask.java
@@ -46,6 +46,7 @@ public abstract class RepairTask implements NotificationListener
 {
     private static final Logger LOG = LoggerFactory.getLogger(RepairTask.class);
     private static final Pattern RANGE_PATTERN = Pattern.compile("\\((-?[0-9]+),(-?[0-9]+)\\]");
+    private static final int HEALTH_CHECK_INTERVAL = 10;
     private final ScheduledExecutorService myExecutor = Executors.newSingleThreadScheduledExecutor(
             new ThreadFactoryBuilder().setNameFormat("HangPreventingTask-%d").build());
     private final CountDownLatch myLatch = new CountDownLatch(1);
@@ -259,7 +260,7 @@ public abstract class RepairTask implements NotificationListener
             myHangPreventFuture.cancel(false);
         }
         // Schedule the first check to happen after 10 minutes
-        myHangPreventFuture = myExecutor.schedule(new HangPreventingTask(), 10,
+        myHangPreventFuture = myExecutor.schedule(new HangPreventingTask(), HEALTH_CHECK_INTERVAL,
                 TimeUnit.MINUTES);
     }
 
@@ -386,7 +387,7 @@ public abstract class RepairTask implements NotificationListener
                     else
                     {
                         checkCount++;
-                        myHangPreventFuture = myExecutor.schedule(this, 10, TimeUnit.MINUTES);
+                        myHangPreventFuture = myExecutor.schedule(this, HEALTH_CHECK_INTERVAL, TimeUnit.MINUTES);
                     }
                 }
                 else

--- a/core/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/repair/TestRepairGroupTasks.java
+++ b/core/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/repair/TestRepairGroupTasks.java
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.when;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -254,13 +255,13 @@ public class TestRepairGroupTasks
         @Override
         public List<String> getLiveNodes()
         {
-            throw new UnsupportedOperationException();
+            return Collections.emptyList();
         }
 
         @Override
         public List<String> getUnreachableNodes()
         {
-            throw new UnsupportedOperationException();
+            return Collections.emptyList();
         }
 
         @Override
@@ -286,7 +287,7 @@ public class TestRepairGroupTasks
         @Override
         public long liveDiskSpaceUsed(TableReference tableReference)
         {
-            throw new UnsupportedOperationException();
+            return 5;
         }
 
         @Override
@@ -299,6 +300,12 @@ public class TestRepairGroupTasks
         public double getPercentRepaired(TableReference tableReference)
         {
             throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public String getNodeStatus()
+        {
+            return "NORMAL";
         }
 
         @Override

--- a/core/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/repair/TestUtils.java
+++ b/core/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/repair/TestUtils.java
@@ -327,6 +327,12 @@ public class TestUtils
             throw new UnsupportedOperationException();
         }
 
+        @Override
+        public String getNodeStatus()
+        {
+            return "NORMAL";
+        }
+
         public void notify(Notification notification)
         {
             myListener.handleNotification(notification, null);

--- a/core/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/repair/TestVnodeRepairTask.java
+++ b/core/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/repair/TestVnodeRepairTask.java
@@ -21,14 +21,11 @@ import static com.ericsson.bss.cassandra.ecchronos.core.repair.TestUtils.getRepa
 import static com.ericsson.bss.cassandra.ecchronos.core.repair.TestUtils.startRepair;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.ignoreStubs;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
@@ -47,11 +44,8 @@ import java.util.stream.Collectors;
 import javax.management.Notification;
 import javax.management.remote.JMXConnectionNotification;
 
-import com.ericsson.bss.cassandra.ecchronos.core.JmxProxy;
-import com.ericsson.bss.cassandra.ecchronos.core.exceptions.ScheduledJobException;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -81,9 +75,6 @@ public class TestVnodeRepairTask
 
     @Mock
     private RepairHistory repairHistory;
-
-    @Mock
-    private JmxProxy myJmxProxy;
 
     private RepairConfiguration myRepairConfiguration = RepairConfiguration.DEFAULT;
 
@@ -115,30 +106,6 @@ public class TestVnodeRepairTask
     public void finalVerification()
     {
         verifyNoMoreInteractions(ignoreStubs(myTableRepairMetrics));
-    }
-
-
-    @Test
-    public void testWhenLocalNodeIsDown() throws Exception
-    {
-        when(jmxProxyFactory.connect()).thenReturn(myJmxProxy);
-        when(myJmxProxy.getNodeStatus()).thenReturn("DOWN");
-        Set<LongTokenRange> ranges = new HashSet<>();
-        LongTokenRange range1 = new LongTokenRange(1, 2);
-        LongTokenRange range2 = new LongTokenRange(3, 4);
-
-        ranges.add(range1);
-        ranges.add(range2);
-
-        RepairTask repairTask = new VnodeRepairTask(jmxProxyFactory, myTableReference, myRepairConfiguration,
-                myTableRepairMetrics, repairHistory, ranges, participants, jobId);
-
-        Exception exception = assertThrows(ScheduledJobException.class, repairTask::execute);
-        String expectedMessage = "Unable to repair 'Vnode repairTask of keyspace.table (mock)";
-        String actualMessage = exception.getMessage();
-        assertTrue(actualMessage.contains(expectedMessage));
-
-        verify(myTableRepairMetrics).repairSession(eq(myTableReference), anyLong(), any(TimeUnit.class), eq(false));
     }
 
     @Test

--- a/core/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/repair/TestVnodeRepairTask.java
+++ b/core/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/repair/TestVnodeRepairTask.java
@@ -21,11 +21,14 @@ import static com.ericsson.bss.cassandra.ecchronos.core.repair.TestUtils.getRepa
 import static com.ericsson.bss.cassandra.ecchronos.core.repair.TestUtils.startRepair;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.ignoreStubs;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
@@ -44,8 +47,11 @@ import java.util.stream.Collectors;
 import javax.management.Notification;
 import javax.management.remote.JMXConnectionNotification;
 
+import com.ericsson.bss.cassandra.ecchronos.core.JmxProxy;
+import com.ericsson.bss.cassandra.ecchronos.core.exceptions.ScheduledJobException;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -75,6 +81,9 @@ public class TestVnodeRepairTask
 
     @Mock
     private RepairHistory repairHistory;
+
+    @Mock
+    private JmxProxy myJmxProxy;
 
     private RepairConfiguration myRepairConfiguration = RepairConfiguration.DEFAULT;
 
@@ -106,6 +115,30 @@ public class TestVnodeRepairTask
     public void finalVerification()
     {
         verifyNoMoreInteractions(ignoreStubs(myTableRepairMetrics));
+    }
+
+
+    @Test
+    public void testWhenLocalNodeIsDown() throws Exception
+    {
+        when(jmxProxyFactory.connect()).thenReturn(myJmxProxy);
+        when(myJmxProxy.getNodeStatus()).thenReturn("DOWN");
+        Set<LongTokenRange> ranges = new HashSet<>();
+        LongTokenRange range1 = new LongTokenRange(1, 2);
+        LongTokenRange range2 = new LongTokenRange(3, 4);
+
+        ranges.add(range1);
+        ranges.add(range2);
+
+        RepairTask repairTask = new VnodeRepairTask(jmxProxyFactory, myTableReference, myRepairConfiguration,
+                myTableRepairMetrics, repairHistory, ranges, participants, jobId);
+
+        Exception exception = assertThrows(ScheduledJobException.class, repairTask::execute);
+        String expectedMessage = "Unable to repair 'Vnode repairTask of keyspace.table (mock)";
+        String actualMessage = exception.getMessage();
+        assertTrue(actualMessage.contains(expectedMessage));
+
+        verify(myTableRepairMetrics).repairSession(eq(myTableReference), anyLong(), any(TimeUnit.class), eq(false));
     }
 
     @Test


### PR DESCRIPTION
ecChronos makes use of hang preventing task to make sure no repair tasks are hanging. The task is scheduled to run 30 minutes after the last response on the JMX, effectively failing the repair task.

30 minutes is a bit long time, investigate if we can make some improvements to it.

    Detect that local Cassandra is down and fail the task early
    Make the hang preventing task dynamic? 30 minutes is a lot of time.