### PR TITLE
Issue 397 Metric reporter to log debug messages if configured number …

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,12 @@
 # Changes
+## Version 5.0.5
+
+* Metric status logger for troubleshooting - Issue #397
+
+## Version 5.0.4
+
+* ecChronos will break if repair interval is shorter than the initial delay - Issue #667
+
 ## Version 5.0.3
 
 * Possibility for repairs to never be triggered - Issue #264

--- a/application/src/main/java/com/ericsson/bss/cassandra/ecchronos/application/ECChronosInternals.java
+++ b/application/src/main/java/com/ericsson/bss/cassandra/ecchronos/application/ECChronosInternals.java
@@ -113,8 +113,8 @@ public class ECChronosInternals implements Closeable
                     .build();
 
             myMetricInspector = new MetricInspector(meterRegistry,
-                    configuration.getStatisticsConfig().getRepairFailureCountForReporting(),
-                    configuration.getStatisticsConfig().getTimeWindowSizeinMinsForReporting());
+                    configuration.getStatisticsConfig().getRepairFailuresCount(),
+                    configuration.getStatisticsConfig().getRepairFailuresTimeWindowInMinutes());
             myMetricInspector.startInspection();
         }
         else

--- a/application/src/main/java/com/ericsson/bss/cassandra/ecchronos/application/ECChronosInternals.java
+++ b/application/src/main/java/com/ericsson/bss/cassandra/ecchronos/application/ECChronosInternals.java
@@ -114,8 +114,10 @@ public class ECChronosInternals implements Closeable
 
             myMetricInspector = new MetricInspector(meterRegistry,
                     configuration.getStatisticsConfig().getRepairFailuresCount(),
-                    configuration.getStatisticsConfig().getRepairFailuresTimeWindowInMinutes(),
-                    configuration.getStatisticsConfig().getTriggerIntervalForMetricInspectionInMillSeconds());
+                    configuration.getStatisticsConfig().getRepairFailuresTimeWindow()
+                            .getInterval(TimeUnit.MINUTES),
+                    configuration.getStatisticsConfig().getTriggerIntervalForMetricInspection()
+                            .getInterval(TimeUnit.MILLISECONDS));
             myMetricInspector.startInspection();
         }
         else

--- a/application/src/main/java/com/ericsson/bss/cassandra/ecchronos/application/ECChronosInternals.java
+++ b/application/src/main/java/com/ericsson/bss/cassandra/ecchronos/application/ECChronosInternals.java
@@ -114,7 +114,8 @@ public class ECChronosInternals implements Closeable
 
             myMetricInspector = new MetricInspector(meterRegistry,
                     configuration.getStatisticsConfig().getRepairFailuresCount(),
-                    configuration.getStatisticsConfig().getRepairFailuresTimeWindowInMinutes());
+                    configuration.getStatisticsConfig().getRepairFailuresTimeWindowInMinutes(),
+                    configuration.getStatisticsConfig().getTriggerIntervalForMetricInspectionInMillSeconds());
             myMetricInspector.startInspection();
         }
         else

--- a/application/src/main/java/com/ericsson/bss/cassandra/ecchronos/application/ECChronosInternals.java
+++ b/application/src/main/java/com/ericsson/bss/cassandra/ecchronos/application/ECChronosInternals.java
@@ -113,8 +113,8 @@ public class ECChronosInternals implements Closeable
                     .build();
 
             myMetricInspector = new MetricInspector(meterRegistry,
-                    configuration.getStatisticsConfig().getMyRepairFailureCountForReporting(),
-                    configuration.getStatisticsConfig().getMyTimeWindowSizeinMinsForReporting());
+                    configuration.getStatisticsConfig().getRepairFailureCountForReporting(),
+                    configuration.getStatisticsConfig().getTimeWindowSizeinMinsForReporting());
             myMetricInspector.startInspection();
         }
         else

--- a/application/src/main/java/com/ericsson/bss/cassandra/ecchronos/application/config/Config.java
+++ b/application/src/main/java/com/ericsson/bss/cassandra/ecchronos/application/config/Config.java
@@ -86,6 +86,7 @@ public class Config
         if (statisticsConfig != null)
         {
             myStatisticsConfig = statisticsConfig;
+            myStatisticsConfig.validate();
         }
     }
 

--- a/application/src/main/java/com/ericsson/bss/cassandra/ecchronos/application/config/metrics/StatisticsConfig.java
+++ b/application/src/main/java/com/ericsson/bss/cassandra/ecchronos/application/config/metrics/StatisticsConfig.java
@@ -22,16 +22,16 @@ import java.util.concurrent.TimeUnit;
 
 public class StatisticsConfig
 {
-    private static final int DEFAULT_FAILURE_TIME_WINDOW_IN_MINUTES = 30;
+    private static final int DEFAULT_FAILURES_TIME_WINDOW_IN_MINUTES = 30;
     private static final int DEFAULT_TRIGGER_INTERVAL_FOR_METRIC_INSPECTION_IN_SECONDS = 5;
-    private static final int DEFAULT_REPAIR_FAILURE_COUNT = 5;
+    private static final int DEFAULT_REPAIR_FAILURES_COUNT = 5;
     private boolean myIsEnabled = true;
 
     private File myOutputDirectory = new File("./statistics");
     private ReportingConfigs myReportingConfigs = new ReportingConfigs();
     private String myMetricsPrefix = "";
-    private int myRepairFailuresCount = DEFAULT_REPAIR_FAILURE_COUNT;
-    private Interval myRepairFailuresTimeWindow = new Interval(DEFAULT_FAILURE_TIME_WINDOW_IN_MINUTES,
+    private int myRepairFailuresCount = DEFAULT_REPAIR_FAILURES_COUNT;
+    private Interval myRepairFailuresTimeWindow = new Interval(DEFAULT_FAILURES_TIME_WINDOW_IN_MINUTES,
             TimeUnit.MINUTES);
     private Interval myTriggerIntervalForMetricInspection = new
             Interval(DEFAULT_TRIGGER_INTERVAL_FOR_METRIC_INSPECTION_IN_SECONDS, TimeUnit.SECONDS);

--- a/application/src/main/java/com/ericsson/bss/cassandra/ecchronos/application/config/metrics/StatisticsConfig.java
+++ b/application/src/main/java/com/ericsson/bss/cassandra/ecchronos/application/config/metrics/StatisticsConfig.java
@@ -24,8 +24,8 @@ public class StatisticsConfig
     private File myOutputDirectory = new File("./statistics");
     private ReportingConfigs myReportingConfigs = new ReportingConfigs();
     private String myMetricsPrefix = "";
-    private int myRepairFailureCountForReporting = 0;
-    private int myTimeWindowSizeinMinsForReporting = 0;
+    private int myRepairFailuresCount = 0;
+    private int myRepairFailuresTimeWindowInMinutes = 0;
 
     @JsonProperty("enabled")
     public final boolean isEnabled()
@@ -54,19 +54,17 @@ public class StatisticsConfig
         return myMetricsPrefix;
     }
 
-
     @JsonProperty("repair_failures_count")
-    public final int getRepairFailureCountForReporting()
+    public final int getRepairFailuresCount()
     {
-        return myRepairFailureCountForReporting;
+        return myRepairFailuresCount;
     }
 
     @JsonProperty("repair_failure_time_window")
-    public final int getTimeWindowSizeinMinsForReporting()
+    public final int getRepairFailuresTimeWindowInMinutes()
     {
-        return myTimeWindowSizeinMinsForReporting;
+        return myRepairFailuresTimeWindowInMinutes;
     }
-
 
     @JsonProperty("enabled")
     public final void setEnabled(final boolean enabled)
@@ -93,16 +91,17 @@ public class StatisticsConfig
     }
 
     @JsonProperty("repair_failures_count")
-    public final void setMyRepairFailureCountForReporting(final int repairFailureCount)
+    public final void setRepairFailuresCount(final int repairFailureCount)
     {
-        myRepairFailureCountForReporting =  repairFailureCount;
+        myRepairFailuresCount = repairFailureCount;
     }
 
-    @JsonProperty("repair_failure_time_window")
-    public final void setMyTimeWindowSizeinMinsForReporting(final int repairFailureTimeWindow)
+    @JsonProperty("repair_failures_time_window_in_minutes")
+    public final void setRepairFailuresTimeWindowInMinutes(final int repairFailureTimeWindow)
     {
-        myTimeWindowSizeinMinsForReporting = repairFailureTimeWindow;
+        myRepairFailuresTimeWindowInMinutes = repairFailureTimeWindow;
     }
 }
+
 
 

--- a/application/src/main/java/com/ericsson/bss/cassandra/ecchronos/application/config/metrics/StatisticsConfig.java
+++ b/application/src/main/java/com/ericsson/bss/cassandra/ecchronos/application/config/metrics/StatisticsConfig.java
@@ -24,12 +24,8 @@ public class StatisticsConfig
     private File myOutputDirectory = new File("./statistics");
     private ReportingConfigs myReportingConfigs = new ReportingConfigs();
     private String myMetricsPrefix = "";
-
     private int myRepairFailureCountForReporting = 0;
-
     private int myTimeWindowSizeinMinsForReporting = 0;
-
-
 
     @JsonProperty("enabled")
     public final boolean isEnabled()
@@ -60,13 +56,13 @@ public class StatisticsConfig
 
 
     @JsonProperty("repair_failures_count")
-    public final int getMyRepairFailureCountForReporting()
+    public final int getRepairFailureCountForReporting()
     {
         return myRepairFailureCountForReporting;
     }
 
     @JsonProperty("repair_failure_time_window")
-    public final int getMyTimeWindowSizeinMinsForReporting()
+    public final int getTimeWindowSizeinMinsForReporting()
     {
         return myTimeWindowSizeinMinsForReporting;
     }

--- a/application/src/main/java/com/ericsson/bss/cassandra/ecchronos/application/config/metrics/StatisticsConfig.java
+++ b/application/src/main/java/com/ericsson/bss/cassandra/ecchronos/application/config/metrics/StatisticsConfig.java
@@ -23,9 +23,10 @@ import java.util.concurrent.TimeUnit;
 public class StatisticsConfig
 {
     private static final int DEFAULT_FAILURE_TIME_WINDOW_IN_MINUTES = 30;
-    private static final int DEFAULT_TRIGGER_INTERVAL_FOR_METRIC_INSPECTION = 5;
+    private static final int DEFAULT_TRIGGER_INTERVAL_FOR_METRIC_INSPECTION_IN_SECONDS = 5;
     private static final int DEFAULT_REPAIR_FAILURE_COUNT = 5;
     private boolean myIsEnabled = true;
+
     private File myOutputDirectory = new File("./statistics");
     private ReportingConfigs myReportingConfigs = new ReportingConfigs();
     private String myMetricsPrefix = "";
@@ -33,7 +34,7 @@ public class StatisticsConfig
     private Interval myRepairFailuresTimeWindow = new Interval(DEFAULT_FAILURE_TIME_WINDOW_IN_MINUTES,
             TimeUnit.MINUTES);
     private Interval myTriggerIntervalForMetricInspection = new
-            Interval(DEFAULT_TRIGGER_INTERVAL_FOR_METRIC_INSPECTION, TimeUnit.SECONDS);
+            Interval(DEFAULT_TRIGGER_INTERVAL_FOR_METRIC_INSPECTION_IN_SECONDS, TimeUnit.SECONDS);
 
     @JsonProperty("enabled")
     public final boolean isEnabled()
@@ -65,7 +66,7 @@ public class StatisticsConfig
         return myRepairFailuresCount;
     }
 
