### PR TITLE
chore: update/tune dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,31 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Europe/Stockholm"
+    # Create a group of dependencies to lower amount of PRs
+    groups:
+      maven-dep:
+        applies-to: version-updates # Applies the group rule to version updates
+        update-types:
+        - "minor"
+        - "patch"
+      maven-security:
+        applies-to: security-updates # Applies the group rule to security updates
+        update-types:
+        - "minor"
+        - "patch"
+    # Ignore a major version update to avoid breaking changes
+    ignore:
+      - dependency-name: "*"
+        update-types:
+        - "version-update:semver-major"
+
   - package-ecosystem: "github-actions" # See documentation for possible values
-    directory: "/" # Location of package manifests
+    directory: "/.github/" # Location of package manifests
     schedule:
       interval: "weekly"
+      day: "wednesday"
+      time: "09:00"
+      timezone: "Europe/Stockholm"


### PR DESCRIPTION
Since dependabot was added by PR #786 it was a huge inflow of PRs generated by the bot, and aim of this PR is to improve flow of dependency updates a little bit.

To do so, I propose:

- Group dependencies to reduce the number of PRs;
- Limit updates to minor and patch versions to avoid breaking changes in the major update;
- Update the schedule to check for updates every week with shift between dependency types:
  - Monday at 9:00 AM for Maven dependencies
  - Wednesday at 9:00 AM for GitHub actions.

So, instead of multiple PRs it will be a single PR with version-updates limited to minor and patch versions of all updated dependency, major updates that may have backward incomatiable will be not included. Security updates will be handled separately (and gripped, where it possible, except critical vulnerabilities that will be handled as separate PR).

Reference: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file