### PR TITLE
Update Test Template to Enable or Disable Jolokia in Cassandra

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -27,6 +27,9 @@ jobs:
            test_suite: 'test jacoco:report'
          - name: "Style check"
            test_suite: 'compile com.mycila:license-maven-plugin:check pmd:pmd pmd:cpd pmd:check pmd:cpd-check javadoc:jar'
+         - name: "Standalone integration 4.0 - Java 17"
+           test_suite: 'verify -P standalone-integration-tests -DskipUTs'
+           artifacts_dir: "standalone-integration/target"
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Cache local Maven repository

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Version 1.0.0 (Not yet Released)
 
+* Update TestContainers Template to Enable or Disable Jolokia in Cassandra - Issue #844
 * Reconcile Jolokia Notification Listener Implementation with RepairTask - Issue #831
 * Introduce REST Module for Scheduling and Managing Cassandra Repairs - Issue #771
 * Create On Demand Repair Job on Agent - Issue #775

--- a/cassandra-test-image/src/main/docker/Dockerfile
+++ b/cassandra-test-image/src/main/docker/Dockerfile
@@ -8,4 +8,4 @@ COPY users.cql /etc/cassandra/
 COPY setup_db.sh /etc/cassandra/
 
 ENTRYPOINT ["ecc-entrypoint.sh"]
-EXPOSE 7000 7001 7199 9042
+EXPOSE 7000 7001 7199 9042 8778

--- a/cassandra-test-image/src/main/docker/docker-compose.yml
+++ b/cassandra-test-image/src/main/docker/docker-compose.yml
@@ -17,6 +17,7 @@ services:
       - MAX_HEAP_SIZE=2G
       - HEAP_NEWSIZE=200M
       - LOCAL_JMX=no
+      - JOLOKIA= ${JOLOKIA}
       - JVM_EXTRA_OPTS=-Dcom.sun.management.jmxremote.authenticate=false -Dcassandra.superuser_setup_delay_ms=0 -Dcassandra.skip_wait_for_gossip_to_settle=0 -Dcassandra.ring_delay_ms=0
     volumes:
       - cassandra-seed-dc1-rack1-node1-data:/var/lib/cassandra
@@ -39,6 +40,7 @@ services:
       - MAX_HEAP_SIZE=2G
       - HEAP_NEWSIZE=200M
       - LOCAL_JMX=no
+      - JOLOKIA= ${JOLOKIA}
       - JVM_EXTRA_OPTS=-Dcom.sun.management.jmxremote.authenticate=false -Dcassandra.superuser_setup_delay_ms=0 -Dcassandra.skip_wait_for_gossip_to_settle=0 -Dcassandra.ring_delay_ms=0
     volumes:
       - cassandra-seed-dc2-rack1-node1-data:/var/lib/cassandra
@@ -60,6 +62,7 @@ services:
       - MAX_HEAP_SIZE=2G
       - HEAP_NEWSIZE=200M
       - LOCAL_JMX=no
+      - JOLOKIA= ${JOLOKIA}
       - JVM_EXTRA_OPTS=-Dcom.sun.management.jmxremote.authenticate=false -Dcassandra.superuser_setup_delay_ms=0 -Dcassandra.skip_wait_for_gossip_to_settle=0 -Dcassandra.ring_delay_ms=0
     volumes:
       - cassandra-node-dc1-rack1-node2-data:/var/lib/cassandra
@@ -81,6 +84,7 @@ services:
       - MAX_HEAP_SIZE=2G
       - HEAP_NEWSIZE=200M
       - LOCAL_JMX=no
+      - JOLOKIA= ${JOLOKIA}
       - JVM_EXTRA_OPTS=-Dcom.sun.management.jmxremote.authenticate=false -Dcassandra.superuser_setup_delay_ms=0 -Dcassandra.skip_wait_for_gossip_to_settle=0 -Dcassandra.ring_delay_ms=0
     volumes:
       - cassandra-node-dc2-rack1-node2-data:/var/lib/cassandra

--- a/cassandra-test-image/src/main/docker/ecc-entrypoint.sh
+++ b/cassandra-test-image/src/main/docker/ecc-entrypoint.sh
@@ -85,4 +85,19 @@ EOF
 
 fi
 
