### PR TITLE
Process multiple jobs per scheduler tick - Issue #1479

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Version 1.0.0 (Not yet Released)
 
+* Process multiple jobs per scheduler tick to improve throughput - Issue #1479
 * Add host id to alarms - Issue #1491
 * Fix alarm not raised when CQL session is broken - Issue #1477
 * Intermittent Jolokia Communication Failures Cause Ecchronos to Incorrectly Mark Repairs as Failed - Issue #1473

--- a/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/scheduler/ScheduleManagerImpl.java
+++ b/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/scheduler/ScheduleManagerImpl.java
@@ -273,15 +273,17 @@ public final class ScheduleManagerImpl implements ScheduleManager, Closeable
         private void tryRunNext()
         {
             LOG.debug("Looking for Job for Node {}", nodeID);
+            long tickStart = System.currentTimeMillis();
             for (ScheduledJob next : myQueue.get(nodeID))
             {
+                if (System.currentTimeMillis() - tickStart > myRunIntervalInMs)
+                {
+                    break;
+                }
                 if (validate(next))
                 {
                     currentExecutingJob.set(next);
-                    if (tryRunTasks(next))
-                    {
-                        break;
-                    }
+                    tryRunTasks(next);
                 }
             }
             currentExecutingJob.set(null);

--- a/core.impl/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/scheduler/TestScheduleManager.java
+++ b/core.impl/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/scheduler/TestScheduleManager.java
@@ -122,6 +122,24 @@ public class TestScheduleManager
     }
 
     @Test
+    public void testRunningMultipleJobsInSingleTick()
+    {
+        DummyJob job1 = new DummyJob(ScheduledJob.Priority.LOW, nodeID1);
+        DummyJob job2 = new DummyJob(ScheduledJob.Priority.LOW, nodeID1);
+        DummyJob job3 = new DummyJob(ScheduledJob.Priority.LOW, nodeID1);
+        myScheduler.schedule(nodeID1, job1);
+        myScheduler.schedule(nodeID1, job2);
+        myScheduler.schedule(nodeID1, job3);
+
+        myScheduler.run(nodeID1);
+
+        assertThat(job1.hasRun()).isTrue();
+        assertThat(job2.hasRun()).isTrue();
+        assertThat(job3.hasRun()).isTrue();
+        assertThat(myScheduler.getQueueSize(nodeID1)).isEqualTo(3);
+    }
+
+    @Test
     public void testRunningJobWithFailingRunPolicy()
     {
         DummyJob job1 = new DummyJob(ScheduledJob.Priority.LOW, nodeID1);


### PR DESCRIPTION
The scheduler was processing only one job per tick then waiting for the next tick. With the standalone agent managing multiple nodes, this limited throughput to one table repair per node per tick.

Remove the break after the first successful job and add a time budget equal to the scheduler frequency. Each tick now processes as many jobs as it can within the budget. In testing with 60 tables across 6 nodes, this keeps schedules at 0 late and 0 overdue, matching sidecar behavior.