### PR TITLE
Fix: Installing curl through Dockerfile

### DIFF
--- a/cassandra-test-image/src/main/docker/Dockerfile
+++ b/cassandra-test-image/src/main/docker/Dockerfile
@@ -1,6 +1,10 @@
 ARG CASSANDRA_VERSION
 FROM cassandra:${CASSANDRA_VERSION}
 
+RUN apt-get update \
+    && apt-get install -y curl \
+    && rm -rf /var/lib/apt/lists/*
+
 COPY ecc-entrypoint.sh /usr/local/bin/
 RUN ln -s usr/local/bin/ecc-entrypoint.sh /ecc-entrypoint.sh
 


### PR DESCRIPTION
Installing curl in Dockerfile because someone decided to remove it from base image.