+JOLOKIA_JAR="/opt/jolokia-jvm-agent.jar"
+
+if [ "$(echo -n "$JOLOKIA" | xargs)" = "true" ]; then
+    echo "Attempting to download Jolokia jar..."
+    curl -L -o "$JOLOKIA_JAR" "https://search.maven.org/remotecontent?filepath=org/jolokia/jolokia-agent-jvm/2.1.1/jolokia-agent-jvm-2.1.1-javaagent.jar"
+
+    JOLOKIA_OPTS="--add-opens=java.base/jdk.internal.ref=ALL-UNNAMED -javaagent:$JOLOKIA_JAR=port=8778,host=0.0.0.0,useSsl=false"
+
+    if [ -n "$JVM_EXTRA_OPTS" ]; then
+        export JVM_EXTRA_OPTS="$JVM_EXTRA_OPTS $JOLOKIA_OPTS"
+    else
+        export JVM_EXTRA_OPTS="$JOLOKIA_OPTS"
+    fi
+fi
+
 docker-entrypoint.sh

--- a/cassandra-test-image/src/test/java/cassandracluster/AbstractCassandraCluster.java
+++ b/cassandra-test-image/src/test/java/cassandracluster/AbstractCassandraCluster.java
@@ -39,7 +39,7 @@ public class AbstractCassandraCluster
     private static final Logger LOG = LoggerFactory.getLogger(AbstractCassandraCluster.class);
     protected static String containerIP;
     protected static CqlSession mySession;
-    private static final long DEFAULT_WAIT_TIME_IN_SC = 10000;
+    private static final long DEFAULT_WAIT_TIME_IN_SECS= 10000;
 
     @BeforeClass
     public static void setup() throws IOException, InterruptedException
@@ -105,7 +105,7 @@ public class AbstractCassandraCluster
         LOG.info("Waiting 10sec");
         try
         {
-            Thread.sleep(DEFAULT_WAIT_TIME_IN_SC);
+            Thread.sleep(DEFAULT_WAIT_TIME_IN_SECS);
         }
         catch (InterruptedException e)
         {

--- a/cassandra-test-image/src/test/java/cassandracluster/AbstractCassandraCluster.java
+++ b/cassandra-test-image/src/test/java/cassandracluster/AbstractCassandraCluster.java
@@ -17,52 +17,63 @@ package cassandracluster;
 import com.datastax.oss.driver.api.core.CqlSession;
 import com.datastax.oss.driver.api.core.CqlSessionBuilder;
 
-import java.io.BufferedReader;
-import java.io.FileReader;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
-import com.github.dockerjava.api.DockerClient;
-import com.github.dockerjava.api.command.StartContainerCmd;
-import com.github.dockerjava.api.command.StopContainerCmd;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.testcontainers.DockerClientFactory;
 import org.testcontainers.containers.DockerComposeContainer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
+import org.testcontainers.containers.output.Slf4jLogConsumer;
 
 public class AbstractCassandraCluster
 {
+    private static final String DOCKER_COMPOSE_FILE_PATH = "cassandra-test-image/src/main/docker/docker-compose.yml";
+    private static final String CASSANDRA_SETUP_DB_SCRIPT_PATH = "/etc/cassandra/setup_db.sh";
+    protected static final String CASSANDRA_SEED_NODE_NAME = "cassandra-seed-dc1-rack1-node1";
+    protected static final long DEFAULT_WAIT_TIME_IN_MS = 50000;
     protected static DockerComposeContainer<?> composeContainer;
     private static final Logger LOG = LoggerFactory.getLogger(AbstractCassandraCluster.class);
     protected static String containerIP;
     protected static CqlSession mySession;
-    private static final long TENSECONDS = 10000;
+    private static final long DEFAULT_WAIT_TIME_IN_SC = 10000;
 
     @BeforeClass
-    public static void setup() throws InterruptedException
+    public static void setup() throws IOException, InterruptedException
     {
         Path dockerComposePath = Paths.get("")
                 .toAbsolutePath()
                 .getParent()
-                .resolve("cassandra-test-image/src/main/docker/docker-compose.yml");
-        composeContainer = new DockerComposeContainer<>(dockerComposePath.toFile());
+                .resolve(DOCKER_COMPOSE_FILE_PATH);
+        composeContainer = new DockerComposeContainer<>(dockerComposePath.toFile())
+                .withEnv("JOLOKIA", "false")
+                .withLogConsumer(CASSANDRA_SEED_NODE_NAME, new Slf4jLogConsumer(LOG));
+
         composeContainer.start();
         LOG.info("Waiting for the Cassandra cluster to finish starting up.");
-        waitForNodesToBeUp("cassandra-seed-dc1-rack1-node1",4,50000);
+        waitForNodesToBeUp(CASSANDRA_SEED_NODE_NAME,4,DEFAULT_WAIT_TIME_IN_MS);
 
-        containerIP = composeContainer.getContainerByServiceName("cassandra-seed-dc1-rack1-node1").get()
+        containerIP = composeContainer.getContainerByServiceName(CASSANDRA_SEED_NODE_NAME).get()
                 .getContainerInfo()
                 .getNetworkSettings().getNetworks().values().stream().findFirst().get().getIpAddress();
-        CqlSessionBuilder builder = CqlSession.builder()
+        composeContainer.getContainerByServiceName(CASSANDRA_SEED_NODE_NAME).get()
+                .execInContainer("bash", CASSANDRA_SETUP_DB_SCRIPT_PATH);
+    }
+
+    protected static void createDefaultSession()
+    {
+        mySession = defaultBuilder().build();
+    }
+
+    protected static CqlSessionBuilder defaultBuilder()
+    {
+        return CqlSession.builder()
                 .addContactPoint(new InetSocketAddress(containerIP, 9042))
                 .withLocalDatacenter("datacenter1")
                 .withAuthCredentials("cassandra", "cassandra");
-        mySession = builder.build();
     }
 
     @AfterClass
@@ -81,29 +92,6 @@ public class AbstractCassandraCluster
                 .execInContainer("nodetool", "-u", "cassandra", "-pw", "cassandra", "decommission").getStdout();
     }
 
-    protected void startContainer ( String node)
-    {
-        DockerClient dockerClient = DockerClientFactory.instance().client();
-        String container = composeContainer
-                .getContainerByServiceName(node).get().getContainerId();
-
-        try (StartContainerCmd startCmd3 = dockerClient.startContainerCmd(container))
-        {
-            startCmd3.exec();
-        }
-    }
-
-    protected void stopContainer ( String node)
-    {
-        DockerClient dockerClient = DockerClientFactory.instance().client();
-        String container = composeContainer
-                .getContainerByServiceName(node).get().getContainerId();
-        try (StopContainerCmd stopCmd = dockerClient.stopContainerCmd(container))
-        {
-            stopCmd.exec();
-        }
-    }
-
     protected static int getNodeCountViaNodetool( String node) throws IOException, InterruptedException
     {
         String stdout = composeContainer.getContainerByServiceName(node).get()
@@ -111,14 +99,15 @@ public class AbstractCassandraCluster
         return stdout.split("UN",-1).length-1;
     }
 
-    protected static boolean waitForNodesToBeUp( String node, int expectedNodes, long maxWaitTimeInMillis)
+    protected static void waitForNodesToBeUp( String node, int expectedNodes, long maxWaitTimeInMillis)
     {
         long startTime = System.currentTimeMillis();
         LOG.info("Waiting 10sec");
         try
         {
-            Thread.sleep(TENSECONDS);
-        } catch (InterruptedException e)
+            Thread.sleep(DEFAULT_WAIT_TIME_IN_SC);
+        }
+        catch (InterruptedException e)
         {
             // ignore and retry
         }
@@ -128,7 +117,7 @@ public class AbstractCassandraCluster
             {
                 if (getNodeCountViaNodetool(node) == expectedNodes)
                 {
-                    return true;
+                    return;
                 }
             }
             catch (IOException | InterruptedException e)
@@ -137,31 +126,6 @@ public class AbstractCassandraCluster
             }
         }
         LOG.info("Timed out waiting for the Cassandra cluster to finish starting up.");
