### PR TITLE
Implement Dynamic Jolokia Notification Listener

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -41,6 +41,15 @@ jobs:
         with:
           java-version: 17
           distribution: 'temurin'
+      - name: Download and install custom dependency
+        run: |
+          curl -L -o jolokia-jmx-adapter-2.1.1.jar https://search.maven.org/remotecontent?filepath=org/jolokia/jolokia-client-jmx-adapter/2.1.1/jolokia-client-jmx-adapter-2.1.1.jar
+          mvn install:install-file \
+            -Dfile=jolokia-jmx-adapter-2.1.1.jar \
+            -DgroupId=org.jolokia \
+            -DartifactId=jolokia-jmx-adapter \
+            -Dversion=2.1.1 \
+            -Dpackaging=jar
       - name: install dependencies
         run: mvn install -Pbuild-cassandra-test-jar -DskipTests=true
       - run: mvn $TEST_SUITE -B

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Version 1.0.0 (Not yet Released)
 
+* Reconcile Jolokia Notification Listener Implementation with RepairTask - Issue #831
 * Introduce REST Module for Scheduling and Managing Cassandra Repairs - Issue #771
 * Create On Demand Repair Job on Agent - Issue #775
 * Modify DistributedNativeConnectionProvider to Return a Map<UUID, Node> - Issue #778

--- a/application/src/main/java/com/ericsson/bss/cassandra/ecchronos/application/spring/ECChronosInternals.java
+++ b/application/src/main/java/com/ericsson/bss/cassandra/ecchronos/application/spring/ECChronosInternals.java
@@ -66,6 +66,8 @@ public class ECChronosInternals implements Closeable
                 .withJmxConnectionProvider(jmxConnectionProvider)
                 .withEccNodesSync(eccNodesSync)
                 .withNodesMap(nativeConnectionProvider.getNodes())
+                .withJolokiaEnabled(configuration
+                        .getConnectionConfig().getJmxConnection().getJolokiaConfig().isEnabled())
                 .build();
 
         CqlSession session = nativeConnectionProvider.getCqlSession();

--- a/connection.impl/pom.xml
+++ b/connection.impl/pom.xml
@@ -49,7 +49,24 @@
 
         <dependency>
             <groupId>org.jolokia</groupId>
