### PR TITLE
Update versions of github/actions in workflow

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -32,16 +32,16 @@ jobs:
          - name: "Standalone integration 3.11"
            test_suite: 'verify -P docker-integration-test,standalone-integration-tests -Dit.cassandra.version=3.11 -DskipUTs'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Cache local Maven repository
-        uses: actions/cache@v3
+        uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2 # v4.0.0
         with:
           path: ~/.m2/repository
           key: build-${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             build-${{ runner.os }}-maven-
       - name: Set up JDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@387ac29b308b003ca37ba93a6cab5eb57c8f5f93 # v4.0.0
         with:
           java-version: '8'
           distribution: 'temurin'
@@ -51,7 +51,7 @@ jobs:
         env:
           TEST_SUITE: ${{ matrix.test_suite }}
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@e0b68c6749509c5f83f984dd99a76a1c1a231044 # v4.0.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: >


### PR DESCRIPTION
We need to update all github/actions to versions that support Node 20 since Node 16 is deprecated, for more info see https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/