-        return false;
-    }
-    
-    protected void loadEcchronosKeyspace () throws InterruptedException
-    {
-        Path cqlfile = Paths.get("")
-            .toAbsolutePath()
-            .getParent()
-            .resolve("cassandra-test-image/src/main/docker/create_keyspaces.cql");
-
-        try (BufferedReader reader = new BufferedReader(new FileReader(cqlfile.toFile())))
-        {
-            String line;
-            while ((line = reader.readLine()) != null)
-            {
-
-                System.out.println(line);
-                mySession.execute(line);
-                Thread.sleep(500);
-            }
-        }
-        catch (IOException e)
-        {
-            System.err.println("Error reading the file: " + e.getMessage());
-        }
     }
 }
 

--- a/cassandra-test-image/src/test/java/cassandracluster/ITNodeAddition.java
+++ b/cassandra-test-image/src/test/java/cassandracluster/ITNodeAddition.java
@@ -14,8 +14,6 @@
  */
 package cassandracluster;
 
-import com.datastax.oss.driver.api.core.CqlSession;
-import com.datastax.oss.driver.api.core.CqlSessionBuilder;
 import com.ericsson.bss.cassandra.ecchronos.core.impl.repair.DefaultRepairConfigurationProvider;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -24,7 +22,6 @@ import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.DockerComposeContainer;
 
 import java.io.IOException;