-            <artifactId>jolokia-jsr160</artifactId>
+            <artifactId>jolokia-jmx-adapter</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jolokia</groupId>
+            <artifactId>jolokia-service-jmx</artifactId>
+            <version>${jolokia.adapter.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jolokia</groupId>
+            <artifactId>jolokia-service-serializer</artifactId>
+            <version>${jolokia.adapter.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jolokia</groupId>
+            <artifactId>jolokia-client-java</artifactId>
+            <version>${jolokia.adapter.version}</version>
         </dependency>
 
         <!-- Cassandra driver -->

--- a/connection.impl/pom.xml
+++ b/connection.impl/pom.xml
@@ -55,18 +55,15 @@
         <dependency>
             <groupId>org.jolokia</groupId>
             <artifactId>jolokia-service-jmx</artifactId>
-            <version>${jolokia.adapter.version}</version>
         </dependency>
         <dependency>
             <groupId>org.jolokia</groupId>
             <artifactId>jolokia-service-serializer</artifactId>
-            <version>${jolokia.adapter.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.jolokia</groupId>
             <artifactId>jolokia-client-java</artifactId>
-            <version>${jolokia.adapter.version}</version>
         </dependency>
 
         <!-- Cassandra driver -->

--- a/core.impl/pom.xml
+++ b/core.impl/pom.xml
@@ -145,18 +145,15 @@
         <dependency>
             <groupId>org.jolokia</groupId>
             <artifactId>jolokia-service-jmx</artifactId>
-            <version>${jolokia.adapter.version}</version>
         </dependency>
         <dependency>
             <groupId>org.jolokia</groupId>
             <artifactId>jolokia-service-serializer</artifactId>
-            <version>${jolokia.adapter.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.jolokia</groupId>
             <artifactId>jolokia-client-java</artifactId>
-            <version>${jolokia.adapter.version}</version>
         </dependency>
     </dependencies>
 </project>

--- a/core.impl/pom.xml
+++ b/core.impl/pom.xml
@@ -136,5 +136,27 @@
             <groupId>nl.jqno.equalsverifier</groupId>
             <artifactId>equalsverifier</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>org.jolokia</groupId>
+            <artifactId>jolokia-jmx-adapter</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jolokia</groupId>
+            <artifactId>jolokia-service-jmx</artifactId>
+            <version>${jolokia.adapter.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jolokia</groupId>
+            <artifactId>jolokia-service-serializer</artifactId>
+            <version>${jolokia.adapter.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jolokia</groupId>
+            <artifactId>jolokia-client-java</artifactId>
+            <version>${jolokia.adapter.version}</version>
+        </dependency>
     </dependencies>
 </project>

--- a/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/jmx/DistributedJmxProxyFactoryImpl.java
+++ b/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/jmx/DistributedJmxProxyFactoryImpl.java
@@ -16,6 +16,9 @@ package com.ericsson.bss.cassandra.ecchronos.core.impl.jmx;
 
 import com.datastax.oss.driver.api.core.metadata.Node;
 import com.ericsson.bss.cassandra.ecchronos.connection.DistributedJmxConnectionProvider;
+import com.ericsson.bss.cassandra.ecchronos.core.impl.jmx.http.ClientRegisterResponse;
+import com.ericsson.bss.cassandra.ecchronos.core.impl.jmx.http.NotificationListenerResponse;
+import com.ericsson.bss.cassandra.ecchronos.core.impl.jmx.http.NotificationRegisterResponse;
 import com.ericsson.bss.cassandra.ecchronos.core.jmx.DistributedJmxProxy;
 import com.ericsson.bss.cassandra.ecchronos.core.jmx.DistributedJmxProxyFactory;
 import com.ericsson.bss.cassandra.ecchronos.core.table.TableReference;
@@ -23,11 +26,26 @@ import com.ericsson.bss.cassandra.ecchronos.core.table.TableReference;
 import com.ericsson.bss.cassandra.ecchronos.data.sync.EccNodesSync;
 import com.ericsson.bss.cassandra.ecchronos.utils.enums.sync.NodeStatus;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import java.util.ArrayList;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import javax.management.Notification;
 import javax.management.ObjectName;
 import java.io.IOException;
 
@@ -40,7 +58,12 @@ import javax.management.NotificationListener;
 import javax.management.ReflectionException;
 import javax.management.openmbean.CompositeData;
 import javax.management.remote.JMXConnector;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 
+import org.jolokia.client.J4pClient;
+import org.jolokia.client.request.J4pExecRequest;
+
+import org.jolokia.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -50,6 +73,7 @@ import org.slf4j.LoggerFactory;
 @SuppressWarnings({"PMD.ClassWithOnlyPrivateConstructorsShouldBeFinal", "checkstyle:finalclass"})
 public class DistributedJmxProxyFactoryImpl implements DistributedJmxProxyFactory
 {
+    private static final long DEFAULT_RUN_DELAY_IN_MS = 100;
     private static final Logger LOG = LoggerFactory.getLogger(DistributedJmxProxyFactoryImpl.class);
     private static final String SS_OBJ_NAME = "org.apache.cassandra.db:type=StorageService";
     private static final String RS_OBJ_NAME = "org.apache.cassandra.db:type=RepairService";
@@ -62,12 +86,14 @@ public class DistributedJmxProxyFactoryImpl implements DistributedJmxProxyFactor
     private final DistributedJmxConnectionProvider myDistributedJmxConnectionProvider;
     private final Map<UUID, Node> nodesMap;
     private final EccNodesSync eccNodesSync;
+    private final boolean isJolokiaEnabled;
 
     private DistributedJmxProxyFactoryImpl(final Builder builder)
     {
         myDistributedJmxConnectionProvider = builder.myDistributedJmxConnectionProvider;
         nodesMap = builder.myNodesMap;
         eccNodesSync = builder.myEccNodesSync;
+        isJolokiaEnabled = builder.isJolokiaEnabled;
     }
 
     @Override
@@ -78,7 +104,8 @@ public class DistributedJmxProxyFactoryImpl implements DistributedJmxProxyFactor
             return new InternalDistributedJmxProxy(
                     myDistributedJmxConnectionProvider,
                     nodesMap,
-                    eccNodesSync);
+                    eccNodesSync,
+                    isJolokiaEnabled);
         }
         catch (MalformedObjectNameException e)
         {
@@ -90,14 +117,28 @@ public class DistributedJmxProxyFactoryImpl implements DistributedJmxProxyFactor
     {
         private final DistributedJmxConnectionProvider myDistributedJmxConnectionProvider;
         private final Map<UUID, Node> myNodesMap;
+        private final Map<NotificationListener, String> myJolokiaRelationshipListeners = new HashMap<>();
+
+        private final ScheduledExecutorService myNotificationExecutor = Executors.newSingleThreadScheduledExecutor(
+                new ThreadFactoryBuilder().setNameFormat("NotificationRefresher-%d").build());
+
+        private final Map<UUID, Map<String, String>> myClientIdMap = new ConcurrentHashMap<>();
+        private final Map<UUID, Map<String, NotificationListener>> myNodeListenersMap = new ConcurrentHashMap<>();
+        private final Map<UUID, Map<String, ScheduledFuture<?>>> myNotificationMonitors = new ConcurrentHashMap<>();
+
+        private final boolean isJolokiaEnabled;
         private final EccNodesSync myEccNodesSync;
         private final ObjectName myStorageServiceObject;
         private final ObjectName myRepairServiceObject;
 
+        private final ObjectMapper objectMapper = new ObjectMapper();
+        private final HttpClient client = HttpClient.newHttpClient();
+
         private InternalDistributedJmxProxy(
                 final DistributedJmxConnectionProvider distributedJmxConnectionProvider,
                 final Map<UUID, Node> nodesMap,
-                final EccNodesSync eccNodesSync
+                final EccNodesSync eccNodesSync,
+                final boolean jolokiaEnabled
         ) throws MalformedObjectNameException
         {
             myDistributedJmxConnectionProvider = distributedJmxConnectionProvider;
@@ -105,6 +146,181 @@ public class DistributedJmxProxyFactoryImpl implements DistributedJmxProxyFactor
             myEccNodesSync = eccNodesSync;
             myStorageServiceObject = new ObjectName(SS_OBJ_NAME);
             myRepairServiceObject = new ObjectName(RS_OBJ_NAME);
+            isJolokiaEnabled = jolokiaEnabled;
+        }
+
+        private void startNotificationMonitor(final UUID nodeID, final String notificationID)
+        {
+            ScheduledFuture<?> future = myNotificationExecutor.scheduleWithFixedDelay(
+                    new NotificationRunTask(nodeID, notificationID), 0, DEFAULT_RUN_DELAY_IN_MS, TimeUnit.MILLISECONDS);
+
+            synchronized (myNotificationMonitors)
+            {
+                myNotificationMonitors
+                        .computeIfAbsent(nodeID, k -> new ConcurrentHashMap<>())
+                        .put(notificationID, future);
+            }
+        }
+
+        private final class NotificationRunTask implements Runnable
+        {
+            private final UUID myNodeID;
+            private final String myNotificationID;
+            private final Set<Integer> notificationController = new HashSet<>();
+
+            private NotificationRunTask(final UUID nodeID, final String notificationID)
+            {
+                myNodeID = nodeID;
+                myNotificationID = notificationID;
+            }
+
+            @Override
+            public void run()
+            {
+                try
+                {
+                    JSONObject response = checkForNotifications(myNodeID, myNotificationID);
+                    NotificationListenerResponse notificationListenerResponse = objectMapper.readValue(response.toJSONString(),
+                            NotificationListenerResponse.class);
+
+                    if (notificationListenerResponse.getValue() != null)
+                    {
+                        List<NotificationListenerResponse.Notification> notifications =
+                                notificationListenerResponse.getValue().getNotifications();
+
+                        for (NotificationListenerResponse.Notification notificationObj : notifications)
+                        {
+                            Notification notification = new Notification(
+                                    notificationObj.getType(),
+                                    notificationObj.getSource(),
+                                    notificationObj.getTimeStamp(),
+                                    notificationObj.getMessage()
+                            );
+                            notification.setUserData(notificationObj.getUserData());
+                            if (!notificationController.contains(notification.hashCode()))
+                            {
+                                notificationController.add(notification.hashCode());
+                                synchronized (myNodeListenersMap)
+                                {
+                                    NotificationListener listener = myNodeListenersMap.get(myNodeID).get(myNotificationID);
+                                    if (listener != null)
+                                    {
+                                        listener.handleNotification(notification, null);
+                                    }
+                                    else
+                                    {
+                                        LOG.warn("Listener not found for node {} and notificationID {}", myNodeID, myNotificationID);
+                                    }
+                                }
+                            }
+                        }
+                    }
+
+                }
+                catch (Exception e)
+                {
+                    LOG.error("Error monitoring notifications for node {} and notificationID {}: {}", myNodeID, myNotificationID, e.getMessage());
+                }
+            }
+        }
+
+        private void registerClientId(final UUID nodeID)
+        {
+            try
+            {
+                String url = mountJolokiaBaseURL(nodeID) + "/notification/register";
+
+                HttpRequest request = HttpRequest.newBuilder().uri(URI.create(url)).GET().build();
+
+                HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+
+                ClientRegisterResponse clientRegisterResponse = objectMapper.readValue(response.body(),
+                        ClientRegisterResponse.class);
+
+                Map<String, String> properties = new HashMap<>();
+                properties.put("clientID", clientRegisterResponse.getValue().getId());
+                properties.put("store", clientRegisterResponse.getValue().getBackend().getPull().getStore());
+
+                myClientIdMap.put(nodeID, properties);
+            }
+            catch (IOException | InterruptedException e)
+            {
+                LOG.error("Unable to register Jolokia Client in node with ID {} because of {}", nodeID, e.getMessage());
+            }
+        }
+
+        private String registerJolokiaNotification(final UUID nodeID) throws IOException, InterruptedException
+        {
+            String url = mountJolokiaBaseURL(nodeID) + "/notification";
+
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create(url)).POST(HttpRequest.BodyPublishers.ofString(jolokiaNotificationOptions(nodeID))).build();
+            HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+
+            NotificationRegisterResponse notificationRegisterResponse = objectMapper.readValue(response.body(),
+                    NotificationRegisterResponse.class);
+
+            return notificationRegisterResponse.getValue();
+        }
+
+        private String jolokiaNotificationOptions(final UUID nodeID)
+        {
+            Map<String, Object> params = new HashMap<>();
+            params.put("type", "notification");
+            params.put("command", "add");
+            params.put("client", myClientIdMap.get(nodeID).get("clientID"));
+            params.put("mode", "pull");
+            params.put("mbean", SS_OBJ_NAME);
+            List<String> filter = List.of(
+                    "progress",
+                    "jmx.remote.connection.lost.notifications",
+                    "jmx.remote.connection.failed",
+                    "jmx.remote.connection.closed"
+            );
+            params.put("filter", filter);
+
+            try
+            {
+                return objectMapper.writeValueAsString(params);
+            }
+            catch (JsonProcessingException e)
+            {
+                LOG.error("Unable to serialize notification options for node {} because of {}", nodeID, e.getMessage());
+            }
+            return "";
+        }
+
+        private J4pClient mountJolokiaClient(final UUID nodeID)
+        {
+            return new J4pClient(mountJolokiaBaseURL(nodeID));
+        }
+
+        private String mountJolokiaBaseURL(final UUID nodeID)
+        {
+            String host = myNodesMap.get(nodeID).getBroadcastRpcAddress().get().getHostString();
+            return "http://" + host + ":8778/jolokia";
+        }
+
+        private JSONObject checkForNotifications(final UUID nodeID, final String notificationID)
+        {
+            String operation = "pull";
+            try
+            {
+                synchronized (myClientIdMap)
+                {
+                    J4pExecRequest execRequest = new J4pExecRequest(
+                            myClientIdMap.get(nodeID).get("store"),
+                            operation, myClientIdMap.get(nodeID).get("clientID"),
+                            notificationID);
+
+                    return mountJolokiaClient(nodeID).execute(execRequest).asJSONObject();
+                }
+            }
+            catch (Exception e)
+            {
+                LOG.error("Error checking notifications for node {} and notificationID {}: {}", nodeID, notificationID, e.getMessage());
+            }
+            return new JSONObject();
         }
 
         @Override
@@ -123,9 +339,27 @@ public class DistributedJmxProxyFactoryImpl implements DistributedJmxProxyFactor
                 try
                 {
                     nodeConnection.addConnectionNotificationListener(listener, null, null);
-                    nodeConnection.getMBeanServerConnection().addNotificationListener(myStorageServiceObject, listener, null, null);
+                    if (isJolokiaEnabled)
+                    {
+                        registerClientId(nodeID);
+
+                        String jolokiaNotificationID = registerJolokiaNotification(nodeID);
+
+                        synchronized (myNodeListenersMap)
+                        {
+                            myNodeListenersMap.computeIfAbsent(nodeID, k -> new ConcurrentHashMap<>()).put(jolokiaNotificationID, listener);
+                        }
+
+                        myJolokiaRelationshipListeners.put(listener, jolokiaNotificationID);
+
+                        startNotificationMonitor(nodeID, jolokiaNotificationID);
+                    }
+                    else
+                    {
+                        nodeConnection.getMBeanServerConnection().addNotificationListener(myStorageServiceObject, listener, null, null);
+                    }
                 }
-                catch (InstanceNotFoundException | IOException e)
+                catch (InstanceNotFoundException | IOException | InterruptedException e)
                 {
                     LOG.error("Unable to add StorageService listener in node {} with because of {}", nodeID, e.getMessage());
                 }
@@ -295,7 +529,22 @@ public class DistributedJmxProxyFactoryImpl implements DistributedJmxProxyFactor
                 try
                 {
                     nodeConnection.removeConnectionNotificationListener(listener);
-                    nodeConnection.getMBeanServerConnection().removeNotificationListener(myStorageServiceObject, listener);
+                    if (isJolokiaEnabled)
+                    {
+                        String jolokiaNotificationID = myJolokiaRelationshipListeners.get(listener);
+                        synchronized (myNotificationMonitors)
+                        {
+                            myNotificationMonitors.get(nodeID).get(jolokiaNotificationID).cancel(true);
+                            myNotificationMonitors.get(nodeID).remove(jolokiaNotificationID);
+                        }
+                        myNodeListenersMap.get(nodeID).remove(jolokiaNotificationID);
+                        myJolokiaRelationshipListeners.remove(listener);
+                    }
+                    else
+                    {
+                        nodeConnection.getMBeanServerConnection().removeNotificationListener(myStorageServiceObject, listener);
+                    }
+
                 }
                 catch (InstanceNotFoundException | ListenerNotFoundException | IOException e)
                 {
@@ -482,6 +731,7 @@ public class DistributedJmxProxyFactoryImpl implements DistributedJmxProxyFactor
             LOG.error("Unable to get connection with node {}, marking as UNREACHABLE", nodeID);
             myEccNodesSync.updateNodeStatus(NodeStatus.UNAVAILABLE, myNodesMap.get(nodeID).getDatacenter(), nodeID);
         }
+
     }
 
     public static Builder builder()
@@ -494,6 +744,7 @@ public class DistributedJmxProxyFactoryImpl implements DistributedJmxProxyFactor
         private DistributedJmxConnectionProvider myDistributedJmxConnectionProvider;
         private Map<UUID, Node> myNodesMap;
         private EccNodesSync myEccNodesSync;
+        private boolean isJolokiaEnabled = false;
 
         /**
          * Build with JMX connection provider.
@@ -528,6 +779,18 @@ public class DistributedJmxProxyFactoryImpl implements DistributedJmxProxyFactor
         public Builder withEccNodesSync(final EccNodesSync eccNodesSync)
         {
             myEccNodesSync = eccNodesSync;
+            return this;
+        }
+
+        /**
+         * Build with Jolokia Agent.
+         *
+         * @param jolokiaEnabled Define if Jolokia Client must be used.
+         * @return Builder
+         */
+        public Builder withJolokiaEnabled(final boolean jolokiaEnabled)
+        {
+            isJolokiaEnabled = jolokiaEnabled;
             return this;
         }
 

--- a/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/jmx/http/ClientRegisterResponse.java
+++ b/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/jmx/http/ClientRegisterResponse.java
@@ -71,7 +71,7 @@ public final class ClientRegisterResponse
     @Override
     public String toString()
     {
-        return "NotificationResponse{" + "request=" + myRequest
+        return "NotificationResponse{ request=" + myRequest
                 + ", value=" + myValue + ", status=" + myStatus
                 + ", timestamp=" + myTimestamp + '}';
     }
@@ -81,7 +81,6 @@ public final class ClientRegisterResponse
         private String myType;
         private String myCommand;
 
-        // Getters e Setters
         public String getType()
         {
             return myType;
@@ -105,7 +104,7 @@ public final class ClientRegisterResponse
         @Override
         public String toString()
         {
-            return "Request{" + "type='" + myType + '\'' + ", command='" + myCommand + '\'' + '}';
+            return "Request{ type='" + myType + '\'' + ", command='" + myCommand + '\'' + '}';
         }
     }
 
@@ -114,7 +113,6 @@ public final class ClientRegisterResponse
         private Backend myBackend;
         private String myId;
 
-        // Getters e Setters
         public Backend getBackend()
         {
             return myBackend;
@@ -138,8 +136,7 @@ public final class ClientRegisterResponse
         @Override
         public String toString()
         {
-            return "Value{"
-                    + "backend=" + myBackend
+            return "Value{ backend=" + myBackend
                     + ", id='" + myId + '\'' + '}';
         }
     }
@@ -151,7 +148,6 @@ public final class ClientRegisterResponse
         @JsonProperty("sse")
         private Map<String, String> mySse;
 
-        // Getters e Setters
         public Pull getPull()
         {
             return myPull;
@@ -175,7 +171,7 @@ public final class ClientRegisterResponse
         @Override
         public String toString()
         {
-            return "Backend{" + "pull=" + myPull + ", sse=" + mySse + '}';
+            return "Backend{ pull=" + myPull + ", sse=" + mySse + '}';
         }
     }
 
@@ -207,13 +203,8 @@ public final class ClientRegisterResponse
         @Override
         public String toString()
         {
-            return "Pull{"
-                    +
-                    "maxEntries=" + myMaxEntries
-                    +
-                    ", store='" + myStore + '\''
-                    +
-                    '}';
+            return "Pull { maxEntries=" + myMaxEntries
+                    + ", store='" + myStore + '\'' + '}';
         }
     }
 }

--- a/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/jmx/http/ClientRegisterResponse.java
+++ b/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/jmx/http/ClientRegisterResponse.java
@@ -1,0 +1,219 @@
+/*
+ * Copyright 2025 Telefonaktiebolaget LM Ericsson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ericsson.bss.cassandra.ecchronos.core.impl.jmx.http;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Map;
+
+/**
+ * Class used to construct Jolokia Client Register Response.
+ */
+public final class ClientRegisterResponse
+{
+    // CPD-OFF
+    private Request myRequest;
+    private Value myValue;
+    private int myStatus;
+    private long myTimestamp;
+
+    public Request getRequest()
+    {
+        return myRequest;
+    }
+
+    public void setRequest(final Request request)
+    {
+        myRequest = request;
+    }
+
+    public Value getValue()
+    {
+        return myValue;
+    }
+
+    public void setValue(final Value value)
+    {
+        myValue = value;
+    }
+
+    public int getStatus()
+    {
+        return myStatus;
+    }
+
+    public void setStatus(final int status)
+    {
+        myStatus = status;
+    }
+
+    public long getTimestamp()
+    {
+        return myTimestamp;
+    }
+
+    public void setTimestamp(final long timestamp)
+    {
+        myTimestamp = timestamp;
+    }
+
+    @Override
+    public String toString()
+    {
+        return "NotificationResponse{" + "request=" + myRequest
+                + ", value=" + myValue + ", status=" + myStatus
+                + ", timestamp=" + myTimestamp + '}';
+    }
+
+    public static final class Request
+    {
+        private String myType;
+        private String myCommand;
+
+        // Getters e Setters
+        public String getType()
+        {
+            return myType;
+        }
+
+        public void setType(final String type)
+        {
+            myType = type;
+        }
+
+        public String getCommand()
+        {
+            return myCommand;
+        }
+
+        public void setCommand(final String command)
+        {
+            myCommand = command;
+        }
+
+        @Override
+        public String toString()
+        {
+            return "Request{" + "type='" + myType + '\'' + ", command='" + myCommand + '\'' + '}';
+        }
+    }
+
+    public static final class Value
+    {
+        private Backend myBackend;
+        private String myId;
+
+        // Getters e Setters
+        public Backend getBackend()
+        {
+            return myBackend;
+        }
+
+        public void setBackend(final Backend backend)
+        {
+            myBackend = backend;
+        }
+
+        public String getId()
+        {
+            return myId;
+        }
+
+        public void setId(final String id)
+        {
+            myId = id;
+        }
+
+        @Override
+        public String toString()
+        {
+            return "Value{"
+                    + "backend=" + myBackend
+                    + ", id='" + myId + '\'' + '}';
+        }
+    }
+
+    public static final class Backend
+    {
+        private Pull myPull;
+
+        @JsonProperty("sse")
+        private Map<String, String> mySse;
+
+        // Getters e Setters
+        public Pull getPull()
+        {
+            return myPull;
+        }
+
+        public void setPull(final Pull pull)
+        {
+            myPull = pull;
+        }
+
+        public Map<String, String> getSse()
+        {
+            return mySse;
+        }
+
+        public void setSse(final Map<String, String> sse)
+        {
+            mySse = sse;
+        }
+
+        @Override
+        public String toString()
+        {
+            return "Backend{" + "pull=" + myPull + ", sse=" + mySse + '}';
+        }
+    }
+
+    public static final class Pull
+    {
+        private int myMaxEntries;
+        private String myStore;
+
+        public int getMaxEntries()
+        {
+            return myMaxEntries;
+        }
+
+        public void setMaxEntries(final int maxEntries)
+        {
+            myMaxEntries = maxEntries;
+        }
+
+        public String getStore()
+        {
+            return myStore;
+        }
+
+        public void setStore(final String store)
+        {
+            myStore = store;
+        }
+
+        @Override
+        public String toString()
+        {
+            return "Pull{"
+                    +
+                    "maxEntries=" + myMaxEntries
+                    +
+                    ", store='" + myStore + '\''
+                    +
+                    '}';
+        }
+    }
+}

--- a/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/jmx/http/NotificationListenerResponse.java
+++ b/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/jmx/http/NotificationListenerResponse.java
@@ -1,0 +1,235 @@
+/*
+ * Copyright 2025 Telefonaktiebolaget LM Ericsson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ericsson.bss.cassandra.ecchronos.core.impl.jmx.http;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Class used to construct Jolokia Notification Listener Response.
+ */
+public final class NotificationListenerResponse
+{
+    private Request myRequest;
+    private Value myValue;
+    private int myStatus;
+    private long myTimestamp;
+
+    public Request getRequest()
+    {
+        return myRequest;
+    }
+
+    public void setRequest(final Request request)
+    {
+        myRequest = request;
+    }
+
+    public Value getValue()
+    {
+        return myValue;
+    }
+
+    public void setValue(final Value value)
+    {
+        myValue = value;
+    }
+
+    public int getStatus()
+    {
+        return myStatus;
+    }
+
+    public void setStatus(final int status)
+    {
+        myStatus = status;
+    }
+
+    public long getTimestamp()
+    {
+        return myTimestamp;
+    }
+
+    public void setTimestamp(final long timestamp)
+    {
+        myTimestamp = timestamp;
+    }
+
+    public static final class Request
+    {
+        private String myMbean;
+        private List<String> myArguments;
+        private String myType;
+        private String myOperation;
+
+        public String getMbean()
+        {
+            return myMbean;
+        }
+
+        public void setMbean(final String mbean)
+        {
+            myMbean = mbean;
+        }
+
+        public List<String> getArguments()
+        {
+            return myArguments;
+        }
+
+        public void setArguments(final List<String> arguments)
+        {
+            myArguments = arguments;
+        }
+
+        public String getType()
+        {
+            return myType;
+        }
+
+        public void setType(final String type)
+        {
+            myType = type;
+        }
+
+        public String getOperation()
+        {
+            return myOperation;
+        }
+
+        public void setOperation(final String operation)
+        {
+            myOperation = operation;
+        }
+    }
+
+    public static final class Value
+    {
+        private int myDropped;
+        private String myHandle;
+        private Object myHandback;
+        private List<Notification> myNotifications;
+
+        public int getDropped()
+        {
+            return myDropped;
+        }
+
+        public void setDropped(final int dropped)
+        {
+            myDropped = dropped;
+        }
+
+        public String getHandle()
+        {
+            return myHandle;
+        }
+
+        public void setHandle(final String handle)
+        {
+            myHandle = handle;
+        }
+
+        public Object getHandback()
+        {
+            return myHandback;
+        }
+
+        public void setHandback(final Object handback)
+        {
+            myHandback = handback;
+        }
+
+        public List<Notification> getNotifications()
+        {
+            return myNotifications;
+        }
+
+        public void setNotifications(final List<Notification> notifications)
+        {
+            myNotifications = notifications;
+        }
+    }
+
+    public static final class Notification
+    {
+        private long myTimeStamp;
+        private long mySequenceNumber;
+        private Map<String, Object> myUserData;
+        private String mySource;
+        private String myMessage;
+        private String myType;
+
+        public long getTimeStamp()
+        {
+            return myTimeStamp;
+        }
+
+        public void setTimeStamp(final long timeStamp)
+        {
+            myTimeStamp = timeStamp;
+        }
+
+        public long getSequenceNumber()
+        {
+            return mySequenceNumber;
+        }
+
+        public void setSequenceNumber(final long sequenceNumber)
+        {
+            mySequenceNumber = sequenceNumber;
+        }
+
+        public Map<String, Object> getUserData()
+        {
+            return myUserData;
+        }
+
+        public void setUserData(final Map<String, Object> userData)
+        {
+            myUserData = userData;
+        }
+
+        public String getSource()
+        {
+            return mySource;
+        }
+
+        public void setSource(final String source)
+        {
+            mySource = source;
+        }
+
+        public String getMessage()
+        {
+            return myMessage;
+        }
+
+        public void setMessage(final String message)
+        {
+            myMessage = message;
+        }
+
+        public String getType()
+        {
+            return myType;
+        }
+
+        public void setType(final String type)
+        {
+            myType = type;
+        }
+    }
+}

--- a/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/jmx/http/NotificationRegisterResponse.java
+++ b/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/jmx/http/NotificationRegisterResponse.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2025 Telefonaktiebolaget LM Ericsson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ericsson.bss.cassandra.ecchronos.core.impl.jmx.http;
+
+import java.util.List;
+
+/**
+ * Class used to construct Jolokia Notification Register Response.
+ */
+public final class NotificationRegisterResponse
+{
+    private Request myRequest;
+    private String myValue;
+    private int myStatus;
+    private long myTimestamp;
+
+    public Request getRequest()
+    {
+        return myRequest;
+    }
+
+    public void setRequest(final Request request)
+    {
+        myRequest = request;
+    }
+
+    public String getValue()
+    {
+        return myValue;
+    }
+
+    public void setValue(final String value)
+    {
+        myValue = value;
+    }
+
+    public int getStatus()
+    {
+        return myStatus;
+    }
+
+    public void setStatus(final int status)
+    {
+        myStatus = status;
+    }
+
+    public long getTimestamp()
+    {
+        return myTimestamp;
+    }
+
+    public void setTimestamp(final long timestamp)
+    {
+        myTimestamp = timestamp;
+    }
+
+    @Override
+    public String toString()
+    {
+        return "NotificationAddResponse{"
+                + "request=" + myRequest
+                + ", value='" + myValue
+                + '\'' + ", status="
+                + myStatus + ", timestamp="
+                + myTimestamp + '}';
+    }
+
+    public static final class Request
+    {
+        private String myMode;
+        private List<String> myFilter;
+        private String myMbean;
+        private String myClient;
+        private String myType;
+        private String myCommand;
+
+        public String getMode()
+        {
+            return myMode;
+        }
+
+        public void setMode(final String mode)
+        {
+            myMode = mode;
+        }
+
+        public List<String> getFilter()
+        {
+            return myFilter;
+        }
+
+        public void setFilter(final List<String> filter)
+        {
+            myFilter = filter;
+        }
+
+        public String getMbean()
+        {
+            return myMbean;
+        }
+
+        public void setMbean(final String mbean)
+        {
+            myMbean = mbean;
+        }
+
+        public String getClient()
+        {
+            return myClient;
+        }
+
+        public void setClient(final String client)
+        {
+            myClient = client;
+        }
+
+        public String getType()
+        {
+            return myType;
+        }
+
+        public void setType(final String type)
+        {
+            myType = type;
+        }
+
+        public String getCommand()
+        {
+            return myCommand;
+        }
+
+        public void setCommand(final String command)
+        {
+            myCommand = command;
+        }
+
+        @Override
+        public String toString()
+        {
+            return "Request{"
+                    + "mode='"
+                    + myMode + '\''
+                    + ", filter="
+                    + myFilter
+                    + ", mbean='"
+                    + myMbean + '\''
+                    + ", client='" + myClient + '\''
+                    + ", type='" + myType + '\''
+                    + ", command='" + myCommand + '\'' + '}';
+        }
+    }
+}

--- a/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/jmx/http/NotificationRegisterResponse.java
+++ b/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/jmx/http/NotificationRegisterResponse.java
@@ -69,8 +69,7 @@ public final class NotificationRegisterResponse
     @Override
     public String toString()
     {
-        return "NotificationAddResponse{"
-                + "request=" + myRequest
+        return "NotificationAddResponse{ request=" + myRequest
                 + ", value='" + myValue
                 + '\'' + ", status="
                 + myStatus + ", timestamp="
@@ -149,8 +148,7 @@ public final class NotificationRegisterResponse
         @Override
         public String toString()
         {
-            return "Request{"
-                    + "mode='"
+            return "Request{ mode='"
                     + myMode + '\''
                     + ", filter="
                     + myFilter

--- a/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/jmx/http/package-info.java
+++ b/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/jmx/http/package-info.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2025 Telefonaktiebolaget LM Ericsson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Contains the implementation and resources for Jolokia HTTP requests.
+ */
+package com.ericsson.bss.cassandra.ecchronos.core.impl.jmx.http;

--- a/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/scheduler/RepairSchedulerImpl.java
+++ b/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/scheduler/RepairSchedulerImpl.java
@@ -191,7 +191,10 @@ public final class RepairSchedulerImpl implements RepairScheduler, Closeable
                     LOG.info("Creating schedule for table {} in node {}", tableReference, node.getHostId());
                     createTableSchedule(node, tableReference, repairConfigurations);
                 }
-                LOG.info("No configuration changes for table {} in node {}", tableReference, node.getHostId());
+                else
+                {
+                    LOG.info("No configuration changes for table {} in node {}", tableReference, node.getHostId());
+                }
             }
             catch (Exception e)
             {

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -1,9 +1,38 @@
 # Compatibility
 
-Below matrix defines which ecChronos versions have been tested and verified with which Cassandra version.
+## Cassandra
+
+Below matrix defines which ecChronos agent versions have been tested and verified with which Cassandra version.
 
 | ecchronos version      | Cassandra 3.0.X | Cassandra 3.11.X | Cassandra 4.0.X | Cassandra 4.1.X | Cassandra 5.0-alpha1 |
 |------------------------|-----------------|------------------|-----------------|-----------------|----------------------|
-| &lt;= 2.0.5            | X               | X                |                 |                 |                      |
-| &gt; 2.0.5  &lt; 5.0.0 | X               | X                | X               |                 |                      |
-| &gt;= 5.0.0            |                 |                  | X               | X               | X                    |
+| &gt;= 1.0.0            |                 |                  | X               | X               | X                    |
+
+## Jolokia
+
+In ecChronos, a new feature has been introduced via issue #831, enabling the use of dynamic notification listeners in conjunction with Jolokia. This enhancement ensures that notifications can be monitored dynamically using Jolokia without affecting the existing architecture of RepairTask, which is implemented as a NotificationListener.
+
+### Background
+
+Traditionally, JMX notification listeners were registered using the following method:
+
+```java
+MBeanServerConnection().addNotificationListener(objectName, listener, filter, handback);
+```
+
+However, this approach is not supported by Jolokia, which relies on HTTP and JSON-based interactions instead of direct Java method calls. With Jolokia version 2 or later, it is now possible to add notification listeners dynamically using its JSON or JavaScript interface.
+
+In the context of ecChronos, the RepairTask component is tightly coupled to JMX notification listeners, and integrating it with Jolokia required a new approach that preserved the architecture while extending functionality.
+
+### Compatibility Requirements
+
+This feature requires Jolokia version 2 or later. Additionally, any environment running this implementation, including Cassandra, must ensure that the Jolokia agent is updated to version 2 or above. Older versions of Jolokia do not support the dynamic listener functionality.
+
+### Implementation Overview
+
+This pull request introduces a dynamic notification listener feature that allows ecChronos to handle notifications via Jolokia seamlessly. The feature works by:
+
+- Leveraging Jolokia's JSON interface to register listeners dynamically.
+- Ensuring compatibility with the RepairTask implementation as a NotificationListener.
+- Bridging the gap between traditional JMX listener registration and Jolokia's HTTP-based operations.
+- This enhancement does not disrupt the core architecture of RepairTask, maintaining its design integrity while enabling modernized handling of notifications.

--- a/pom.xml
+++ b/pom.xml
@@ -180,7 +180,7 @@
         <org.codehaus.mojo.license-maven-plugin.version>2.4.0</org.codehaus.mojo.license-maven-plugin.version>
         <org.jacoco.jacoco-maven-plugin.version>0.8.12</org.jacoco.jacoco-maven-plugin.version>
 
-        <jolokia.adapter.version>1.7.1</jolokia.adapter.version>
+        <jolokia.adapter.version>2.1.1</jolokia.adapter.version>
 
         <skipTests>false</skipTests>
         <skipUTs>${skipTests}</skipUTs>
@@ -377,7 +377,24 @@
 
             <dependency>
                 <groupId>org.jolokia</groupId>
-                <artifactId>jolokia-jsr160</artifactId>
+                <artifactId>jolokia-jmx-adapter</artifactId>
+                <version>${jolokia.adapter.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.jolokia</groupId>
+                <artifactId>jolokia-service-jmx</artifactId>
+                <version>${jolokia.adapter.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jolokia</groupId>
+                <artifactId>jolokia-service-serializer</artifactId>
+                <version>${jolokia.adapter.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.jolokia</groupId>
+                <artifactId>jolokia-client-java</artifactId>
                 <version>${jolokia.adapter.version}</version>
             </dependency>
 


### PR DESCRIPTION
In Jolokia 2, it is possible to create notification listeners using JavaScript or JSON. Currently, a RepairTask is an implementation of NotificationListener. However, when using Jolokia, it is not possible to add the listener using the traditional method:

```java
nodeConnection.getMBeanServerConnection().addNotificationListener(myStorageServiceObject, listener, null, null);
```

This approach is not supported by Jolokia.

The purpose of this pull request is to reconcile the current method of adding notification listeners in Jolokia with the RepairTask. Integration tests for this functionality will be implemented in a separate pull request.

Closes #831