-    @JsonProperty("repair_failure_time_window")
+    @JsonProperty("repair_failures_time_window")
     public final Interval getRepairFailuresTimeWindow()
     {
         return myRepairFailuresTimeWindow;
@@ -102,15 +103,15 @@ public class StatisticsConfig
     }
 
     @JsonProperty("repair_failures_count")
-    public final void setRepairFailuresCount(final int repairFailureCount)
+    public final void setRepairFailuresCount(final int repairFailuresCount)
     {
-        myRepairFailuresCount = repairFailureCount;
+        myRepairFailuresCount = repairFailuresCount;
     }
 
     @JsonProperty("repair_failures_time_window")
-    public final void setRepairFailuresTimeWindow(final Interval repairFailureTimeWindow)
+    public final void setRepairFailuresTimeWindow(final Interval repairFailuresTimeWindow)
     {
-        myRepairFailuresTimeWindow = repairFailureTimeWindow;
+        myRepairFailuresTimeWindow = repairFailuresTimeWindow;
     }
     @JsonProperty("trigger_interval_for_metric_inspection")
     public final void setTriggerIntervalForMetricInspection(final Interval triggerIntervalForStatusLogger)
@@ -118,24 +119,14 @@ public class StatisticsConfig
         myTriggerIntervalForMetricInspection = triggerIntervalForStatusLogger;
      }
 
-     public final long getRepairFailuresTimeWindowInMinutes()
-     {
-        return myRepairFailuresTimeWindow.getInterval(TimeUnit.MINUTES);
-     }
-
-     public final long getTriggerIntervalForMetricInspectionInMillSeconds()
-     {
-        return myTriggerIntervalForMetricInspection.getInterval(TimeUnit.MILLISECONDS);
-     }
-
-    public final void validate()
+     public final void validate()
     {
-        long repairTimeWindowInSeconds = myRepairFailuresTimeWindow.getInterval(TimeUnit.SECONDS);
-        long triggerIntervalForMetricInspection = this.myTriggerIntervalForMetricInspection
+        long repairTimeWindowInSeconds = getRepairFailuresTimeWindow().getInterval(TimeUnit.SECONDS);
+        long triggerIntervalForMetricInspection = getTriggerIntervalForMetricInspection()
                 .getInterval(TimeUnit.SECONDS);
         if (triggerIntervalForMetricInspection >= repairTimeWindowInSeconds)
         {
-            throw new IllegalArgumentException(String.format("Repair Window time must be greater than trigger interval."
+            throw new IllegalArgumentException(String.format("Repair window time must be greater than trigger interval."
                             + " Current repair window time: %d seconds,"
                             + " trigger interval for metric inspection: %d seconds",
                     repairTimeWindowInSeconds, triggerIntervalForMetricInspection));
@@ -143,6 +134,4 @@ public class StatisticsConfig
      }
 
 }
-
-
 

--- a/application/src/main/java/com/ericsson/bss/cassandra/ecchronos/application/config/metrics/StatisticsConfig.java
+++ b/application/src/main/java/com/ericsson/bss/cassandra/ecchronos/application/config/metrics/StatisticsConfig.java
@@ -25,6 +25,12 @@ public class StatisticsConfig
     private ReportingConfigs myReportingConfigs = new ReportingConfigs();
     private String myMetricsPrefix = "";
 
+    private int myRepairFailureCountForReporting = 0;
+
+    private int myTimeWindowSizeinMinsForReporting = 0;
+
+
+
     @JsonProperty("enabled")
     public final boolean isEnabled()
     {
@@ -52,6 +58,20 @@ public class StatisticsConfig
         return myMetricsPrefix;
     }
 
+
+    @JsonProperty("repair_failures_count")
+    public final int getMyRepairFailureCountForReporting()
+    {
+        return myRepairFailureCountForReporting;
+    }
+
+    @JsonProperty("repair_failure_time_window")
+    public final int getMyTimeWindowSizeinMinsForReporting()
+    {
+        return myTimeWindowSizeinMinsForReporting;
+    }
+
+
     @JsonProperty("enabled")
     public final void setEnabled(final boolean enabled)
     {
@@ -75,4 +95,18 @@ public class StatisticsConfig
     {
         myMetricsPrefix = metricsPrefix;
     }
+
+    @JsonProperty("repair_failures_count")
+    public final void setMyRepairFailureCountForReporting(final int repairFailureCount)
+    {
+        myRepairFailureCountForReporting =  repairFailureCount;
+    }
+
+    @JsonProperty("repair_failure_time_window")
+    public final void setMyTimeWindowSizeinMinsForReporting(final int repairFailureTimeWindow)
+    {
+        myTimeWindowSizeinMinsForReporting = repairFailureTimeWindow;
+    }
 }
+
+

--- a/application/src/main/java/com/ericsson/bss/cassandra/ecchronos/application/config/metrics/StatisticsConfig.java
+++ b/application/src/main/java/com/ericsson/bss/cassandra/ecchronos/application/config/metrics/StatisticsConfig.java
@@ -107,7 +107,7 @@ public class StatisticsConfig
         myRepairFailuresCount = repairFailureCount;
     }
 
-    @JsonProperty("repair_failures_time_window_in_minutes")
+    @JsonProperty("repair_failures_time_window")
     public final void setRepairFailuresTimeWindow(final Interval repairFailureTimeWindow)
     {
         myRepairFailuresTimeWindow = repairFailureTimeWindow;

--- a/application/src/main/java/com/ericsson/bss/cassandra/ecchronos/application/spring/MetricBeans.java
+++ b/application/src/main/java/com/ericsson/bss/cassandra/ecchronos/application/spring/MetricBeans.java
@@ -23,6 +23,7 @@ import com.ericsson.bss.cassandra.ecchronos.application.config.metrics.Statistic
 import io.micrometer.core.instrument.Clock;
 import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
 import io.micrometer.core.instrument.config.MeterFilter;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import io.micrometer.jmx.JmxConfig;
 import io.micrometer.jmx.JmxMeterRegistry;
 import io.micrometer.prometheus.PrometheusConfig;
@@ -66,6 +67,8 @@ public class MetricBeans
                 createPrometheusMeterRegistry(metricConfig);
             }
         }
+
+        createStatusLoggerMeterRegistry();
     }
 
     private void createJmxMeterRegistry(final StatisticsConfig metricConfig)
@@ -101,6 +104,14 @@ public class MetricBeans
         myPrometheusMeterRegistry = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT);
         myPrometheusMeterRegistry.config().meterFilter(meterFilter);
         myCompositeMeterRegistry.add(myPrometheusMeterRegistry);
+    }
+
+
+    private void createStatusLoggerMeterRegistry()
+    {
+        SimpleMeterRegistry simpleMeterRegistry = new SimpleMeterRegistry();
+        myCompositeMeterRegistry.add(simpleMeterRegistry);
+
     }
 
     @Bean

--- a/application/src/main/java/com/ericsson/bss/cassandra/ecchronos/application/spring/MetricBeans.java
+++ b/application/src/main/java/com/ericsson/bss/cassandra/ecchronos/application/spring/MetricBeans.java
@@ -67,7 +67,6 @@ public class MetricBeans
                 createPrometheusMeterRegistry(metricConfig);
             }
         }
-
         createStatusLoggerMeterRegistry();
     }
 
@@ -106,12 +105,10 @@ public class MetricBeans
         myCompositeMeterRegistry.add(myPrometheusMeterRegistry);
     }
 
-
     private void createStatusLoggerMeterRegistry()
     {
         SimpleMeterRegistry simpleMeterRegistry = new SimpleMeterRegistry();
         myCompositeMeterRegistry.add(simpleMeterRegistry);
-
     }
 
     @Bean

--- a/application/src/main/resources/ecc.yml
+++ b/application/src/main/resources/ecc.yml
@@ -282,10 +282,18 @@ statistics:
   ##
   repair_failures_count: 5
   ##
-  ## Time window in minutes over which to track repair failures in node for trigger status logger messages in debug log
+  ## Time window over which to track repair failures in node for trigger status logger messages in debug log
   ##
-  repair_failures_time_window_in_minutes: 30
-
+  repair_failures_time_window:
+      time: 30
+      unit: minutes
+  ##
+  ## Trigger interval for metric inspection.
+  ## This time should always be lesser than repair_failures_time_window
+  ##
+  trigger_interval_for_metric_inspection:
+       time: 5
+       unit: seconds
 
 lock_factory:
   cas:

--- a/application/src/main/resources/ecc.yml
+++ b/application/src/main/resources/ecc.yml
@@ -278,11 +278,11 @@ statistics:
   prefix: ''
   ##
   ## Number of repair failures before status logger logs metrics in debug logs
-  ## The number is used to trigger a status once number of failures is breached in a timewindow mentioned below
+  ## The number is used to trigger a status once number of failures is breached in a time window mentioned below
   ##
   repair_failures_count: 5
   ##
-  ## Timewindow in minutes over which to track repair failures in node for trigger statuslogger messages in debug log
+  ## Time window in minutes over which to track repair failures in node for trigger status logger messages in debug log
   ##
   repair_failure_time_window: 30
 

--- a/application/src/main/resources/ecc.yml
+++ b/application/src/main/resources/ecc.yml
@@ -284,7 +284,7 @@ statistics:
   ##
   ## Time window in minutes over which to track repair failures in node for trigger status logger messages in debug log
   ##
-  repair_failure_time_window: 30
+  repair_failures_time_window_in_minutes: 30
 
 
 lock_factory:

--- a/application/src/main/resources/ecc.yml
+++ b/application/src/main/resources/ecc.yml
@@ -276,6 +276,16 @@ statistics:
   ## The prefix cannot start or end with a dot or any other path separator.
   ##
   prefix: ''
+  ##
+  ## Number of repair failures before status logger logs metrics in debug logs
+  ## The number is used to trigger a status once number of failures is breached in a timewindow mentioned below
+  ##
+  repair_failures_count: 5
+  ##
+  ## Timewindow in minutes over which to track repair failures in node for trigger statuslogger messages in debug log
+  ##
+  repair_failure_time_window: 30
+
 
 lock_factory:
   cas:

--- a/application/src/test/java/com/ericsson/bss/cassandra/ecchronos/application/config/TestConfig.java
+++ b/application/src/test/java/com/ericsson/bss/cassandra/ecchronos/application/config/TestConfig.java
@@ -160,12 +160,9 @@ public class TestConfig
         assertThat(httpReportingConfig.getExcludedMetrics()).hasSize(1);
         assertThat(httpReportingConfig.getExcludedMetrics()).contains(expectedHttpExcludedMetric);
 
-        assertThat(statisticsConfig.getRepairFailuresTimeWindow().getInterval(TimeUnit.MINUTES)).isEqualTo(30);
-        assertThat(statisticsConfig.getTriggerIntervalForMetricInspection().getInterval(TimeUnit.SECONDS)).isEqualTo(5);
+        assertThat(statisticsConfig.getRepairFailuresTimeWindow().getInterval(TimeUnit.MINUTES)).isEqualTo(5);
+        assertThat(statisticsConfig.getTriggerIntervalForMetricInspection().getInterval(TimeUnit.SECONDS)).isEqualTo(30);
         assertThat(statisticsConfig.getRepairFailuresCount()).isEqualTo(5);
-
-        assertThat(statisticsConfig.getRepairFailuresTimeWindowInMinutes()).isEqualTo(30);
-        assertThat(statisticsConfig.getTriggerIntervalForMetricInspectionInMillSeconds()).isEqualTo(5000);
 
         LockFactoryConfig lockFactoryConfig = config.getLockFactory();
         assertThat(lockFactoryConfig.getCasLockFactoryConfig().getKeyspaceName()).isEqualTo("ecc");
@@ -375,10 +372,7 @@ public class TestConfig
         assertThat(statisticsConfig.getTriggerIntervalForMetricInspection().getInterval(TimeUnit.SECONDS)).isEqualTo(5);
         assertThat(statisticsConfig.getRepairFailuresCount()).isEqualTo(5);
 
-        assertThat(statisticsConfig.getRepairFailuresTimeWindowInMinutes()).isEqualTo(30);
-        assertThat(statisticsConfig.getTriggerIntervalForMetricInspectionInMillSeconds()).isEqualTo(5000);
-
-        LockFactoryConfig lockFactoryConfig = config.getLockFactory();
+       LockFactoryConfig lockFactoryConfig = config.getLockFactory();
         assertThat(lockFactoryConfig.getCasLockFactoryConfig().getKeyspaceName()).isEqualTo("ecchronos");
         assertThat(lockFactoryConfig.getCasLockFactoryConfig().getConsistencySerial().equals(ConsistencyType.DEFAULT)).isTrue();
 
@@ -392,8 +386,6 @@ public class TestConfig
         assertThat(restServerConfig.getHost()).isEqualTo("localhost");
         assertThat(restServerConfig.getPort()).isEqualTo(8080);
     }
-
-
 
     @Test
     public void testRepairIntervalLongerThanWarn()
@@ -432,6 +424,17 @@ public class TestConfig
         assertThat(statisticsConfig.getReportingConfigs().isFileReportingEnabled()).isFalse();
         assertThat(statisticsConfig.getReportingConfigs().isHttpReportingEnabled()).isFalse();
         assertThat(statisticsConfig.isEnabled()).isTrue();
+    }
+
+    @Test
+    public void testTriggerIntervalBiggerThanRepairFailuresWindow()
+    {
+        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+        File file = new File(classLoader.getResource("trigger_interval_bigger_than_repair_failures_window.yml").getFile());
+
+        ObjectMapper objectMapper = new ObjectMapper(new YAMLFactory());
+
+        assertThatExceptionOfType(JsonMappingException.class).isThrownBy(() -> objectMapper.readValue(file, Config.class));
     }
 
     public static class TestNativeConnectionProvider implements NativeConnectionProvider

--- a/application/src/test/java/com/ericsson/bss/cassandra/ecchronos/application/config/TestConfig.java
+++ b/application/src/test/java/com/ericsson/bss/cassandra/ecchronos/application/config/TestConfig.java
@@ -160,6 +160,13 @@ public class TestConfig
         assertThat(httpReportingConfig.getExcludedMetrics()).hasSize(1);
         assertThat(httpReportingConfig.getExcludedMetrics()).contains(expectedHttpExcludedMetric);
 
+        assertThat(statisticsConfig.getRepairFailuresTimeWindow().getInterval(TimeUnit.MINUTES)).isEqualTo(30);
+        assertThat(statisticsConfig.getTriggerIntervalForMetricInspection().getInterval(TimeUnit.SECONDS)).isEqualTo(5);
+        assertThat(statisticsConfig.getRepairFailuresCount()).isEqualTo(5);
+
+        assertThat(statisticsConfig.getRepairFailuresTimeWindowInMinutes()).isEqualTo(30);
+        assertThat(statisticsConfig.getTriggerIntervalForMetricInspectionInMillSeconds()).isEqualTo(5000);
+
         LockFactoryConfig lockFactoryConfig = config.getLockFactory();
         assertThat(lockFactoryConfig.getCasLockFactoryConfig().getKeyspaceName()).isEqualTo("ecc");
         assertThat(lockFactoryConfig.getCasLockFactoryConfig().getConsistencySerial().equals(ConsistencyType.LOCAL)).isTrue();
@@ -364,6 +371,13 @@ public class TestConfig
         assertThat(httpReportingConfig.isEnabled()).isTrue();
         assertThat(httpReportingConfig.getExcludedMetrics()).isEmpty();
 
+        assertThat(statisticsConfig.getRepairFailuresTimeWindow().getInterval(TimeUnit.MINUTES)).isEqualTo(30);
+        assertThat(statisticsConfig.getTriggerIntervalForMetricInspection().getInterval(TimeUnit.SECONDS)).isEqualTo(5);
+        assertThat(statisticsConfig.getRepairFailuresCount()).isEqualTo(5);
+
+        assertThat(statisticsConfig.getRepairFailuresTimeWindowInMinutes()).isEqualTo(30);
+        assertThat(statisticsConfig.getTriggerIntervalForMetricInspectionInMillSeconds()).isEqualTo(5000);
+
         LockFactoryConfig lockFactoryConfig = config.getLockFactory();
         assertThat(lockFactoryConfig.getCasLockFactoryConfig().getKeyspaceName()).isEqualTo("ecchronos");
         assertThat(lockFactoryConfig.getCasLockFactoryConfig().getConsistencySerial().equals(ConsistencyType.DEFAULT)).isTrue();
@@ -378,6 +392,8 @@ public class TestConfig
         assertThat(restServerConfig.getHost()).isEqualTo("localhost");
         assertThat(restServerConfig.getPort()).isEqualTo(8080);
     }
+
+
 
     @Test
     public void testRepairIntervalLongerThanWarn()
@@ -402,7 +418,7 @@ public class TestConfig
     }
 
     @Test
-    public void testStatisticsDisabledIfNoReporting() throws Exception
+    public void testStatisticsEnabledIfNoReporting() throws Exception
     {
         ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
         File file = new File(classLoader.getResource("all_reporting_disabled.yml").getFile());
@@ -415,7 +431,7 @@ public class TestConfig
         assertThat(statisticsConfig.getReportingConfigs().isJmxReportingEnabled()).isFalse();
         assertThat(statisticsConfig.getReportingConfigs().isFileReportingEnabled()).isFalse();
         assertThat(statisticsConfig.getReportingConfigs().isHttpReportingEnabled()).isFalse();
-        assertThat(statisticsConfig.isEnabled()).isFalse();
+        assertThat(statisticsConfig.isEnabled()).isTrue();
     }
 
     public static class TestNativeConnectionProvider implements NativeConnectionProvider

--- a/application/src/test/resources/all_set.yml
+++ b/application/src/test/resources/all_set.yml
@@ -85,6 +85,13 @@ statistics:
       excludedMetrics:
         - name: '.*httpExcluded'
   prefix: "unittest"
+  repair_failures_count: 5
+  repair_failures_time_window:
+    time: 30
+    unit: minutes
+  trigger_interval_status_logger:
+    time: 5
+    unit: seconds
 
 lock_factory:
   cas:

--- a/application/src/test/resources/all_set.yml
+++ b/application/src/test/resources/all_set.yml
@@ -89,7 +89,7 @@ statistics:
   repair_failures_time_window:
     time: 30
     unit: minutes
-  trigger_interval_status_logger:
+  trigger_interval_for_metric_inspection:
     time: 5
     unit: seconds
 

--- a/application/src/test/resources/all_set.yml
+++ b/application/src/test/resources/all_set.yml
@@ -87,10 +87,10 @@ statistics:
   prefix: "unittest"
   repair_failures_count: 5
   repair_failures_time_window:
-    time: 30
+    time: 5
     unit: minutes
   trigger_interval_for_metric_inspection:
-    time: 5
+    time: 30
     unit: seconds
 
 lock_factory:

--- a/application/src/test/resources/trigger_interval_bigger_than_repair_failures_window.yml
+++ b/application/src/test/resources/trigger_interval_bigger_than_repair_failures_window.yml
@@ -1,0 +1,22 @@
+#
+# Copyright 2024 Telefonaktiebolaget LM Ericsson
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+statistics:
+  repair_failures_time_window:
+    time: 30
+    unit: seconds
+  trigger_interval_for_metric_inspection:
+    time: 5
+    unit: minutes

