### PR TITLE
Fix: cleanHostName with K8S CoreDNS pattern

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -238,7 +238,7 @@ These three layers provide comprehensive coverage for topology changes:
 Due to a specific timing window where a node might still be initializing and the driver might not send an `onAdd` notification, an additional reload mechanism is implemented:
 
 - **ReloadSchedulerService**: A scheduled service that periodically triggers a complete topology reload
-- **Configurable Interval**: The reload frequency can be configured via `connection.cql.agent.reloadTopologyIntervalInSeconds`
+- **Configurable Interval**: The reload frequency can be configured via `connection.cql.reloadSchedule`
 - **Full Rebuild**: During reload, the entire node topology map is reconstructed from the current cluster state
 
 This multi-layered approach ensures that topology changes are detected and handled reliably, even in edge cases where immediate event notifications might be missed.

--- a/utils/src/main/java/com/ericsson/bss/cassandra/ecchronos/utils/dns/ReverseDNS.java
+++ b/utils/src/main/java/com/ericsson/bss/cassandra/ecchronos/utils/dns/ReverseDNS.java
@@ -28,8 +28,11 @@ import org.slf4j.LoggerFactory;
 public final class ReverseDNS
 {
     private static final Logger LOG = LoggerFactory.getLogger(ReverseDNS.class);
-    private static final Pattern IPV4_PREFIX = Pattern.compile("^((25[0-5]|(2[0-4]|1\\d|[1-9]|)\\d)\\.){4}");
-    private static final Pattern IPV6_PREFIX = Pattern.compile("^([0-9a-fA-F]{0,4}:){2,7}[0-9a-fA-F]{0,4}\\.");
+    private static final Pattern IPV4_PREFIX_DEFAULT = Pattern.compile("^((25[0-5]|(2[0-4]|1\\d|[1-9]|)\\d)\\.){4}");
+    private static final Pattern IPV6_PREFIX_DEFAULT = Pattern.compile("^([0-9a-fA-F]{0,4}:){2,7}[0-9a-fA-F]{0,4}\\.");
+
+    private static final Pattern IPV4_PREFIX_K8S = Pattern.compile("^((25[0-5]|(2[0-4]|1\\d|[1-9]|)\\d)\\-){3}((25[0-5]|(2[0-4]|1\\d|[1-9]|)\\d))\\.");
+    private static final Pattern IPV6_PREFIX_K8S = Pattern.compile("^([0-9a-fA-F]{1,4}\\-){2,}([0-9a-fA-F]{0,4}\\-)*[0-9a-fA-F]{0,4}\\.");
 
     private ReverseDNS()
     {
@@ -80,13 +83,23 @@ public final class ReverseDNS
         }
 
         // Remove IPv4 prefix
-        String result = IPV4_PREFIX.matcher(hostname).replaceFirst("");
-        if (!result.equals(hostname))
+        if (IPV4_PREFIX_DEFAULT.matcher(hostname).find())
         {
-            return result;
+            return IPV4_PREFIX_DEFAULT.matcher(hostname).replaceFirst("");
+        }
+        else if (IPV4_PREFIX_K8S.matcher(hostname).find())
+        {
+            return IPV4_PREFIX_K8S.matcher(hostname).replaceFirst("");
+        }
+        else if (IPV6_PREFIX_DEFAULT.matcher(hostname).find())
+        {
+            return IPV6_PREFIX_DEFAULT.matcher(hostname).replaceFirst("");
+        }
+        else if (IPV6_PREFIX_K8S.matcher(hostname).find())
+        {
+            return IPV6_PREFIX_K8S.matcher(hostname).replaceFirst("");
         }
 
-        // Remove IPv6 prefix
-        return IPV6_PREFIX.matcher(hostname).replaceFirst("");
+        return hostname;
     }
 }

--- a/utils/src/test/java/com/ericsson/bss/cassandra/ecchronos/utils/dns/TestReverseDNS.java
+++ b/utils/src/test/java/com/ericsson/bss/cassandra/ecchronos/utils/dns/TestReverseDNS.java
@@ -90,6 +90,45 @@ public class TestReverseDNS
         assertEquals(onlyIPv4, invokeCleanHostname(onlyIPv4));
     }
 
+    @Test
+    public void testCleanHostnameWithIPPrefixK8S()
+    {
+        // K8s scenario: IP concatenated with pod DNS
+        String input = "10-244-1-5.cassandra-0.cassandra.default.svc.cluster.local";
+        String expected = "cassandra-0.cassandra.default.svc.cluster.local";
+        
+        String result = invokeCleanHostname(input);
+        assertEquals(expected, result);
+    }
+
+
+    @Test
+    public void testCleanHostnameIPv6K8S()
+    {
+        // Real IPv6 scenario - test with actual IPv6 format
+        String ipv6Input = "2001-db8--1.cassandra-0.cassandra.default.svc.cluster.local";
+        String expected = "cassandra-0.cassandra.default.svc.cluster.local";
+
+        String result = invokeCleanHostname(ipv6Input);
+        assertEquals(expected, result);
+    }
+
+    @Test
+    public void testCleanHostnameEdgeCasesK8S()
+    {
+        // Malformed IP prefix (incomplete IPv4)
+        String malformed = "10-244.cassandra-0.default.svc.cluster.local";
+        assertEquals(malformed, invokeCleanHostname(malformed)); // Should not match
+
+        // IPv6 real format - should be cleaned
+        String ipv6Raw = "2001-db8--1.pod-name.namespace.svc.cluster.local";
+        assertEquals("pod-name.namespace.svc.cluster.local", invokeCleanHostname(ipv6Raw));
+
+        // Edge case: only IP without DNS
+        String onlyIPv4 = "192-168-1-100";
+        assertEquals(onlyIPv4, invokeCleanHostname(onlyIPv4));
+    }
+
     // Helper method to access private cleanHostname method via reflection
     private String invokeCleanHostname(String hostname)
     {


### PR DESCRIPTION
Fix cleanHostName to handle k8s ip pattern described in https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pods