### PR TITLE
Fix ClassCastException when using Jolokia and add Integration Tests

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -118,3 +118,76 @@ jobs:
             ./core/target/site/jacoco/jacoco.xml,
             ./fm.impl/target/site/jacoco/jacoco.xml,
             ./connection/target/site/jacoco/jacoco.xml
+
+  jolokia-tests:
+    runs-on: ubuntu-latest
+    needs: tests
+    if: always() # Run even if main tests fail
+    strategy:
+      fail-fast: false
+      matrix:
+       include:
+          # Java 17 Jolokia tests
+          - name: "Jolokia Standalone integration 4.1 - Java 17"
+            java_version: 17
+            test_suite: 'verify -P standalone-integration-tests -Dit.cassandra.version=4.1 -Djava.version=17 -Dit.jolokia.enabled=true -DskipUTs'
+            artifacts_dir: "standalone-integration/target"
+          - name: "Jolokia Standalone integration 5.0 - Java 17"
+            java_version: 17
+            test_suite: 'verify -P standalone-integration-tests -Dit.cassandra.version=5.0 -Djava.version=17 -Dit.jolokia.enabled=true -DskipUTs'
+            artifacts_dir: "standalone-integration/target"
+          - name: "Jolokia Python integration - Java 17"
+            java_version: 17
+            test_suite: 'verify -P python-integration-tests -Dit.cassandra.version=5.0 -Djava.version=17 -Dit.jolokia.enabled=true -DskipUTs'
+            artifacts_dir: "ecchronos-binary/target"
+
+          # Java 21 Jolokia tests
+          - name: "Jolokia Standalone integration 4.1 - Java 21"
+            java_version: 21
+            test_suite: 'verify -P standalone-integration-tests -Dit.cassandra.version=4.1 -Djava.version=21 -Dit.jolokia.enabled=true -DskipUTs'
+            artifacts_dir: "standalone-integration/target"
+          - name: "Jolokia Standalone integration 5.0 - Java 21"
+            java_version: 21
+            test_suite: 'verify -P standalone-integration-tests -Dit.cassandra.version=5.0 -Djava.version=21 -Dit.jolokia.enabled=true -DskipUTs'
+            artifacts_dir: "standalone-integration/target"
+          - name: "Jolokia Python integration - Java 21"
+            java_version: 21
+            test_suite: 'verify -P python-integration-tests -Dit.cassandra.version=5.0 -Djava.version=21 -Dit.jolokia.enabled=true -DskipUTs'
+            artifacts_dir: "ecchronos-binary/target"
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - name: Cache local Maven repository
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+        with:
+          path: ~/.m2/repository
+          key: build-${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            build-${{ runner.os }}-maven-
+
+      - name: Set up JDK ${{ matrix.java_version }}
+        uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 # v5.0.0
+        with:
+          java-version: ${{ matrix.java_version }}
+          distribution: 'temurin'
+
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      - name: Set up Python 3
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: 3.12 #current python-driver only support up to 3.12
+
+      - name: Install black
+        run: python -m pip install black==24.10.0
+
+      - name: Run black in the check mode
+        run: black --check --verbose --line-length 120 ./ecchronos-binary/src
+
+      - name: install dependencies
+        run: mvn install -Pbuild-cassandra-test-jar -DskipTests=true
+
+      - run: mvn $TEST_SUITE -B
+        id: tests
+        env:
+          TEST_SUITE: ${{ matrix.test_suite }}
+

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Version 1.0.0 (Not yet Released)
 
+* Create Integration Tests Using the New Jolokia Functionality - Issue #845
+* ClassCastException when using Jolokia for JMX metrics retrieval - Issue #1126
 * ecc.sh in evolved ecchronos uses old SpringBooter package reference - Issue #1123
 * ecctool with node and keyspace gives an error -Issue #1055
 * REST Interface to provide list of nodes - Issue #1045

--- a/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/OnDemandStatus.java
+++ b/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/OnDemandStatus.java
@@ -207,12 +207,20 @@ public final class OnDemandStatus
             OngoingJob.Status status;
             try
             {
-                status = OngoingJob.Status.valueOf(row.getString(STATUS_COLUMN_NAME));
+                String statusStr = row.getString(STATUS_COLUMN_NAME);
+                if (statusStr == null || statusStr.trim().isEmpty())
+                {
+                    LOG.warn("Ignoring table repair job with id {}, status is null or empty",
+                            row.getUuid(JOB_ID_COLUMN_NAME));
+                    continue;
+                }
+                status = OngoingJob.Status.valueOf(statusStr);
             }
             catch (IllegalArgumentException e)
             {
-                LOG.warn("Ignoring table repair job with id {}, unable to parse status",
-                        row.getUuid(JOB_ID_COLUMN_NAME));
+                LOG.warn("Ignoring table repair job with id {}, unable to parse status: {}",
+                        row.getUuid(JOB_ID_COLUMN_NAME),
+                        row.getString(STATUS_COLUMN_NAME));
                 continue;
             }
 
@@ -263,13 +271,22 @@ public final class OnDemandStatus
             OngoingJob.Status status;
             try
             {
-                status = OngoingJob.Status.valueOf(row.getString(STATUS_COLUMN_NAME));
+                String statusStr = row.getString(STATUS_COLUMN_NAME);
+                if (statusStr == null || statusStr.trim().isEmpty())
+                {
+                    LOG.warn("Ignoring table repair job with id {} and hostId {}, status is null or empty",
+                            row.getUuid(JOB_ID_COLUMN_NAME),
+                            hostId);
+                    continue;
+                }
+                status = OngoingJob.Status.valueOf(statusStr);
             }
             catch (IllegalArgumentException e)
             {
-                LOG.warn("Ignoring table repair job with id {} and hostId {}, unable to parse status",
+                LOG.warn("Ignoring table repair job with id {} and hostId {}, unable to parse status: {}",
                         row.getUuid(JOB_ID_COLUMN_NAME),
-                        hostId);
+                        hostId,
+                        row.getString(STATUS_COLUMN_NAME));
                 continue;
             }
 

--- a/ecchronos-binary/src/test/bin/cass_config.py
+++ b/ecchronos-binary/src/test/bin/cass_config.py
@@ -39,7 +39,7 @@ class CassandraCluster:
         self.local = local
         os.environ["CERTIFICATE_DIRECTORY"] = global_vars.CERTIFICATE_DIRECTORY
         os.environ["CASSANDRA_VERSION"] = global_vars.CASSANDRA_VERSION
-        os.environ["JOLOKIA_ENABLED"] = global_vars.JOLOKIA_ENABLED
+        os.environ["JOLOKIA"] = global_vars.JOLOKIA_ENABLED
         os.environ["DOCKER_BUILDKIT"] = "1"
         self.cassandra_compose = DockerCompose(
             global_vars.CASSANDRA_DOCKER_COMPOSE_FILE_PATH,

--- a/ecchronos-binary/src/test/bin/ecc_config.py
+++ b/ecchronos-binary/src/test/bin/ecc_config.py
@@ -33,6 +33,9 @@ class EcchronosConfig:
         self._modify_scheduler_configuration()
         self._modify_spring_doc_configuration()
 
+        if global_vars.JOLOKIA_ENABLED == "true":
+            self._modify_jolokia_configuration()
+
         if self.context.local != "true":
             self._modify_security_configuration()
             self._modify_application_configuration()
@@ -182,6 +185,11 @@ class EcchronosConfig:
             },
         ]
         self._modify_yaml_data(global_vars.SCHEDULE_YAML_FILE_PATH, data)