--- a/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/metrics/MetricInspector.java
+++ b/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/metrics/MetricInspector.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2024 Telefonaktiebolaget LM Ericsson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ericsson.bss.cassandra.ecchronos.core.metrics;
+
+import com.ericsson.bss.cassandra.ecchronos.core.utils.StatusLogger;
+import com.google.common.annotations.VisibleForTesting;
+import io.micrometer.core.instrument.MeterRegistry;
+
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.Timer;
+import java.util.TimerTask;
+
+public final class MetricInspector
+{
+
+    private final MeterRegistry myMeterRegistry;
+    private long myRepairFailureCountSinceLastReport = 0;
+
+    private static final int REPEAT_INTERVAL_PERIOD = 5000;
+
+     @VisibleForTesting
+     long getMyRepairFailureCountSinceLastReport()
+     {
+        return myRepairFailureCountSinceLastReport;
+    }
+
+    @VisibleForTesting
+    long getMyTotalRecordFailures()
+    {
+        return myTotalRecordFailures;
+    }
+
+    @VisibleForTesting
+    LocalDateTime getRecordingStartTimestamp()
+    {
+        return recordingStartTimestamp;
+    }
+
+    private long myTotalRecordFailures = 0;
+
+    private final int myRepairFailureThreshold;
+
+    private final int myRepairFailureTimeWindow;
+
+
+    private LocalDateTime recordingStartTimestamp = LocalDateTime.now();
+
+
+    public MetricInspector(final MeterRegistry meterRegistry,
+                           final int repairFailureThreshold,
+                           final int repairFailureTimeWindow)
+    {
+        this.myMeterRegistry = meterRegistry;
+        this.myRepairFailureThreshold = repairFailureThreshold;
+        this.myRepairFailureTimeWindow = repairFailureTimeWindow;
+    }
+
+
+    public void startInspection()
+    {
+        java.util.Timer timer = new Timer();
+        timer.scheduleAtFixedRate(new TimerTask()
+        {
+            @Override
+            public void run()
+            {
+                inspectMeterRegistryForRepairFailures();
+            }
+        }, 0, REPEAT_INTERVAL_PERIOD);
+    }
+
+
+        @VisibleForTesting
+        void inspectMeterRegistryForRepairFailures()
+        {
+
+            io.micrometer.core.instrument.Timer nodeRepairSessions = myMeterRegistry
+                     .find(TableRepairMetricsImpl.NODE_REPAIR_SESSIONS)
+                    .tags("successful", "false")
+                    .timer();
+            if (nodeRepairSessions != null)
+            {
+                myTotalRecordFailures = nodeRepairSessions.count();
+            }
+
+            if (myTotalRecordFailures - myRepairFailureCountSinceLastReport > myRepairFailureThreshold)
+            {
+                //reset count failure and reinitialize time window
+                myRepairFailureCountSinceLastReport = myTotalRecordFailures;
+                recordingStartTimestamp = LocalDateTime.now();
+                StatusLogger.log(myMeterRegistry);
+
+            }
+
+            resetRepairFailureCount();
+
+
+    }
+
+    /*
+     * If in defined time window, number of repair failure has not crossed the configured number, then
+     * reset failure count for new timed window. Reinitialize time window.
+     */
+
+    @VisibleForTesting
+    void resetRepairFailureCount()
+        {
+
+            LocalDateTime currentTimeStamp = LocalDateTime.now();
+            LocalDateTime thirtyMinutesAgo = currentTimeStamp.minus(myRepairFailureTimeWindow, ChronoUnit.MINUTES);
+
+            if (recordingStartTimestamp.isBefore(thirtyMinutesAgo))
+            {
+                myRepairFailureCountSinceLastReport = myTotalRecordFailures;
+                recordingStartTimestamp = LocalDateTime.now();
+            }
+
+
+        }
+
+
+}

--- a/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/metrics/MetricInspector.java
+++ b/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/metrics/MetricInspector.java
@@ -50,13 +50,10 @@ public final class MetricInspector
     }
 
     private long myTotalRecordFailures = 0;
-
     private final int myRepairFailureThreshold;
-
     private final int myRepairFailureTimeWindow;
-
-
     private LocalDateTime recordingStartTimestamp = LocalDateTime.now();
+    private java.util.Timer timer;
 
 
     public MetricInspector(final MeterRegistry meterRegistry,
@@ -71,7 +68,7 @@ public final class MetricInspector
 
     public void startInspection()
     {
-        java.util.Timer timer = new Timer();
+        timer = new Timer();
         timer.scheduleAtFixedRate(new TimerTask()
         {
             @Override
@@ -80,6 +77,14 @@ public final class MetricInspector
                 inspectMeterRegistryForRepairFailures();
             }
         }, 0, REPEAT_INTERVAL_PERIOD);
+    }
+
+    public void stopInspection()
+    {
+        if (timer != null)
+        {
+            timer.cancel();
+        }
     }
 
 
@@ -118,18 +123,14 @@ public final class MetricInspector
     @VisibleForTesting
     void resetRepairFailureCount()
         {
-
             LocalDateTime currentTimeStamp = LocalDateTime.now();
-            LocalDateTime thirtyMinutesAgo = currentTimeStamp.minus(myRepairFailureTimeWindow, ChronoUnit.MINUTES);
-
-            if (recordingStartTimestamp.isBefore(thirtyMinutesAgo))
+            LocalDateTime timeWindowMinsAgo = currentTimeStamp.minus(myRepairFailureTimeWindow, ChronoUnit.MINUTES);
+            if (recordingStartTimestamp.isBefore(timeWindowMinsAgo))
             {
                 myRepairFailureCountSinceLastReport = myTotalRecordFailures;
                 recordingStartTimestamp = LocalDateTime.now();
             }
-
-
-        }
+        };
 
 
 }

--- a/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/metrics/MetricInspector.java
+++ b/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/metrics/MetricInspector.java
@@ -26,16 +26,12 @@ import java.util.TimerTask;
 
 public final class MetricInspector
 {
-
     private final MeterRegistry myMeterRegistry;
     private long myRepairFailureCountSinceLastReport = 0;
-    private static final long REPEAT_INTERVAL_PERIOD_IN_MILLISECONDS = 5000;
-    private static final long  DEFAULT_TIME_WINDOW = 30;
-    private static final int DEFAULT_REPAIR_FAILURES_THRESHOLD = 5;
     private long myTotalRecordFailures = 0;
-    private int myRepairFailureThreshold = DEFAULT_REPAIR_FAILURES_THRESHOLD;
-    private long myRepairFailureTimeWindow = DEFAULT_TIME_WINDOW;
-    private long myTriggerIntervalForMetricInspection = REPEAT_INTERVAL_PERIOD_IN_MILLISECONDS;
+    private final int myRepairFailureThreshold;
+    private final long myRepairFailureTimeWindow;
+    private final long myTriggerIntervalForMetricInspection;
     private LocalDateTime myRecordingStartTimestamp = LocalDateTime.now();
     private Timer timer;
 
@@ -57,16 +53,7 @@ public final class MetricInspector
         return myRecordingStartTimestamp;
     }
 
-    public MetricInspector(final MeterRegistry meterRegistry,
-                           final int repairFailureThreshold,
-                           final long repairFailureTimeWindow)
-    {
-        this.myMeterRegistry = meterRegistry;
-        this.myRepairFailureThreshold = repairFailureThreshold;
-        this.myRepairFailureTimeWindow = repairFailureTimeWindow;
-    }
-
-    public MetricInspector(final MeterRegistry meterRegistry,
+       public MetricInspector(final MeterRegistry meterRegistry,
                     final int repairFailureThreshold,
                     final long repairFailureTimeWindow,
                     final long triggerIntervalForMetricInspection)
@@ -87,7 +74,7 @@ public final class MetricInspector
             {
                 inspectMeterRegistryForRepairFailures();
             }
-        }, 0, REPEAT_INTERVAL_PERIOD_IN_MILLISECONDS);
+        }, 0, myTriggerIntervalForMetricInspection);
     }
 
     public void stopInspection()

--- a/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/metrics/MetricInspector.java
+++ b/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/metrics/MetricInspector.java
@@ -52,7 +52,7 @@ public final class MetricInspector
         return myRecordingStartTimestamp;
     }
 
-       public MetricInspector(final MeterRegistry meterRegistry,
+    public MetricInspector(final MeterRegistry meterRegistry,
                     final int repairFailureThreshold,
                     final long repairFailuresTimeWindow,
                     final long triggerIntervalForMetricInspection)
@@ -92,16 +92,15 @@ public final class MetricInspector
                     .tags("successful", "false")
                     .timer();
         if (nodeRepairSessions != null)
-            {
-                myTotalRecordFailures = nodeRepairSessions.count();
-            }
+        {
+            myTotalRecordFailures = nodeRepairSessions.count();
+        }
         if (myTotalRecordFailures - myRepairFailuresCountSinceLastReport > myRepairFailureThreshold)
-            {
-                //reset count failure and reinitialize time window
-                myRepairFailuresCountSinceLastReport = myTotalRecordFailures;
-                myRecordingStartTimestamp = LocalDateTime.now();
-                StatusLogger.log(myMeterRegistry);
-            }
+        {
+             myRepairFailuresCountSinceLastReport = myTotalRecordFailures;
+             myRecordingStartTimestamp = LocalDateTime.now();
+             StatusLogger.log(myMeterRegistry);
+        }
         resetRepairFailureCount();
     }
 

