### PR TITLE
Fix python version in test to 3.12

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -92,7 +92,7 @@ jobs:
       - name: Set up Python 3
         uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
         with:
-          python-version: 3.12
+          python-version: 3.12 #current python-driver only support up to 3.12
 
       - name: Install black
         run: python -m pip install black==24.10.0

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -92,7 +92,7 @@ jobs:
       - name: Set up Python 3
         uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
         with:
-          python-version: 3
+          python-version: 3.12
 
       - name: Install black
         run: python -m pip install black==24.10.0


### PR DESCRIPTION
The latest version (3.29.2) of the python driver does not support python 3.13, once a new version of the python-driver supporting python 3.13 is available this change should be reverted.