### PR TITLE
Sync dependency versions with old ecchrons

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -31,16 +31,16 @@ jobs:
            test_suite: 'verify -P standalone-integration-tests -DskipUTs'
            artifacts_dir: "standalone-integration/target"
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - name: Cache local Maven repository
-        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: ~/.m2/repository
           key: build-${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             build-${{ runner.os }}-maven-
       - name: Set up JDK
-        uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
+        uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 # v5.0.0
         with:
           java-version: 17
           distribution: 'temurin'

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -32,12 +32,12 @@ jobs:
 
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           persist-credentials: false
 
       - name: "Run analysis"
-        uses: ossf/scorecard-action@f49aabe0b5af0936a0987cfb85d86b75731b0186 # v2.4.1
+        uses: ossf/scorecard-action@05b42c624433fc40578a4040d5cf5e36ddca8cde # v2.4.2
         with:
           results_file: results.sarif
           results_format: sarif
@@ -67,7 +67,7 @@ jobs:
 
       # Upload the results to GitHub's code scanning dashboard.
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@28deaeda66b76a05916b6923827895f2b14ab387 # v3.28.16
+        uses: github/codeql-action/upload-sarif@2d92b76c45b91eb80fc44c74ce3fce0ee94e8f9d # v3.29.5
         with:
           sarif_file: results.sarif
 

--- a/pom.xml
+++ b/pom.xml
@@ -109,35 +109,36 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!-- Spring boot -->
-        <org.springframework.boot.version>3.5.0</org.springframework.boot.version>
-        <springdoc.openapi-starter-webmvc-ui.version>2.8.8</springdoc.openapi-starter-webmvc-ui.version>
+        <org.springframework.boot.version>3.5.5</org.springframework.boot.version>
+        <springdoc.openapi-starter-webmvc-ui.version>2.8.13</springdoc.openapi-starter-webmvc-ui.version>
         <jakarta.servlet-api.version>6.1.0</jakarta.servlet-api.version>
         <jakarta.validation-api.version>3.1.1</jakarta.validation-api.version>
-        <swagger-annotations.version>2.2.32</swagger-annotations.version>
+        <swagger-annotations.version>2.2.36</swagger-annotations.version>
 
         <!-- Cassandra -->
         <cassandra.driver.core.version>4.19.0</cassandra.driver.core.version>
-        <com.typesafe.config.version>1.4.3</com.typesafe.config.version>
+        <com.typesafe.config.version>1.4.4</com.typesafe.config.version>
         <guava.version>33.4.8-jre</guava.version>
-        <caffeine.version>3.2.0</caffeine.version>
+        <caffeine.version>3.2.2</caffeine.version>
         <slf4j.version>2.0.17</slf4j.version>
         <logback.version>1.5.18</logback.version>
 
         <!-- Jackson -->
-        <com.fasterxml.jackson.core.version>2.19.0</com.fasterxml.jackson.core.version>
-        <com.fasterxml.jackson.dataformat.version>2.19.0</com.fasterxml.jackson.dataformat.version>
-        <org.yaml.snakeyaml.version>2.4</org.yaml.snakeyaml.version>
+        <com.fasterxml.jackson.core.version>2.20.0</com.fasterxml.jackson.core.version>
+        <com.fasterxml.jackson.annotations.version>2.20</com.fasterxml.jackson.annotations.version>
+        <com.fasterxml.jackson.dataformat.version>2.20.0</com.fasterxml.jackson.dataformat.version>
+        <org.yaml.snakeyaml.version>2.5</org.yaml.snakeyaml.version>
 
         <!-- Tests -->
-        <mockito.core.version>5.18.0</mockito.core.version>
-        <assertj.version>3.27.3</assertj.version>
-        <junit.version>5.12.2</junit.version>
-        <org.apache.commons.io.version>2.19.0</org.apache.commons.io.version>
-        <org.apache.commons.commons-compress.version>1.27.1</org.apache.commons.commons-compress.version>
-        <equalsverifier.version>4.0</equalsverifier.version>
+        <mockito.core.version>5.19.0</mockito.core.version>
+        <assertj.version>3.27.4</assertj.version>
+        <junit.version>5.13.4</junit.version>
+        <org.apache.commons.io.version>2.20.0</org.apache.commons.io.version>
+        <org.apache.commons.commons-compress.version>1.28.0</org.apache.commons.commons-compress.version>
+        <equalsverifier.version>4.1</equalsverifier.version>
         <jcip.version>1.0</jcip.version>
-        <testcontainers.version>1.21.0</testcontainers.version>
-        <org.bouncycastle.bcpkix-jdk18on.version>1.80</org.bouncycastle.bcpkix-jdk18on.version>
+        <testcontainers.version>1.21.3</testcontainers.version>
+        <org.bouncycastle.bcpkix-jdk18on.version>1.81</org.bouncycastle.bcpkix-jdk18on.version>
 
         <!-- Plugin versions -->
         <com.mycila.license-maven-plugin.version>5.0.0</com.mycila.license-maven-plugin.version>
@@ -148,10 +149,10 @@
         <org.apache.maven.plugins-maven-dependency-plugin.version>3.8.1</org.apache.maven.plugins-maven-dependency-plugin.version>
         <org.apache.maven.plugins.maven-deploy-plugin.version>3.1.4</org.apache.maven.plugins.maven-deploy-plugin.version>
         <org.apache.maven.plugins.maven-failsafe-plugin.version>3.5.3</org.apache.maven.plugins.maven-failsafe-plugin.version>
-        <org.apache.maven.plugins.maven-gpg-plugin.version>3.2.7</org.apache.maven.plugins.maven-gpg-plugin.version>
+        <org.apache.maven.plugins.maven-gpg-plugin.version>3.2.8</org.apache.maven.plugins.maven-gpg-plugin.version>
         <org.apache.maven.plugins.maven-install-plugin.version>3.1.4</org.apache.maven.plugins.maven-install-plugin.version>
         <org.apache.maven.plugins-maven-jar-plugin.version>3.4.2</org.apache.maven.plugins-maven-jar-plugin.version>
-        <org.apache.maven.plugins.maven-javadoc-plugin.version>3.11.2</org.apache.maven.plugins.maven-javadoc-plugin.version>
+        <org.apache.maven.plugins.maven-javadoc-plugin.version>3.11.3</org.apache.maven.plugins.maven-javadoc-plugin.version>
         <org.apache.maven.plugins-maven-pmd-plugin.version>3.26.0</org.apache.maven.plugins-maven-pmd-plugin.version>
         <org.apache.maven.plugins.maven-release-plugin.version>3.1.1</org.apache.maven.plugins.maven-release-plugin.version>
         <org.apache.maven.plugins-maven-resources-plugin.version>3.3.1</org.apache.maven.plugins-maven-resources-plugin.version>
@@ -159,10 +160,10 @@
         <org.apache.maven.plugins.maven-source-plugin.version>3.3.1</org.apache.maven.plugins.maven-source-plugin.version>
         <org.apache.maven.plugins.maven-surefire-plugin.version>3.5.3</org.apache.maven.plugins.maven-surefire-plugin.version>
         <org.apache.servicemix.tooling.depends-maven-plugin.version>1.5.0</org.apache.servicemix.tooling.depends-maven-plugin.version>
-        <org.codehaus.mojo.exec-maven-plugin.version>3.5.0</org.codehaus.mojo.exec-maven-plugin.version>
-        <org.codehaus.mojo.license-maven-plugin.version>2.5.0</org.codehaus.mojo.license-maven-plugin.version>
+        <org.codehaus.mojo.exec-maven-plugin.version>3.5.1</org.codehaus.mojo.exec-maven-plugin.version>
+        <org.codehaus.mojo.license-maven-plugin.version>2.6.0</org.codehaus.mojo.license-maven-plugin.version>
         <org.jacoco.jacoco-maven-plugin.version>0.8.13</org.jacoco.jacoco-maven-plugin.version>
-        <org.sonatype.central-central-publishing-maven-plugin>0.7.0</org.sonatype.central-central-publishing-maven-plugin>
+        <org.sonatype.central-central-publishing-maven-plugin>0.8.0</org.sonatype.central-central-publishing-maven-plugin>
 
         <jolokia.adapter.version>2.1.1</jolokia.adapter.version>
 
@@ -181,13 +182,6 @@
                 <artifactId>commons-compress</artifactId>
                 <version>${org.apache.commons.commons-compress.version}</version>
                 <scope>test</scope>
-            </dependency>
-
-            <!-- Used by spring-boot-starter-web -->
-            <dependency>
-                <groupId>jakarta.servlet</groupId>
-                <artifactId>jakarta.servlet-api</artifactId>
-                <version>${jakarta.servlet-api.version}</version>
             </dependency>
 
             <!-- Used by java-driver -->
@@ -212,6 +206,12 @@
                 <groupId>org.springdoc</groupId>
                 <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
                 <version>${springdoc.openapi-starter-webmvc-ui.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>jakarta.servlet</groupId>
+                <artifactId>jakarta.servlet-api</artifactId>
+                <version>${jakarta.servlet-api.version}</version>
             </dependency>
 
             <!-- Cassandra Driver -->
@@ -306,7 +306,7 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-annotations</artifactId>
-                <version>${com.fasterxml.jackson.core.version}</version>
+                <version>${com.fasterxml.jackson.annotations.version}</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
I did not update the pmd-plugin since that will trigger new pmd rules, we can do that later.