### PR TITLE
Added support for parallel vnode repair

### DIFF
--- a/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/vnode/VnodeRepairTask.java
+++ b/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/vnode/VnodeRepairTask.java
@@ -167,13 +167,13 @@ public class VnodeRepairTask extends RepairTask
     }
 
     @VisibleForTesting
-    final Set<LongTokenRange> getTokenRanges()
+    public final Set<LongTokenRange> getTokenRanges()
     {
         return Sets.newLinkedHashSet(myTokenRanges);
     }
 
     @VisibleForTesting
-    final Set<DriverNode> getReplicas()
+    public final Set<DriverNode> getReplicas()
     {
         return Sets.newHashSet(myReplicas);
     }


### PR DESCRIPTION
- Iterates through all token ranges in the replica repair group
- Adds each range to the combinedRanges set
- Create one vnode repair task for all combinedRanges
- Create one repair session per range in collection and start each session