### PR TITLE
#1179 Add check during startup to ensure there are enough local nodes

### DIFF
--- a/connection.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/connection/impl/builders/DistributedNativeBuilder.java
+++ b/connection.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/connection/impl/builders/DistributedNativeBuilder.java
@@ -237,7 +237,7 @@ public class DistributedNativeBuilder
         Optional<KeyspaceMetadata> keyspaceMetadata = session
                 .getMetadata()
                 .getKeyspace(ecchronosKeyspaceName);
-        if (keyspaceMetadata == null)
+        if (keyspaceMetadata.isEmpty())
         {
             throw new IllegalStateException("ecchronos Keyspace is not setup yet");
         }

--- a/connection.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/connection/impl/providers/DistributedNativeConnectionProviderImpl.java
+++ b/connection.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/connection/impl/providers/DistributedNativeConnectionProviderImpl.java
@@ -16,6 +16,7 @@ package com.ericsson.bss.cassandra.ecchronos.connection.impl.providers;
 
 import com.datastax.oss.driver.api.core.CqlSession;
 import com.datastax.oss.driver.api.core.metadata.Node;
+import com.datastax.oss.driver.api.core.metadata.NodeState;
 import com.ericsson.bss.cassandra.ecchronos.connection.DistributedNativeConnectionProvider;
 import com.ericsson.bss.cassandra.ecchronos.connection.impl.builders.DistributedNativeBuilder;
 
@@ -162,6 +163,7 @@ public class DistributedNativeConnectionProviderImpl implements DistributedNativ
         Integer replicationFactor = Integer.parseInt(replication.get(localDatacenter));
 
         Long localNodeCount = myNodes.entrySet().stream()
+                .filter(node -> node.getValue().getState().equals(NodeState.UP))
                 .filter(node -> node.getValue().getDatacenter().equals(localDatacenter)).count();
 
         int quorumValue = (replicationFactor / 2) + 1;


### PR DESCRIPTION
Add check during startup to ensure there are enough local nodes to allow local_quorum on the ecchronos keyspace