### PR TITLE
Log yaml config at startup

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 
 ## Version 1.0.0-beta2
 
+* Log yaml config at startup
 * Improve concurrency in IpTranslator
 * Create DatacenterAware Integration tests with Multi Agent setup - Issue #1382
 * Strip port number from internal ip address in IpTranslator

--- a/application/src/main/java/com/ericsson/bss/cassandra/ecchronos/application/config/Config.java
+++ b/application/src/main/java/com/ericsson/bss/cassandra/ecchronos/application/config/Config.java
@@ -22,6 +22,10 @@ import com.ericsson.bss.cassandra.ecchronos.application.config.rest.RestServerCo
 import com.ericsson.bss.cassandra.ecchronos.application.config.runpolicy.RunPolicyConfig;
 import com.ericsson.bss.cassandra.ecchronos.application.config.scheduler.SchedulerConfig;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 
 public class Config
 {
@@ -152,6 +156,27 @@ public class Config
         if (lockFactoryConfig != null)
         {
             myLockFactoryConfig = lockFactoryConfig;
+        }
+    }
+
+    /**
+     * Returns a YAML representation of the configuration.
+     *
+     * @return YAML string representation of the configuration.
+     */
+    @Override
+    public String toString()
+    {
+        try
+        {
+            ObjectMapper mapper = new ObjectMapper();
+            mapper.registerModule(new Jdk8Module());
+            mapper.disable(SerializationFeature.FAIL_ON_EMPTY_BEANS);
+            return mapper.writeValueAsString(this);
+        }
+        catch (JsonProcessingException e)
+        {
+            return "Config{error=" + e.getMessage() + "}";
         }
     }
 }

--- a/application/src/main/java/com/ericsson/bss/cassandra/ecchronos/application/config/security/CqlTLSConfig.java
+++ b/application/src/main/java/com/ericsson/bss/cassandra/ecchronos/application/config/security/CqlTLSConfig.java
@@ -116,6 +116,7 @@ public class CqlTLSConfig implements TLSConfig
     }
 
     @Override
+    @JsonProperty(value = "keystore_password", access = JsonProperty.Access.WRITE_ONLY)
     public final String getKeyStorePassword()
     {
         return myKeyStorePassword;
@@ -128,6 +129,7 @@ public class CqlTLSConfig implements TLSConfig
     }
 
     @Override
+    @JsonProperty(value = "truststore_password", access = JsonProperty.Access.WRITE_ONLY)
     public final String getTrustStorePassword()
     {
         return myTrustStorePassword;

--- a/application/src/main/java/com/ericsson/bss/cassandra/ecchronos/application/config/security/Credentials.java
+++ b/application/src/main/java/com/ericsson/bss/cassandra/ecchronos/application/config/security/Credentials.java
@@ -60,7 +60,7 @@ public class Credentials
         myUsername = username;
     }
 
-    @JsonProperty("password")
+    @JsonProperty(value = "password", access = JsonProperty.Access.WRITE_ONLY)
     public final String getPassword()
     {
         return myPassword;

--- a/application/src/main/java/com/ericsson/bss/cassandra/ecchronos/application/config/security/JmxTLSConfig.java
+++ b/application/src/main/java/com/ericsson/bss/cassandra/ecchronos/application/config/security/JmxTLSConfig.java
@@ -106,6 +106,7 @@ public class JmxTLSConfig implements TLSConfig
     }
 
     @Override
+    @JsonProperty(value = "keystore_password", access = JsonProperty.Access.WRITE_ONLY)
     public final String getKeyStorePassword()
     {
         return myKeyStorePassword;
@@ -118,6 +119,7 @@ public class JmxTLSConfig implements TLSConfig
     }
 
     @Override