-import java.net.InetSocketAddress;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
@@ -37,8 +34,9 @@ import static org.mockito.Mockito.any;
 public class ITNodeAddition extends AbstractCassandraCluster
 {
     private static final Logger LOG = LoggerFactory.getLogger(ITNodeAddition.class);
+
     @BeforeClass
-    public static void setup() throws InterruptedException
+    public static void setup()
     {
         Path dockerComposePath = Paths.get("")
                 .toAbsolutePath()
@@ -52,22 +50,15 @@ public class ITNodeAddition extends AbstractCassandraCluster
         composeContainer.start();
 
         LOG.info("Waiting for the Cassandra cluster to finish starting up.");
-        waitForNodesToBeUp("cassandra-seed-dc1-rack1-node1",1,50000);
-
+        waitForNodesToBeUp("cassandra-seed-dc1-rack1-node1",1,DEFAULT_WAIT_TIME_IN_MS);
     }
+
     @Test
     public void testAdditionalNodesAddedToCluster() throws InterruptedException, IOException
     {
         DefaultRepairConfigurationProvider listener = mock(DefaultRepairConfigurationProvider.class);
-        containerIP = composeContainer.getContainerByServiceName("cassandra-seed-dc1-rack1-node1").get()
-                .getContainerInfo()
-                .getNetworkSettings().getNetworks().values().stream().findFirst().get().getIpAddress();
-        CqlSessionBuilder builder = CqlSession.builder()
-                .addContactPoint(new InetSocketAddress(containerIP, 9042))
-                .withLocalDatacenter("datacenter1")
-                .withAuthCredentials("cassandra", "cassandra")
-                .withNodeStateListener(listener);
-        mySession = builder.build();
+        
+        mySession = defaultBuilder().build();
 
         // scale up new nodes
         composeContainer.withScaledService("cassandra-node-dc1-rack1-node2", 1 );
@@ -75,7 +66,7 @@ public class ITNodeAddition extends AbstractCassandraCluster
         composeContainer.withScaledService("cassandra-seed-dc2-rack1-node1", 1 );
         composeContainer.start();
         LOG.info("Waiting for the new nodes to finish starting up.");
-        waitForNodesToBeUp("cassandra-seed-dc1-rack1-node1",4,50000);
+        waitForNodesToBeUp("cassandra-seed-dc1-rack1-node1",4,DEFAULT_WAIT_TIME_IN_MS);
 
         assertEquals( 4, getNodeCountViaNodetool("cassandra-node-dc1-rack1-node2"));
 

--- a/cassandra-test-image/src/test/java/cassandracluster/TestCassandraCluster.java
+++ b/cassandra-test-image/src/test/java/cassandracluster/TestCassandraCluster.java
@@ -25,6 +25,7 @@
      @Test
      public void testCassandraCluster()
      {
+         createDefaultSession();
          mySession.execute(
                  "CREATE KEYSPACE IF NOT EXISTS test_keyspace WITH replication = {'class': 'NetworkTopologyStrategy', " +
                          "'datacenter1': 2}");

--- a/standalone-integration/pom.xml
+++ b/standalone-integration/pom.xml
@@ -141,6 +141,57 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <profiles>
+        <profile>
+            <activation>
+                <property>
+                    <name>precommit.tests</name>
+                </property>
+            </activation>
+            <id>standalone-integration-tests</id>
+            <build>
+                <plugins>
+                    <!-- Integration tests -->
+                    <plugin>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>integration-test</goal>
+                                    <goal>verify</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <activation>
+                <property>
+                    <name>localprecommit.tests</name>
+                </property>
+            </activation>
+            <id>local-standalone-integration-tests</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>integration-test</goal>
+                                    <goal>verify</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
     <build>
         <plugins>
             <plugin>

--- a/standalone-integration/src/test/java/com/ericsson/bss/cassandra/ecchronos/standalone/TestBase.java
+++ b/standalone-integration/src/test/java/com/ericsson/bss/cassandra/ecchronos/standalone/TestBase.java
@@ -112,6 +112,7 @@ abstract public class TestBase extends AbstractCassandraCluster
     @BeforeClass
     public static void setUpCluster() throws Exception
     {
+        createDefaultSession();
         createKeyspaceAndTables();
         Security security = ConfigurationHelper.DEFAULT_INSTANCE.getConfiguration(SECURITY_FILE, Security.class);
         jmxSecurity.set(security.getJmxSecurity());


### PR DESCRIPTION
Currently, the test template using TestContainers does not offer configurable support to enable or disable Jolokia in Cassandra. Jolokia is an extension for exposing JMX metrics over HTTP, often used in monitoring scenarios.

The goal of this task is to modify the test template to include a configuration that allows controlling the activation of Jolokia in Cassandra, preparing the environment for integration tests that depend on this functionality.

Closes #844 