--- a/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/metrics/MetricInspector.java
+++ b/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/metrics/MetricInspector.java
@@ -1,3 +1,4 @@
+
 /*
  * Copyright 2024 Telefonaktiebolaget LM Ericsson
  *
@@ -28,10 +29,13 @@ public final class MetricInspector
 
     private final MeterRegistry myMeterRegistry;
     private long myRepairFailureCountSinceLastReport = 0;
-    private static final int REPEAT_INTERVAL_PERIOD_IN_MILLISECONDS = 5000;
+    private static final long REPEAT_INTERVAL_PERIOD_IN_MILLISECONDS = 5000;
+    private static final long  DEFAULT_TIME_WINDOW = 30;
+    private static final int DEFAULT_REPAIR_FAILURES_THRESHOLD = 5;
     private long myTotalRecordFailures = 0;
-    private final int myRepairFailureThreshold;
-    private final int myRepairFailureTimeWindow;
+    private int myRepairFailureThreshold = DEFAULT_REPAIR_FAILURES_THRESHOLD;
+    private long myRepairFailureTimeWindow = DEFAULT_TIME_WINDOW;
+    private long myTriggerIntervalForMetricInspection = REPEAT_INTERVAL_PERIOD_IN_MILLISECONDS;
     private LocalDateTime myRecordingStartTimestamp = LocalDateTime.now();
     private Timer timer;
 
@@ -55,11 +59,22 @@ public final class MetricInspector
 
     public MetricInspector(final MeterRegistry meterRegistry,
                            final int repairFailureThreshold,
-                           final int repairFailureTimeWindow)
+                           final long repairFailureTimeWindow)
     {
         this.myMeterRegistry = meterRegistry;
         this.myRepairFailureThreshold = repairFailureThreshold;
         this.myRepairFailureTimeWindow = repairFailureTimeWindow;
+    }
+
+    public MetricInspector(final MeterRegistry meterRegistry,
+                    final int repairFailureThreshold,
+                    final long repairFailureTimeWindow,
+                    final long triggerIntervalForMetricInspection)
+    {
+        this.myMeterRegistry = meterRegistry;
+        this.myRepairFailureThreshold = repairFailureThreshold;
+        this.myRepairFailureTimeWindow = repairFailureTimeWindow;
+        this.myTriggerIntervalForMetricInspection = triggerIntervalForMetricInspection;
     }
 
     public void startInspection()

--- a/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/metrics/MetricInspector.java
+++ b/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/metrics/MetricInspector.java
@@ -74,7 +74,7 @@ public final class MetricInspector
             }
         }, 0, REPEAT_INTERVAL_PERIOD_IN_MILLISECONDS);
     }
-    
+
     public void stopInspection()
     {
         if (timer != null)
@@ -82,6 +82,7 @@ public final class MetricInspector
             timer.cancel();
         }
     }
+
     @VisibleForTesting
     void inspectMeterRegistryForRepairFailures()
     {
@@ -112,7 +113,8 @@ public final class MetricInspector
     void resetRepairFailureCount()
         {
             LocalDateTime currentTimeStamp = LocalDateTime.now();
-            LocalDateTime timeRepairWindowMinutesAgo = currentTimeStamp.minus(myRepairFailureTimeWindow, ChronoUnit.MINUTES);
+            LocalDateTime timeRepairWindowMinutesAgo = currentTimeStamp.
+                    minus(myRepairFailureTimeWindow, ChronoUnit.MINUTES);
             if (myRecordingStartTimestamp.isBefore(timeRepairWindowMinutesAgo))
             {
                 myRepairFailureCountSinceLastReport = myTotalRecordFailures;

--- a/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/utils/StatusLogger.java
+++ b/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/utils/StatusLogger.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2024 Telefonaktiebolaget LM Ericsson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ericsson.bss.cassandra.ecchronos.core.utils;
+
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public final class StatusLogger
+{
+
+    private StatusLogger()
+    {
+        throw new AssertionError("Utility classes should not be instantiated");
+    }
+    private static final Logger LOG = LoggerFactory.getLogger(StatusLogger.class);
+
+    static final String NODE_REPAIR_SESSIONS = "node.repair.sessions";
+
+    static final String NODE_REMAINING_REPAIR_TIME = "node.remaining.repair.time";
+
+    static final String NODE_TIME_SINCE_LAST_REPAIRED = "node.time.since.last.repaired";
+
+    static final String NODE_REPAIRED_RATIO = "node.repaired.ratio";
+
+
+/*
+Log the state of the table, if repairs for a table failed for more than time defined
+in configuration in ecc.yml
+//
+
+ */
+    public static void log(final MeterRegistry myMeterRegistry)
+    {
+        Timer failedRepairSessions = myMeterRegistry.find(NODE_REPAIR_SESSIONS)
+                .tags("successful", "false")
+                .timer();
+        if (failedRepairSessions != null)
+        {
+            LOG.debug("Total repair failures in node till now is: {}", failedRepairSessions.count());
+        }
+
+        Timer successfulRepairSessions = myMeterRegistry.find(NODE_REPAIR_SESSIONS)
+                .tags("successful", "true")
+                .timer();
+        if (successfulRepairSessions != null)
+        {
+            LOG.debug("Total repair success in node till now is:{}", successfulRepairSessions.count());
+        }
+
+        Gauge nodeTimeSinceLastRepaired = myMeterRegistry.find(NODE_TIME_SINCE_LAST_REPAIRED)
+                .gauge();
+
+        if (nodeTimeSinceLastRepaired != null)
+        {
+            LOG.debug("Node last repaired at: {}", nodeTimeSinceLastRepaired.value());
+        }
+
+        Gauge nodeRemainingRepairTime = myMeterRegistry.find(NODE_REMAINING_REPAIR_TIME)
+                .gauge();
+        if (nodeRemainingRepairTime != null)
+        {
+            LOG.debug("Remaining time for node repair :{}", nodeRemainingRepairTime.value());
+        }
+
+        Gauge nodeRepairedRatio = myMeterRegistry.find(NODE_REPAIRED_RATIO)
+                .gauge();
+        if (nodeRepairedRatio != null)
+        {
+            LOG.debug("Node Repair Ratio is :: {}", nodeRepairedRatio.value());
+        }
+
+    }
+
+}

--- a/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/utils/StatusLogger.java
+++ b/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/utils/StatusLogger.java
@@ -28,22 +28,11 @@ public final class StatusLogger
         throw new AssertionError("Utility classes should not be instantiated");
     }
     private static final Logger LOG = LoggerFactory.getLogger(StatusLogger.class);
-
     static final String NODE_REPAIR_SESSIONS = "node.repair.sessions";
-
     static final String NODE_REMAINING_REPAIR_TIME = "node.remaining.repair.time";
-
     static final String NODE_TIME_SINCE_LAST_REPAIRED = "node.time.since.last.repaired";
-
     static final String NODE_REPAIRED_RATIO = "node.repaired.ratio";
 
-
-/*
-Log the state of the table, if repairs for a table failed for more than time defined
-in configuration in ecc.yml
-//
-
- */
     public static void log(final MeterRegistry myMeterRegistry)
     {
         Timer failedRepairSessions = myMeterRegistry.find(NODE_REPAIR_SESSIONS)
@@ -59,7 +48,7 @@ in configuration in ecc.yml
                 .timer();
         if (successfulRepairSessions != null)
         {
-            LOG.debug("Total repair success in node till now is:{}", successfulRepairSessions.count());
+            LOG.debug("Total repair success in node till now is: {}", successfulRepairSessions.count());
         }
 
         Gauge nodeTimeSinceLastRepaired = myMeterRegistry.find(NODE_TIME_SINCE_LAST_REPAIRED)
@@ -74,14 +63,14 @@ in configuration in ecc.yml
                 .gauge();
         if (nodeRemainingRepairTime != null)
         {
-            LOG.debug("Remaining time for node repair :{}", nodeRemainingRepairTime.value());
+            LOG.debug("Remaining time for node repair: {}", nodeRemainingRepairTime.value());
         }
 
         Gauge nodeRepairedRatio = myMeterRegistry.find(NODE_REPAIRED_RATIO)
                 .gauge();
         if (nodeRepairedRatio != null)
         {
-            LOG.debug("Node Repair Ratio is :: {}", nodeRepairedRatio.value());
+            LOG.debug("Node Repair Ratio is: {}", nodeRepairedRatio.value());
         }
 
     }

--- a/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/utils/StatusLogger.java
+++ b/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/utils/StatusLogger.java
@@ -22,16 +22,16 @@ import org.slf4j.LoggerFactory;
 
 public final class StatusLogger
 {
-
-    private StatusLogger()
-    {
-        throw new AssertionError("Utility classes should not be instantiated");
-    }
     private static final Logger LOG = LoggerFactory.getLogger(StatusLogger.class);
     static final String NODE_REPAIR_SESSIONS = "node.repair.sessions";
     static final String NODE_REMAINING_REPAIR_TIME = "node.remaining.repair.time";
     static final String NODE_TIME_SINCE_LAST_REPAIRED = "node.time.since.last.repaired";
     static final String NODE_REPAIRED_RATIO = "node.repaired.ratio";
+
+    private StatusLogger()
+    {
+        throw new AssertionError("Utility classes should not be instantiated");
+    }
 
     public static void log(final MeterRegistry myMeterRegistry)
     {
@@ -70,7 +70,7 @@ public final class StatusLogger
                 .gauge();
         if (nodeRepairedRatio != null)
         {
-            LOG.debug("Node Repair Ratio is: {}", nodeRepairedRatio.value());
+            LOG.debug("Node repair ratio is: {}", nodeRepairedRatio.value());
         }
 
     }

--- a/core/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/metrics/TestMetricInspector.java
+++ b/core/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/metrics/TestMetricInspector.java
@@ -22,32 +22,23 @@ import com.ericsson.bss.cassandra.ecchronos.core.TableStorageStates;
 import com.ericsson.bss.cassandra.ecchronos.core.utils.StatusLogger;
 import com.ericsson.bss.cassandra.ecchronos.core.utils.TableReference;
 import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.core.instrument.Timer;
 import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.slf4j.LoggerFactory;
-
-import java.time.LocalDateTime;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.TimerTask;
 import java.util.concurrent.TimeUnit;
-
 import static com.ericsson.bss.cassandra.ecchronos.core.MockTableReferenceFactory.tableReference;
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.*;
+
 
 @RunWith(MockitoJUnitRunner.class)
 public class TestMetricInspector
 {
-
     private static final String TEST_KEYSPACE = "test_keyspace";
     private static final String TEST_TABLE1 = "test_table1";
     private static final String TEST_TABLE2 = "test_table2";
@@ -55,7 +46,7 @@ public class TestMetricInspector
     private TableStorageStates myTableStorageStates;
     private MeterRegistry myMeterRegistry;
     private TableRepairMetricsImpl myTableRepairMetricsImpl;
-    private MetricInspector myMetericInspector;
+    private MetricInspector myMetricInspector;
     private LoggerContext loggerContext;
     private ListAppender<ILoggingEvent> listAppender;
 
@@ -70,12 +61,12 @@ public class TestMetricInspector
         CompositeMeterRegistry compositeMeterRegistry = new CompositeMeterRegistry();
         // Need at least one registry present in composite to record metrics
         compositeMeterRegistry.add(new SimpleMeterRegistry());
-       myMeterRegistry = compositeMeterRegistry;
-       myTableRepairMetricsImpl = TableRepairMetricsImpl.builder()
+        myMeterRegistry = compositeMeterRegistry;
+        myTableRepairMetricsImpl = TableRepairMetricsImpl.builder()
                 .withTableStorageStates(myTableStorageStates)
                 .withMeterRegistry(myMeterRegistry)
                 .build();
-       myMetericInspector = new MetricInspector(myMeterRegistry,
+        myMetricInspector = new MetricInspector(myMeterRegistry,
                 1, 1);
     }
 
@@ -88,7 +79,7 @@ public class TestMetricInspector
         TableReference tableReference1 = tableReference(TEST_KEYSPACE, TEST_TABLE1);
         expectedRepairTime = 12345L;
         myTableRepairMetricsImpl.repairSession(tableReference, expectedRepairTime, TimeUnit.MILLISECONDS, false);
-        myMetericInspector.inspectMeterRegistryForRepairFailures();
+        myMetricInspector.inspectMeterRegistryForRepairFailures();
         List<ILoggingEvent> logsList = listAppender.list;
         long count = logsList.stream().count();
         String logMessage = logsList.get(0).getFormattedMessage();
@@ -104,7 +95,7 @@ public class TestMetricInspector
         TableReference tableReference = tableReference(TEST_KEYSPACE, TEST_TABLE1);
         long expectedRepairTime = 12345L;
         myTableRepairMetricsImpl.repairSession(tableReference, expectedRepairTime, TimeUnit.MILLISECONDS, false);
-        myMetericInspector.inspectMeterRegistryForRepairFailures();
+        myMetricInspector.inspectMeterRegistryForRepairFailures();
         List<ILoggingEvent> logsList = listAppender.list;
         long count = logsList.stream().count();
         assertEquals(0, count);
@@ -113,14 +104,14 @@ public class TestMetricInspector
     @Test
     public void testStartInspectionMethod() throws InterruptedException
     {
-        assertEquals(0,myMetericInspector.getMyTotalRecordFailures());
+        assertEquals(0, myMetricInspector.getTotalRecordFailures());
         TableReference tableReference = tableReference(TEST_KEYSPACE, TEST_TABLE1);
         long expectedRepairTime = 12345L;
         myTableRepairMetricsImpl.repairSession(tableReference, expectedRepairTime, TimeUnit.MILLISECONDS, false);
         TableReference tableReference1 = tableReference(TEST_KEYSPACE, TEST_TABLE1);
         myTableRepairMetricsImpl.repairSession(tableReference, expectedRepairTime, TimeUnit.MILLISECONDS, false);
         List<ILoggingEvent> logsList = listAppender.list;
-        myMetericInspector.startInspection();
+        myMetricInspector.startInspection();
         Thread.sleep(5000);
         long count = logsList.stream().count();
         String logMessage = logsList.get(0).getFormattedMessage();
@@ -128,7 +119,7 @@ public class TestMetricInspector
         assertEquals("Total repair failures in node till now is: 2", logMessage);
         assertEquals(Level.DEBUG, logLevel);
         assertEquals(1, count);
-        assertEquals(2,myMetericInspector.getMyTotalRecordFailures());
-        myMetericInspector.stopInspection();
+        assertEquals(2, myMetricInspector.getTotalRecordFailures());
+        myMetricInspector.stopInspection();
     }
 }

--- a/core/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/metrics/TestMetricInspector.java
+++ b/core/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/metrics/TestMetricInspector.java
@@ -67,7 +67,7 @@ public class TestMetricInspector
                 .withMeterRegistry(myMeterRegistry)
                 .build();
         myMetricInspector = new MetricInspector(myMeterRegistry,
-                1, 1);
+                1, 1,5000);
     }
 
     @Test