+
+    def _modify_jolokia_configuration(self):
+        data = self._read_yaml_data(global_vars.ECC_YAML_FILE_PATH)
+        data["connection"]["jmx"]["jolokia"]["enabled"] = True
+        self._modify_yaml_data(global_vars.ECC_YAML_FILE_PATH, data)
 
     def _read_yaml_data(self, filename):
         with open(filename, "r") as f:

--- a/standalone-integration/src/test/java/com/ericsson/bss/cassandra/ecchronos/standalone/TestBase.java
+++ b/standalone-integration/src/test/java/com/ericsson/bss/cassandra/ecchronos/standalone/TestBase.java
@@ -76,6 +76,7 @@ abstract public class TestBase
 
     protected static Node MyLocalNode;
     private static final Object lock = new Object();
+    private static boolean myJolokiaEnabled;
 
     @BeforeClass
     public static void initialize() throws IOException
@@ -89,6 +90,8 @@ abstract public class TestBase
             Thread.currentThread().interrupt();
             throw new IOException("Cluster initialization interrupted", e);
         }
+        String jolokiaEnabled = System.getProperty("it.jolokia.enabled", "false");
+        myJolokiaEnabled = jolokiaEnabled == "true" ? true : false;
         List<InetSocketAddress> contactPoints = new ArrayList<>();
         CqlSession initialSession = createDefaultSession();
 
@@ -126,7 +129,7 @@ abstract public class TestBase
         myJmxConnectionProvider = DistributedJmxConnectionProviderImpl.builder()
                 .withCqlSession(myNativeConnectionProvider.getCqlSession())
                 .withNativeConnection(myNativeConnectionProvider)
-                .withJolokiaEnabled(false)
+                .withJolokiaEnabled(myJolokiaEnabled)
                 .withEccNodesSync(myEccNodesSync)
                 .build();
 
@@ -205,7 +208,7 @@ abstract public class TestBase
     private static CqlSessionBuilder defaultBuilder()
     {
         return CqlSession.builder()
-                .addContactPoint(new InetSocketAddress(SharedCassandraCluster.getContainerIP(), 9042))
+                .addContactPoint(new InetSocketAddress(SharedCassandraCluster.getContainerIP(), CASSANDRA_NATIVE_PORT))
                 .withLocalDatacenter("datacenter1")
                 .withAuthCredentials("cassandra", "cassandra");
     }


### PR DESCRIPTION
Fix Cast exceptions when jolokia is used and add ITs, as I'm adding more actions rules, it is better to separate the workflows to avoid too much concurrency process in actions machines, this avoids flakiness results (It might be good to do the same for java 17/21 tests in the future)

Closes #1126 and #845