+    @JsonProperty(value = "truststore_password", access = JsonProperty.Access.WRITE_ONLY)
     public final String getTrustStorePassword()
     {
         return myTrustStorePassword;

--- a/application/src/main/java/com/ericsson/bss/cassandra/ecchronos/application/config/security/Security.java
+++ b/application/src/main/java/com/ericsson/bss/cassandra/ecchronos/application/config/security/Security.java
@@ -15,6 +15,10 @@
 package com.ericsson.bss.cassandra.ecchronos.application.config.security;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 
 public final class Security
 {
@@ -43,6 +47,27 @@ public final class Security
     public void setJmxSecurity(final JmxSecurity jmxSecurity)
     {
         myJmxSecurity = jmxSecurity;
+    }
+
+    /**
+     * Returns a YAML representation of the security configuration.
+     *
+     * @return YAML string representation of the security configuration.
+     */
+    @Override
+    public String toString()
+    {
+        try
+        {
+            ObjectMapper mapper = new ObjectMapper();
+            mapper.registerModule(new Jdk8Module());
+            mapper.disable(SerializationFeature.FAIL_ON_EMPTY_BEANS);
+            return mapper.writeValueAsString(this);
+        }
+        catch (JsonProcessingException e)
+        {
+            return "Security{error=" + e.getMessage() + "}";
+        }
     }
 
     public static final class CqlSecurity

--- a/application/src/main/java/com/ericsson/bss/cassandra/ecchronos/application/spring/BeanConfigurator.java
+++ b/application/src/main/java/com/ericsson/bss/cassandra/ecchronos/application/spring/BeanConfigurator.java
@@ -90,6 +90,8 @@ public class BeanConfigurator
      */
     public BeanConfigurator() throws ConfigurationException, UnknownHostException
     {
+        Security security = getSecurityConfig();
+        LOG.info("Security configuration loaded:\n{}", security);
         if (ConfigurationHelper.DEFAULT_INSTANCE.usePath())
         {
             configRefresher = new ConfigRefresher(ConfigurationHelper.DEFAULT_INSTANCE.getConfigPath());
@@ -100,7 +102,6 @@ public class BeanConfigurator
         {
             configRefresher = null;
         }
-        Security security = getSecurityConfig();
         cqlSecurity.set(security.getCqlSecurity());
         jmxSecurity.set(security.getJmxSecurity());
         ecChronosID = getConfiguration().getConnectionConfig().getCqlConnection().getInstanceName();
@@ -127,7 +128,9 @@ public class BeanConfigurator
     @Bean
     public Config config() throws ConfigurationException
     {
-        return getConfiguration();
+        Config config = getConfiguration();
+        LOG.info("Application configuration loaded:\n{}", config);
+        return config;
     }
 
     /**


### PR DESCRIPTION
I'm really tired of guessing what the config might be when I get a log, this will dump the yaml config, excluding passwords, in the log when ecChronos starts. Its done basically as two one liners, but they are quite long lines. It will look something like this:

> 14:20:55.101 [main] INFO  c.e.b.c.e.a.spring.BeanConfigurator - Security configuration loaded: {"cql":{"tls":{"enabled":false,"certificateConfigured":false,"certificatePath":null,"certificatePrivateKeyPath":null,"trustCertificatePath":null,"keyStorePath":"/path/to/keystore","trustStorePath":"/path/to/truststore","protocols":["TLSv1.2"],"algorithm":null,"cipher_suites":null,"store_type":"JKS","crl":{"path":"/path/to/file.crl","strict":false,"enabled":false,"interval":300,"attempts":5}},"credentials":{"enabled":true,"username":"cassandra"}},"jmx":{"tls":{"enabled":false,"certificateConfigured":false,"certificatePath":null,"certificatePrivateKeyPath":null,"trustCertificatePath":null,"keyStorePath":"/path/to/keystore","trustStorePath":"/path/to/truststore","protocols":["TLSv1.2"],"cipherSuitesAsString":null,"protocol":"TLSv1.2","algorithm":null,"cipher_suites":null,"store_type":null,"crl":{"path":"","strict":false,"enabled":false,"interval":300,"attempts":5}},"credentials":{"enabled":true,"username":"cassandra"}}}
> 14:20:55.233 [main] INFO  c.e.b.c.e.a.spring.BeanConfigurator - Application configuration loaded: {"connection":{"cql":{"type":"datacenterAware","instanceName":"ecchronos-agent-cluster-wide","reloadSchedule":{"initialDelay":1000,"fixedDelay":1000,"unit":"DAYS"},"datacenterAware":{"datacenters":{"datacenter1":{"name":"datacenter1"},"datacenter2":{"name":"datacenter2"}}},"rackAware":{"racks":{"rack1":{"rackName":"rack1","datacenterName":"datacenter1"},"rack2":{"rackName":"rack2","datacenterName":"datacenter1"}}},"hostAware":{"hosts":{"127.0.0.4":{"host":"127.0.0.4","port":9042},"127.0.0.3":{"host":"127.0.0.3","port":9042},"127.0.0.2":{"host":"127.0.0.2","port":9042},"127.0.0.1":{"host":"127.0.0.1","port":9042}}},"connectionDelay":{"time":45,"unit":"MINUTES"},"timeout":{},"contactPoints":{"172.29.0.2":{"host":"172.29.0.2","port":9042}},"localDatacenter":"datacenter1","retryPolicy":{"unit":"SECONDS","delay":5000,"maxAttempts":5,"maxDelay":30000},"provider":"com.ericsson.bss.cassandra.ecchronos.application.providers.AgentNativeConnectionProvider","certificateHandler":"com.ericsson.bss.cassandra.ecchronos.application.config.security.ReloadingCertificateHandler"},"jmx":{"retryPolicy":{"maxAttempts":5,"delay":{"start":5000,"max":30000,"unit":"SECONDS"},"retrySchedule":{"initialDelay":1000,"fixedDelay":1000,"unit":"DAYS"}},"reverseDNSResolution":false,"runDelay":500,"heathCheckInterval":10,"jolokia":{"port":8778,"enabled":true,"usePem":false},"useBroadcastRPCAddress":true,"provider":"com.ericsson.bss.cassandra.ecchronos.application.providers.AgentJmxConnectionProvider","certificateHandler":null},"threadPool":{"maxPoolSize":10,"keepAliveSeconds":60,"queueCapacity":20,"corePoolSize":4}},"rest_server":{"host":"localhost","port":8080},"statistics":{"enabled":true,"reporting":{"jmxReportingEnabled":true,"fileReportingEnabled":true,"httpReportingEnabled":true,"jmx":{"enabled":true,"excludedMetrics":[]},"file":{"enabled":true,"excludedMetrics":[]},"http":{"enabled":true,"excludedMetrics":[]}},"prefix":"","directory":"/opt/ecchronos/ecchronos-binary-agent-1.0.0-SNAPSHOT/./statistics","repair_failures_time_window":{"time":30,"unit":"MINUTES"},"trigger_interval_for_metric_inspection":{"time":5,"unit":"SECONDS"},"repair_failures_count":5},"repair":{"history_lookback":{"time":30,"unit":"DAYS"},"lock_type":"VNODE","provider":"com.ericsson.bss.cassandra.ecchronos.application.config.repair.FileBasedRepairConfiguration","history":{"provider":"ECC","keyspace":"ecchronos"},"priority":{"granularity_unit":"HOURS"},"ignore_twcs_tables":true,"repair_type":"VNODE","initial_delay":{"time":1,"unit":"DAYS"},"alarm":{"faultReporter":"com.ericsson.bss.cassandra.ecchronos.fm.impl.LoggingFaultReporter","warn":{"time":8,"unit":"DAYS"},"error":{"time":10,"unit":"DAYS"}},"interval":{"time":7,"unit":"DAYS"},"backoff":{"time":30,"unit":"MINUTES"}},"run_policy":{"time_based":{"keyspace":"ecchronos"}},"scheduler":{"frequency":{"time":1,"unit":"SECONDS"}},"lock_factory":{"cas":{"keyspace":"ecchronos","cache_expiry_time_in_seconds":30,"consistencySerial":"SERIAL"}}}