--- a/core/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/metrics/TestMetricInspector.java
+++ b/core/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/metrics/TestMetricInspector.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2024 Telefonaktiebolaget LM Ericsson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ericsson.bss.cassandra.ecchronos.core.metrics;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import com.ericsson.bss.cassandra.ecchronos.core.TableStorageStates;
+import com.ericsson.bss.cassandra.ecchronos.core.utils.StatusLogger;
+import com.ericsson.bss.cassandra.ecchronos.core.utils.TableReference;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.slf4j.LoggerFactory;
+
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TimerTask;
+import java.util.concurrent.TimeUnit;
+
+import static com.ericsson.bss.cassandra.ecchronos.core.MockTableReferenceFactory.tableReference;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class TestMetricInspector {
+
+    private static final String TEST_KEYSPACE = "test_keyspace";
+    private static final String TEST_TABLE1 = "test_table1";
+    private static final String TEST_TABLE2 = "test_table2";
+    @Mock
+    private TableStorageStates myTableStorageStates;
+
+
+    private MeterRegistry myMeterRegistry;
+    private TableRepairMetricsImpl myTableRepairMetricsImpl;
+
+    private MetricInspector myMetericInspector;
+
+    private LoggerContext loggerContext;
+    private ListAppender<ILoggingEvent> listAppender;
+
+
+
+
+    @Before
+    public void init() {
+        loggerContext = (LoggerContext) LoggerFactory.getILoggerFactory();
+        listAppender = new ListAppender<>();
+        listAppender.start();
+        loggerContext.getLogger(StatusLogger.class).addAppender(listAppender);
+        // Use composite registry here to simulate real world scenario where we have multiple registries
+        CompositeMeterRegistry compositeMeterRegistry = new CompositeMeterRegistry();
+        // Need at least one registry present in composite to record metrics
+        compositeMeterRegistry.add(new SimpleMeterRegistry());
+       myMeterRegistry = compositeMeterRegistry;
+        myTableRepairMetricsImpl = TableRepairMetricsImpl.builder()
+                .withTableStorageStates(myTableStorageStates)
+                .withMeterRegistry(myMeterRegistry)
+                .build();
+        myMetericInspector = new MetricInspector(myMeterRegistry,
+                1, 1);
+
+
+    }
+
+    @Test
+    public void testInspectMeterRegistryForRepairFailuresWhenFailureThresholdIsBroken()
+    {
+        TableReference tableReference = tableReference(TEST_KEYSPACE, TEST_TABLE1);
+        long expectedRepairTime = 12345L;
+        myTableRepairMetricsImpl.repairSession(tableReference, expectedRepairTime, TimeUnit.MILLISECONDS, false);
+        TableReference tableReference1 = tableReference(TEST_KEYSPACE, TEST_TABLE1);
+        expectedRepairTime = 12345L;
+        myTableRepairMetricsImpl.repairSession(tableReference, expectedRepairTime, TimeUnit.MILLISECONDS, false);
+
+        myMetericInspector.inspectMeterRegistryForRepairFailures();
+
+
+        List<ILoggingEvent> logsList = listAppender.list;
+
+        long count = logsList.stream()
+                .count();
+
+        String logMessage = logsList.get(0).getFormattedMessage();
+        Level logLevel = logsList.get(0).getLevel();
+        assertEquals("Total repair failures in node till now is: 2", logMessage);
+        assertEquals(Level.DEBUG, logLevel);
+        assertEquals(1, count);
+    }
+
+    @Test
+    public void testInspectMeterRegistryForRepairFailuresWhenFailureThresholdIsIntact()
+    {
+        TableReference tableReference = tableReference(TEST_KEYSPACE, TEST_TABLE1);
+        long expectedRepairTime = 12345L;
+        myTableRepairMetricsImpl.repairSession(tableReference, expectedRepairTime, TimeUnit.MILLISECONDS, false);
+
+        myMetericInspector.inspectMeterRegistryForRepairFailures();
+
+
+        List<ILoggingEvent> logsList = listAppender.list;
+
+        long count = logsList.stream()
+                .count();
+
+       assertEquals(0, count);
+    }
+
+}

--- a/core/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/metrics/TestMetricInspector.java
+++ b/core/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/metrics/TestMetricInspector.java
@@ -42,6 +42,7 @@ public class TestMetricInspector
     private static final String TEST_KEYSPACE = "test_keyspace";
     private static final String TEST_TABLE1 = "test_table1";
     private static final String TEST_TABLE2 = "test_table2";
+
     @Mock
     private TableStorageStates myTableStorageStates;
     private MeterRegistry myMeterRegistry;
@@ -57,28 +58,22 @@ public class TestMetricInspector
         listAppender = new ListAppender<>();
         listAppender.start();
         loggerContext.getLogger(StatusLogger.class).addAppender(listAppender);
-        // Use composite registry here to simulate real world scenario where we have multiple registries
         CompositeMeterRegistry compositeMeterRegistry = new CompositeMeterRegistry();
-        // Need at least one registry present in composite to record metrics
         compositeMeterRegistry.add(new SimpleMeterRegistry());
         myMeterRegistry = compositeMeterRegistry;
         myTableRepairMetricsImpl = TableRepairMetricsImpl.builder()
                 .withTableStorageStates(myTableStorageStates)
                 .withMeterRegistry(myMeterRegistry)
                 .build();
