### PR TITLE
#1095 node unable to be connected via jmx after it has joined the cluster

### DIFF
--- a/connection.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/connection/impl/providers/DistributedJmxConnectionProviderImpl.java
+++ b/connection.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/connection/impl/providers/DistributedJmxConnectionProviderImpl.java
@@ -64,7 +64,7 @@ public class DistributedJmxConnectionProviderImpl implements DistributedJmxConne
         {
             jmxConnector.getConnectionId();
         }
-        catch (IOException e)
+        catch (IOException | NullPointerException e)
         {
             return false;
         }


### PR DESCRIPTION
Catch null pointer exception so that the retry loop will work and the jmx connection made when the node is ready to accept jmx connections 