### PR TITLE
REST interface only shows the schedules for the last table added

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Version 1.0.0 (Not yet Released)
 
+* Fix REST interface only shows the schedules for the last table added - Issue #1030
 * Enable Multithreading Support in the EcChronos Agent for Node Operations - Issue #959
 * Modify ecctool to Allow Repairs to be Created Without Requiring a Node ID - Issue #903
 * Create ecchronos-binary Module with ecctool for Interacting with the ecChronos REST API - Issue #867

--- a/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/scheduler/RepairSchedulerImpl.java
+++ b/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/scheduler/RepairSchedulerImpl.java
@@ -261,7 +261,11 @@ public final class RepairSchedulerImpl implements RepairScheduler, Closeable
             final Set<RepairConfiguration> repairConfigurations)
     {
         Set<ScheduledRepairJob> currentJobs = myScheduledJobs.get(node.getHostId()).get(tableReference);
-        Map<TableReference, Set<ScheduledRepairJob>> tableJob = new HashMap<>();
+        Map<TableReference, Set<ScheduledRepairJob>> tableJob = myScheduledJobs.get(node.getHostId());
+        if (tableJob == null)
+        {
+            tableJob = new HashMap<>();
+        }
         if (currentJobs != null)
         {
             for (ScheduledRepairJob job : currentJobs)

--- a/core.impl/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/scheduler/TestRepairSchedulerImpl.java
+++ b/core.impl/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/scheduler/TestRepairSchedulerImpl.java
@@ -142,7 +142,7 @@ public class TestRepairSchedulerImpl
         verify(myRepairState, atLeastOnce()).update();
 
         repairSchedulerImpl.close();
-        verify(scheduleManager, times(1)).deschedule(eq(mockNodeID), any(ScheduledJob.class));
+        verify(scheduleManager, times(2)).deschedule(eq(mockNodeID), any(ScheduledJob.class));
 
         verifyNoMoreInteractions(ignoreStubs(myTableRepairMetrics));
         verifyNoMoreInteractions(myRepairStateFactory);


### PR DESCRIPTION
Fixes RepairSchedulerImpl so that it does not lose earlier table definitions