-        myMetricInspector = new MetricInspector(myMeterRegistry,
-                1, 1,5000);
-    }
+        myMetricInspector = new MetricInspector(myMeterRegistry, 1,  1, 5000);    }
 
     @Test
     public void testInspectMeterRegistryForRepairFailuresWhenFailureThresholdIsBroken()
     {
-        TableReference tableReference = tableReference(TEST_KEYSPACE, TEST_TABLE1);
-        long expectedRepairTime = 12345L;
-        myTableRepairMetricsImpl.repairSession(tableReference, expectedRepairTime, TimeUnit.MILLISECONDS, false);
         TableReference tableReference1 = tableReference(TEST_KEYSPACE, TEST_TABLE1);
-        expectedRepairTime = 12345L;
-        myTableRepairMetricsImpl.repairSession(tableReference, expectedRepairTime, TimeUnit.MILLISECONDS, false);
+        long expectedRepairTime = 12345L;
+        myTableRepairMetricsImpl.repairSession(tableReference1, expectedRepairTime, TimeUnit.MILLISECONDS, false);
+        myTableRepairMetricsImpl.repairSession(tableReference1, expectedRepairTime, TimeUnit.MILLISECONDS, false);
         myMetricInspector.inspectMeterRegistryForRepairFailures();
         List<ILoggingEvent> logsList = listAppender.list;
         long count = logsList.stream().count();
@@ -105,11 +100,10 @@ public class TestMetricInspector
     public void testStartInspectionMethod() throws InterruptedException
     {
         assertEquals(0, myMetricInspector.getTotalRecordFailures());
-        TableReference tableReference = tableReference(TEST_KEYSPACE, TEST_TABLE1);
-        long expectedRepairTime = 12345L;
-        myTableRepairMetricsImpl.repairSession(tableReference, expectedRepairTime, TimeUnit.MILLISECONDS, false);
         TableReference tableReference1 = tableReference(TEST_KEYSPACE, TEST_TABLE1);
-        myTableRepairMetricsImpl.repairSession(tableReference, expectedRepairTime, TimeUnit.MILLISECONDS, false);
+        long expectedRepairTime = 12345L;
+        myTableRepairMetricsImpl.repairSession(tableReference1, expectedRepairTime, TimeUnit.MILLISECONDS, false);
+        myTableRepairMetricsImpl.repairSession(tableReference1, expectedRepairTime, TimeUnit.MILLISECONDS, false);
         List<ILoggingEvent> logsList = listAppender.list;
         myMetricInspector.startInspection();
         Thread.sleep(5000);

--- a/core/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/utils/TestStatusLogger.java
+++ b/core/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/utils/TestStatusLogger.java
@@ -113,13 +113,12 @@ public class TestStatusLogger
     {
         TableReference tableReference = tableReference(TEST_KEYSPACE, TEST_TABLE1);
         myTableRepairMetricsImpl.repairState(tableReference, 1, 0);
-        // Call the method to be tested
         StatusLogger.log(myMeterRegistry);
         List<ILoggingEvent> logsList = listAppender.list;
         long count = logsList.stream().count();
         String logMessage = logsList.get(0).getFormattedMessage();
         Level logLevel = logsList.get(0).getLevel();
-        assertEquals("Node Repair Ratio is: 1.0", logMessage);
+        assertEquals("Node repair ratio is: 1.0", logMessage);
         assertEquals(Level.DEBUG, logLevel);
         assertEquals(1, count);
     }
@@ -151,16 +150,16 @@ public class TestStatusLogger
     {
         TableReference tableReference1 = tableReference(TEST_KEYSPACE, TEST_TABLE1);
         TableReference tableReference2 = tableReference(TEST_KEYSPACE, TEST_TABLE2);
-        long expectedRemainingRepairTime = 10L;
+        long expectedRemainingRepairTime1 = 10L;
         long expectedRemainingRepairTime2 = 20L;
-        myTableRepairMetricsImpl.remainingRepairTime(tableReference1, expectedRemainingRepairTime);
+        myTableRepairMetricsImpl.remainingRepairTime(tableReference1, expectedRemainingRepairTime1);
         myTableRepairMetricsImpl.remainingRepairTime(tableReference2, expectedRemainingRepairTime2);
         StatusLogger.log(myMeterRegistry);
         List<ILoggingEvent> logsList = listAppender.list;
         long count = logsList.stream().count();
         String logMessage = logsList.get(0).getFormattedMessage();
         Level logLevel = logsList.get(0).getLevel();
-        Double expectedRepairTime = (double) (expectedRemainingRepairTime+expectedRemainingRepairTime2) / 1000;
+        Double expectedRepairTime = (double) (expectedRemainingRepairTime1 + expectedRemainingRepairTime2) / 1000;
         assertEquals("Remaining time for node repair: ".concat(expectedRepairTime.toString()), logMessage);
         assertEquals(Level.DEBUG, logLevel);
         assertEquals(1, count);

--- a/core/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/utils/TestStatusLogger.java
+++ b/core/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/utils/TestStatusLogger.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright 2024 Telefonaktiebolaget LM Ericsson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ericsson.bss.cassandra.ecchronos.core.utils;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import com.ericsson.bss.cassandra.ecchronos.core.TableStorageStates;
+import com.ericsson.bss.cassandra.ecchronos.core.metrics.TableRepairMetricsImpl;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static com.ericsson.bss.cassandra.ecchronos.core.MockTableReferenceFactory.tableReference;
+import static org.junit.Assert.assertEquals;
+
+@RunWith(MockitoJUnitRunner.class)
+public class TestStatusLogger
+{
+    private static final String TEST_KEYSPACE = "test_keyspace";
+    private static final String TEST_TABLE1 = "test_table1";
+    private static final String TEST_TABLE2 = "test_table2";
+    @Mock
+    private TableStorageStates myTableStorageStates;
+    private MeterRegistry myMeterRegistry;
+    private TableRepairMetricsImpl myTableRepairMetricsImpl;
+
+    private LoggerContext loggerContext;
+    private ListAppender<ILoggingEvent> listAppender;
+
+    @Before
+    public void init() {
+        loggerContext = (LoggerContext) LoggerFactory.getILoggerFactory();
+        listAppender = new ListAppender<>();
+        listAppender.start();
+        loggerContext.getLogger(StatusLogger.class).addAppender(listAppender);
+        // Use composite registry here to simulate real world scenario where we have multiple registries
+        CompositeMeterRegistry compositeMeterRegistry = new CompositeMeterRegistry();
+        // Need at least one registry present in composite to record metrics
+        compositeMeterRegistry.add(new SimpleMeterRegistry());
+        myMeterRegistry = compositeMeterRegistry;
+        myTableRepairMetricsImpl = TableRepairMetricsImpl.builder()
+                .withTableStorageStates(myTableStorageStates)
+                .withMeterRegistry(myMeterRegistry)
+                .build();
+    }
+
+    @After
+    public void cleanup() {
+        myMeterRegistry.close();
+        myTableRepairMetricsImpl.close();
+    }
+
+    @Test
+    public void testLogForFailedRepairSessionCountLogs() {
+        TableReference tableReference = tableReference(TEST_KEYSPACE, TEST_TABLE1);
+        long expectedRepairTime = 12345L;
+        myTableRepairMetricsImpl.repairSession(tableReference, expectedRepairTime, TimeUnit.MILLISECONDS, false);
+
+        StatusLogger.log(myMeterRegistry);
+
+        List<ILoggingEvent> logsList = listAppender.list;
+
+        long count = logsList.stream()
+                .count();
+
+        String logMessage = logsList.get(0).getFormattedMessage();
+        Level logLevel = logsList.get(0).getLevel();
+        assertEquals("Total repair failures in node till now is: 1", logMessage);
+        assertEquals(Level.DEBUG, logLevel);
+        assertEquals(1, count);
+    }
+
+    @Test
+    public void testLogForSuccessfulRepairSessionCountLogs()
+    {
+        TableReference tableReference = tableReference(TEST_KEYSPACE, TEST_TABLE1);
+        long expectedRepairTime = 12345L;
+        myTableRepairMetricsImpl.repairSession(tableReference, expectedRepairTime, TimeUnit.MILLISECONDS, true);
+
+        StatusLogger.log(myMeterRegistry);
+
+
+        List<ILoggingEvent> logsList = listAppender.list;
+
+        long count = logsList.stream()
+                .count();
+
+        String logMessage = logsList.get(0).getFormattedMessage();
+        Level logLevel = logsList.get(0).getLevel();
+        assertEquals("Total repair success in node till now is:1", logMessage);
+        assertEquals(Level.DEBUG, logLevel);
+        assertEquals(1, count);
+    }
+
+    @Test
+    public void testLogForRepairedRatioStatusLogs()
+    {
+        TableReference tableReference = tableReference(TEST_KEYSPACE, TEST_TABLE1);
+        myTableRepairMetricsImpl.repairState(tableReference, 1, 0);
+        // Call the method to be tested
+        StatusLogger.log(myMeterRegistry);
+
+        List<ILoggingEvent> logsList = listAppender.list;
+
+        long count = logsList.stream()
+                .count();
+
+        String logMessage = logsList.get(0).getFormattedMessage();
+        Level logLevel = logsList.get(0).getLevel();
+        assertEquals("Node Repair Ratio is :: 1.0", logMessage);
+        assertEquals(Level.DEBUG, logLevel);
+        assertEquals(1, count);
+
+    }
+
+@Test
+public void testLogForLastRepairedAtStatusLogs()
+    {
+        TableReference tableReference = tableReference(TEST_KEYSPACE, TEST_TABLE1);
+        TableReference tableReference2 = tableReference(TEST_KEYSPACE, TEST_TABLE2);
+        long timeNow = System.currentTimeMillis();
+
+        long timeDiff = 1000L;
+        long expectedLastRepaired = timeNow - timeDiff;
+        long timeDiff2 = 5000L;
+        long expectedLastRepaired2 = timeNow - timeDiff2;
+
+        myTableRepairMetricsImpl.lastRepairedAt(tableReference, expectedLastRepaired);
+        myTableRepairMetricsImpl.lastRepairedAt(tableReference2, expectedLastRepaired2);
+        StatusLogger.log(myMeterRegistry);
+        List<ILoggingEvent> logsList = listAppender.list;
+
+        long count = logsList.stream()
+                .count();
+
+        String logMessage = logsList.get(0).getFormattedMessage();
+        Level logLevel = logsList.get(0).getLevel();
+        assertEquals("Node last repaired at",logMessage.substring(0, 21));
+        assertEquals(Level.DEBUG, logLevel);
+        assertEquals(1, count);
+    }
+
+    @Test
+    public void testLogForNodeRemainingRepairTimeStatusLogs()
+    {
+        TableReference tableReference = tableReference(TEST_KEYSPACE, TEST_TABLE1);
+        TableReference tableReference2 = tableReference(TEST_KEYSPACE, TEST_TABLE2);
+        long expectedRemainingRepairTime = 10L;
+        long expectedRemainingRepairTime2 = 20L;
+
+        myTableRepairMetricsImpl.remainingRepairTime(tableReference, expectedRemainingRepairTime);
+        myTableRepairMetricsImpl.remainingRepairTime(tableReference2, expectedRemainingRepairTime2);
+        StatusLogger.log(myMeterRegistry);
+        List<ILoggingEvent> logsList = listAppender.list;
+
+        long count = logsList.stream()
+                .count();
+
+        String logMessage = logsList.get(0).getFormattedMessage();
+        Level logLevel = logsList.get(0).getLevel();
+        Double expectedRepairTime = (double) (expectedRemainingRepairTime+expectedRemainingRepairTime2)/1000;
+        assertEquals("Remaining time for node repair :".concat(expectedRepairTime.toString()),logMessage);
+        assertEquals(Level.DEBUG, logLevel);
+        assertEquals(1, count);
+    }
+
+
+}
+
+

--- a/core/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/utils/TestStatusLogger.java
+++ b/core/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/utils/TestStatusLogger.java
@@ -69,7 +69,8 @@ public class TestStatusLogger
     }
 
     @After
-    public void cleanup() {
+    public void cleanup()
+    {
         myMeterRegistry.close();
         myTableRepairMetricsImpl.close();
     }
@@ -79,14 +80,9 @@ public class TestStatusLogger
         TableReference tableReference = tableReference(TEST_KEYSPACE, TEST_TABLE1);
         long expectedRepairTime = 12345L;
         myTableRepairMetricsImpl.repairSession(tableReference, expectedRepairTime, TimeUnit.MILLISECONDS, false);
-
         StatusLogger.log(myMeterRegistry);
-
         List<ILoggingEvent> logsList = listAppender.list;
-
-        long count = logsList.stream()
-                .count();
-
+        long count = logsList.stream().count();
         String logMessage = logsList.get(0).getFormattedMessage();
         Level logLevel = logsList.get(0).getLevel();
         assertEquals("Total repair failures in node till now is: 1", logMessage);
@@ -100,15 +96,9 @@ public class TestStatusLogger
         TableReference tableReference = tableReference(TEST_KEYSPACE, TEST_TABLE1);
         long expectedRepairTime = 12345L;
         myTableRepairMetricsImpl.repairSession(tableReference, expectedRepairTime, TimeUnit.MILLISECONDS, true);
-
         StatusLogger.log(myMeterRegistry);
-
-
         List<ILoggingEvent> logsList = listAppender.list;
-
-        long count = logsList.stream()
-                .count();
-
+        long count = logsList.stream().count();
         String logMessage = logsList.get(0).getFormattedMessage();
         Level logLevel = logsList.get(0).getLevel();
         assertEquals("Total repair success in node till now is:1", logMessage);
@@ -123,12 +113,8 @@ public class TestStatusLogger
         myTableRepairMetricsImpl.repairState(tableReference, 1, 0);
         // Call the method to be tested
         StatusLogger.log(myMeterRegistry);
-
         List<ILoggingEvent> logsList = listAppender.list;
-
-        long count = logsList.stream()
-                .count();
-
+        long count = logsList.stream().count();
         String logMessage = logsList.get(0).getFormattedMessage();
         Level logLevel = logsList.get(0).getLevel();
         assertEquals("Node Repair Ratio is :: 1.0", logMessage);
@@ -143,20 +129,15 @@ public void testLogForLastRepairedAtStatusLogs()
         TableReference tableReference = tableReference(TEST_KEYSPACE, TEST_TABLE1);
         TableReference tableReference2 = tableReference(TEST_KEYSPACE, TEST_TABLE2);
         long timeNow = System.currentTimeMillis();
-
         long timeDiff = 1000L;
         long expectedLastRepaired = timeNow - timeDiff;
         long timeDiff2 = 5000L;
         long expectedLastRepaired2 = timeNow - timeDiff2;
-
         myTableRepairMetricsImpl.lastRepairedAt(tableReference, expectedLastRepaired);
         myTableRepairMetricsImpl.lastRepairedAt(tableReference2, expectedLastRepaired2);
         StatusLogger.log(myMeterRegistry);
         List<ILoggingEvent> logsList = listAppender.list;
-
-        long count = logsList.stream()
-                .count();
-
+        long count = logsList.stream().count();
         String logMessage = logsList.get(0).getFormattedMessage();
         Level logLevel = logsList.get(0).getLevel();
         assertEquals("Node last repaired at",logMessage.substring(0, 21));
@@ -171,15 +152,11 @@ public void testLogForLastRepairedAtStatusLogs()
         TableReference tableReference2 = tableReference(TEST_KEYSPACE, TEST_TABLE2);
         long expectedRemainingRepairTime = 10L;
         long expectedRemainingRepairTime2 = 20L;
-
         myTableRepairMetricsImpl.remainingRepairTime(tableReference, expectedRemainingRepairTime);
         myTableRepairMetricsImpl.remainingRepairTime(tableReference2, expectedRemainingRepairTime2);
         StatusLogger.log(myMeterRegistry);
         List<ILoggingEvent> logsList = listAppender.list;
-
-        long count = logsList.stream()
-                .count();
-
+        long count = logsList.stream().count();
         String logMessage = logsList.get(0).getFormattedMessage();
         Level logLevel = logsList.get(0).getLevel();
         Double expectedRepairTime = (double) (expectedRemainingRepairTime+expectedRemainingRepairTime2)/1000;
@@ -187,8 +164,6 @@ public void testLogForLastRepairedAtStatusLogs()
         assertEquals(Level.DEBUG, logLevel);
         assertEquals(1, count);
     }
-
-
 }
 
 

--- a/core/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/utils/TestStatusLogger.java
+++ b/core/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/utils/TestStatusLogger.java
@@ -52,7 +52,8 @@ public class TestStatusLogger
     private ListAppender<ILoggingEvent> listAppender;
 
     @Before
-    public void init() {
+    public void init()
+    {
         loggerContext = (LoggerContext) LoggerFactory.getILoggerFactory();
         listAppender = new ListAppender<>();
         listAppender.start();
@@ -76,7 +77,8 @@ public class TestStatusLogger
     }
 
     @Test
-    public void testLogForFailedRepairSessionCountLogs() {
+    public void testLogForFailedRepairSessionCountLogs()
+    {
         TableReference tableReference = tableReference(TEST_KEYSPACE, TEST_TABLE1);
         long expectedRepairTime = 12345L;
         myTableRepairMetricsImpl.repairSession(tableReference, expectedRepairTime, TimeUnit.MILLISECONDS, false);
@@ -101,7 +103,7 @@ public class TestStatusLogger
         long count = logsList.stream().count();
         String logMessage = logsList.get(0).getFormattedMessage();
         Level logLevel = logsList.get(0).getLevel();
-        assertEquals("Total repair success in node till now is:1", logMessage);
+        assertEquals("Total repair success in node till now is: 1", logMessage);
         assertEquals(Level.DEBUG, logLevel);
         assertEquals(1, count);
     }
@@ -117,30 +119,29 @@ public class TestStatusLogger
         long count = logsList.stream().count();
         String logMessage = logsList.get(0).getFormattedMessage();
         Level logLevel = logsList.get(0).getLevel();
-        assertEquals("Node Repair Ratio is :: 1.0", logMessage);
+        assertEquals("Node Repair Ratio is: 1.0", logMessage);
         assertEquals(Level.DEBUG, logLevel);
         assertEquals(1, count);
-
     }
 
-@Test
-public void testLogForLastRepairedAtStatusLogs()
+    @Test
+    public void testLogForLastRepairedAtStatusLogs()
     {
-        TableReference tableReference = tableReference(TEST_KEYSPACE, TEST_TABLE1);
+        TableReference tableReference1 = tableReference(TEST_KEYSPACE, TEST_TABLE1);
         TableReference tableReference2 = tableReference(TEST_KEYSPACE, TEST_TABLE2);
         long timeNow = System.currentTimeMillis();
-        long timeDiff = 1000L;
-        long expectedLastRepaired = timeNow - timeDiff;
+        long timeDiff1 = 1000L;
+        long expectedLastRepaired1 = timeNow - timeDiff1;
         long timeDiff2 = 5000L;
         long expectedLastRepaired2 = timeNow - timeDiff2;
-        myTableRepairMetricsImpl.lastRepairedAt(tableReference, expectedLastRepaired);
+        myTableRepairMetricsImpl.lastRepairedAt(tableReference1, expectedLastRepaired1);
         myTableRepairMetricsImpl.lastRepairedAt(tableReference2, expectedLastRepaired2);
         StatusLogger.log(myMeterRegistry);
         List<ILoggingEvent> logsList = listAppender.list;
         long count = logsList.stream().count();
         String logMessage = logsList.get(0).getFormattedMessage();
         Level logLevel = logsList.get(0).getLevel();
-        assertEquals("Node last repaired at",logMessage.substring(0, 21));
+        assertEquals("Node last repaired at", logMessage.substring(0, 21));
         assertEquals(Level.DEBUG, logLevel);
         assertEquals(1, count);
     }
@@ -148,22 +149,20 @@ public void testLogForLastRepairedAtStatusLogs()
     @Test
     public void testLogForNodeRemainingRepairTimeStatusLogs()
     {
-        TableReference tableReference = tableReference(TEST_KEYSPACE, TEST_TABLE1);
+        TableReference tableReference1 = tableReference(TEST_KEYSPACE, TEST_TABLE1);
         TableReference tableReference2 = tableReference(TEST_KEYSPACE, TEST_TABLE2);
         long expectedRemainingRepairTime = 10L;
         long expectedRemainingRepairTime2 = 20L;
-        myTableRepairMetricsImpl.remainingRepairTime(tableReference, expectedRemainingRepairTime);
+        myTableRepairMetricsImpl.remainingRepairTime(tableReference1, expectedRemainingRepairTime);
         myTableRepairMetricsImpl.remainingRepairTime(tableReference2, expectedRemainingRepairTime2);
         StatusLogger.log(myMeterRegistry);
         List<ILoggingEvent> logsList = listAppender.list;
         long count = logsList.stream().count();
         String logMessage = logsList.get(0).getFormattedMessage();
         Level logLevel = logsList.get(0).getLevel();
-        Double expectedRepairTime = (double) (expectedRemainingRepairTime+expectedRemainingRepairTime2)/1000;
-        assertEquals("Remaining time for node repair :".concat(expectedRepairTime.toString()),logMessage);
+        Double expectedRepairTime = (double) (expectedRemainingRepairTime+expectedRemainingRepairTime2) / 1000;
+        assertEquals("Remaining time for node repair: ".concat(expectedRepairTime.toString()), logMessage);
         assertEquals(Level.DEBUG, logLevel);
         assertEquals(1, count);
     }
 }
-
-

--- a/core/src/test/resources/logback-test.xml
+++ b/core/src/test/resources/logback-test.xml
@@ -26,6 +26,7 @@
     <logger name="com.datastax" level="ERROR" />
     <logger name="com.github.benmanes.caffeine" level="ERROR" />
     <logger name="io.netty" level="WARN" />
+    <logger name="com.ericsson.bss.cassandra.ecchronos.core.utils.StatusLogger" level="DEBUG" />
 
     <root level="INFO">
         <appender-ref ref="STDOUT" />

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -743,3 +743,14 @@ repair_sessions_seconds_count{keyspace="ks1",successful="false",table="tbl1",} 7
 repair_sessions_seconds_sum{keyspace="ks1",successful="false",table="tbl1",} 5.317104685
 repair_sessions_seconds_max{keyspace="ks1",successful="false",table="tbl1",} 0.0
 ```
+
+## Metric Status Logger
+Whenever metric is enabled, a logger is triggered which monitors metrics for
+repair failures within a defined time window. If number of repair failures 
+overshoot the number(`repair_failures_count`) configured in ecc.yml within a time
+window then ecchronos metrics are printed in debug logs. 
+
+Repair failures threshold is handled by a property `statistics.repair_failures_count`. The
+time window can be configured via `statistics.repair_failures_time_window`. There is
+another field `statistics.trigger_interval_for_metric_inspection` which is used for controlling
+the repeat time in which metric inspection will take place.

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -745,9 +745,9 @@ repair_sessions_seconds_max{keyspace="ks1",successful="false",table="tbl1",} 0.0
 ```
 
 ## Metric Status Logger
-Whenever metric is enabled, a logger is triggered which monitors metrics for
+Whenever metric is enabled, a logger is triggered which monitor metrics for
 repair failures within a defined time window. If number of repair failures 
-overshoot the number(`repair_failures_count`) configured in ecc.yml within a time
+overshoot the number(`repair_failures_count`) configured in ecc.yml within the time
 window then ecchronos metrics are printed in debug logs. 
 
 Repair failures threshold is handled by a property `statistics.repair_failures_count`. The

--- a/docs/autogenerated/EccYamlFile.md
+++ b/docs/autogenerated/EccYamlFile.md
@@ -270,7 +270,7 @@
 #
 # Time window in minutes over which to track repair failures in node for trigger status logger messages in debug log
 #
-* repair_failure_time_window: 30
+* repair_failures_time_window_in_minutes: 30
 
 
 **lock_factory:**

--- a/docs/autogenerated/EccYamlFile.md
+++ b/docs/autogenerated/EccYamlFile.md
@@ -268,10 +268,18 @@
 #
 * repair_failures_count: 5
 #
-# Time window in minutes over which to track repair failures in node for trigger status logger messages in debug log
+# Time window over which to track repair failures in node for trigger status logger messages in debug log
 #
-* repair_failures_time_window_in_minutes: 30
-
+**repair_failures_time_window:**
+* time: 30
+* unit: minutes
+#
+# Trigger interval for metric inspection.
+# This time should always be lesser than repair_failures_time_window
+#
+**trigger_interval_for_metric_inspection:**
+* time: 5
+* unit: seconds
 
 **lock_factory:**
 **cas:**

--- a/docs/autogenerated/EccYamlFile.md
+++ b/docs/autogenerated/EccYamlFile.md
@@ -84,7 +84,7 @@
 * unit: days
 #
 # Initial delay for new tables. New tables are always assumed to have been repaired in the past, however a delay
-#  can be set for the first repair. This will not affect subsequent repairs and defaults to one day.
+# can be set for the first repair. This will not affect subsequent repairs and defaults to one day.
 #
 **initial_delay:**
 * time: 1
@@ -262,6 +262,16 @@
 # The prefix cannot start or end with a dot or any other path separator.
 #
 * prefix: ''
+#
+# Number of repair failures before status logger logs metrics in debug logs
+# The number is used to trigger a status once number of failures is breached in a time window mentioned below
+#
+* repair_failures_count: 5
+#
+# Time window in minutes over which to track repair failures in node for trigger status logger messages in debug log
+#
+* repair_failure_time_window: 30
+
 
 **lock_factory:**
 **cas:**


### PR DESCRIPTION
Metric inspector to read metrices every 5 seconds. It will check if number of failed repairs in a time window (default 30 minutes) exceed to that configured value in yaml file. If identifies that there are these many repairs in defined time window, then debug messages are printed with some of the metrices,showing status of the system at that moment. Also the timewindow is reconfigured to start next time window.