### PR TITLE
Fix Application Failure When statistics.enabled is False

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Version 6.0.2
 
+* Fail to Initialize ecChronos When statistics.enabled is False - Issue #869
+
 ## Version 6.0.1
 
 * Bump dependecies

--- a/rest/src/main/java/com/ericsson/bss/cassandra/ecchronos/rest/MetricsREST.java
+++ b/rest/src/main/java/com/ericsson/bss/cassandra/ecchronos/rest/MetricsREST.java
@@ -38,10 +38,9 @@ import static org.springframework.http.HttpStatus.NOT_FOUND;
 @RestController
 public class MetricsREST
 {
-    @Autowired
     private final PrometheusMeterRegistry myPrometheusMeterRegistry;
 
-    public MetricsREST(final PrometheusMeterRegistry prometheusMeterRegistry)
+    public MetricsREST(@Autowired(required = false) final PrometheusMeterRegistry prometheusMeterRegistry)
     {
         myPrometheusMeterRegistry = prometheusMeterRegistry;
     }


### PR DESCRIPTION
After some tests, we found that the uplift of spring boot from version 3.3.5 to 3.4.2 is responsible for causing this problem, I didn't find which commit exactly, but I see many changes in beans in spring boot 3.4 release notes https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-3.4-Release-Notes#bean-validation-of-configuration-properties

This commit should allow us to use the new version without breaking application when we do not initialize the bean

Closes #869 