### PR TITLE
Remove sufficientNodesForLocking pre-check and catch driver exception…

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Version 1.0.0 (Not yet Released)
 
+* Remove sufficientNodesForLocking pre-check and catch driver exceptions instead - Issue #1468
 * Improve "Running Task" log message to reduce noise and add repair progress context - Issue #1470
 
 ## Version 1.0.0-beta6

--- a/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/locks/CASLockFactory.java
+++ b/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/locks/CASLockFactory.java
@@ -16,16 +16,13 @@ package com.ericsson.bss.cassandra.ecchronos.core.impl.locks;
 
 import com.datastax.oss.driver.api.core.ConsistencyLevel;
 import com.datastax.oss.driver.api.core.CqlIdentifier;
+import com.datastax.oss.driver.api.core.DriverException;
 import com.datastax.oss.driver.api.core.cql.ResultSet;
 import com.datastax.oss.driver.api.core.cql.Row;
-import com.datastax.oss.driver.api.core.metadata.Metadata;
-import com.datastax.oss.driver.api.core.metadata.Node;
-import com.datastax.oss.driver.api.core.metadata.TokenMap;
 import com.datastax.oss.driver.api.core.metadata.schema.KeyspaceMetadata;
 import com.datastax.oss.driver.api.core.metadata.schema.TableMetadata;
 import com.ericsson.bss.cassandra.ecchronos.connection.DistributedNativeConnectionProvider;
 import com.ericsson.bss.cassandra.ecchronos.core.locks.LockFactory;
-import com.ericsson.bss.cassandra.ecchronos.core.state.HostStates;
 import com.ericsson.bss.cassandra.ecchronos.utils.exceptions.LockException;
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
@@ -35,16 +32,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.Closeable;
-import java.io.UnsupportedEncodingException;
-import java.nio.ByteBuffer;
 import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
@@ -72,7 +63,6 @@ import java.util.concurrent.TimeUnit;
  * WITH default_time_to_live = 600 AND gc_grace_seconds = 0;
  * </pre>
  */
-@SuppressWarnings("PMD.GodClass")
 public final class CASLockFactory implements LockFactory, Closeable
 {
     private static final Logger LOG = LoggerFactory.getLogger(CASLockFactory.class);
@@ -85,7 +75,6 @@ public final class CASLockFactory implements LockFactory, Closeable
     private static final long PRIORITY_CACHE_EXPIRE_SECONDS = 2L;
     private static final int LOCK_REFRESHER_POOL_SIZE = 2;
 
-    private final HostStates myHostStates;
     private final CASLockFactoryCacheContext myCasLockFactoryCacheContext;
     private final Cache<String, List<NodePriority>> myPriorityCache;
 
@@ -93,7 +82,6 @@ public final class CASLockFactory implements LockFactory, Closeable
     private final CASLockStatement myCasLockStatement;
     private final DistributedNativeConnectionProvider myNativeConnectionProvider;
     private final long myCacheExpiryTimeInSeconds;
-    private final String myLocalDatacenter;
 
     CASLockFactory(final CASLockFactoryBuilder builder)
     {
@@ -106,10 +94,7 @@ public final class CASLockFactory implements LockFactory, Closeable
                 builder.getConsistencyType(),
                 builder.getNativeConnectionProvider().getCqlSession());
 
-        myHostStates = builder.getHostStates();
         myNativeConnectionProvider = builder.getNativeConnectionProvider();
-
-        myLocalDatacenter = builder.getLocalDatacenter();
 
         verifySchemasExists();
         myCacheExpiryTimeInSeconds = builder.getCacheExpiryTimeInSecond();
@@ -227,27 +212,7 @@ public final class CASLockFactory implements LockFactory, Closeable
         }
     }
 
-    @Override
-    public boolean sufficientNodesForLocking(final String resource)
-    {
-        try
-        {
-            Set<Node> nodes = getNodesForResource(resource);
 
-            int quorum = nodes.size() / 2 + 1;
-            int liveNodes = liveNodes(nodes);
-
-            LOG.trace("Live nodes {}, quorum: {}", liveNodes, quorum);
-
-            return liveNodes >= quorum;
-        }
-        catch (UnsupportedEncodingException e)
-        {
-            LOG.warn("Unable to encode resource bytes", e);
-        }
-
-        return false;
-    }
 
     @Override
     public Optional<LockException> getCachedFailure(final UUID nodeID, final String dataCenter, final String resource)
@@ -311,20 +276,23 @@ public final class CASLockFactory implements LockFactory, Closeable
     {
         LOG.trace("Trying lock for {} - {}", dataCenter, resource);
 
-        if (!sufficientNodesForLocking(resource))
+        try
         {
-            LOG.warn("Not sufficient nodes to lock resource {}", resource);
-            throw new LockException("Not sufficient nodes to lock");
+            List<NodePriority> priorities = getPrioritiesForResource(resource);
+            CASLock casLock = new CASLock(resource, priority, metadata, nodeId, myCasLockStatement, priorities); // NOSONAR
+            if (casLock.lock())
+            {
+                return casLock;
+            }
+            else
+            {
+                throw new LockException(String.format("Unable to lock resource %s in datacenter %s", resource, dataCenter));
+            }
         }
-        List<NodePriority> priorities = getPrioritiesForResource(resource);
-        CASLock casLock = new CASLock(resource, priority, metadata, nodeId, myCasLockStatement, priorities); // NOSONAR
-        if (casLock.lock())
+        catch (DriverException e)
         {
-            return casLock;
-        }
-        else
-        {
-            throw new LockException(String.format("Unable to lock resource %s in datacenter %s", resource, dataCenter));
+            LOG.warn("Unable to lock resource {}, not enough nodes available", resource, e);
+            throw new LockException("Not enough nodes available to lock resource " + resource, e);
         }
     }
 
@@ -347,48 +315,9 @@ public final class CASLockFactory implements LockFactory, Closeable
         return nodePriorities;
     }
 
-    private Set<Node> getNodesForResource(final String resource) throws UnsupportedEncodingException
-    {
-        Set<Node> dataCenterNodes = new HashSet<>();
 
-        Metadata metadata = myCasLockProperties.getSession().getMetadata();
-        TokenMap tokenMap = metadata.getTokenMap()
-                .orElseThrow(() -> new IllegalStateException("Couldn't get token map, is it disabled?"));
-        Set<Node> nodes = tokenMap.getReplicas(
-                myCasLockProperties.getKeyspaceName(), ByteBuffer.wrap(resource.getBytes("UTF-8")));
 
-        if (myCasLockProperties.getSerialConsistencyLevel() == ConsistencyLevel.LOCAL_SERIAL)
-        {
-            Iterator<Node> iterator = nodes.iterator();
 
-            while (iterator.hasNext())
-            {
-                Node node = iterator.next();
-
-                if (myLocalDatacenter.equals(node.getDatacenter()))
-                {
-                    dataCenterNodes.add(node);
-                }
-            }
-
-            return dataCenterNodes;
-        }
-
-        return nodes;
-    }
-
-    private int liveNodes(final Collection<Node> nodes)
-    {
-        int live = 0;
-        for (Node node : nodes)
-        {
-            if (myHostStates.isUp(node))
-            {
-                live++;
-            }
-        }
-        return live;
-    }
 
     private void verifySchemasExists()
     {

--- a/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/locks/CASLockFactoryBuilder.java
+++ b/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/locks/CASLockFactoryBuilder.java
@@ -29,11 +29,9 @@ public class CASLockFactoryBuilder
     private static final ConsistencyType DEFAULT_CONSISTENCY_SERIAL = ConsistencyType.SERIAL;
 
     private DistributedNativeConnectionProvider myNativeConnectionProvider;
-    private HostStates myHostStates;
     private String myKeyspaceName = DEFAULT_KEYSPACE_NAME;
     private long myCacheExpiryTimeInSeconds = DEFAULT_EXPIRY_TIME_IN_SECONDS;
     private ConsistencyType myConsistencyType = DEFAULT_CONSISTENCY_SERIAL;
-    private String myLocalDatacenter = "datacenter1";
 
     public final CASLockFactoryBuilder withNativeConnectionProvider(final DistributedNativeConnectionProvider nativeConnectionProvider)
     {
@@ -41,9 +39,21 @@ public class CASLockFactoryBuilder
         return this;
     }
 
+    /**
+     * @deprecated HostStates is no longer used by CASLockFactory. This method is a no-op.
+     */
+    @Deprecated
     public final CASLockFactoryBuilder withHostStates(final HostStates hostStates)
     {
-        myHostStates = hostStates;
+        return this;
+    }
+
+    /**
+     * @deprecated Local datacenter is no longer used by CASLockFactory. This method is a no-op.
+     */
+    @Deprecated
+    public final CASLockFactoryBuilder withLocalDatacenter(final String localDatacenter)
+    {
         return this;
     }
 
@@ -72,22 +82,12 @@ public class CASLockFactoryBuilder
             throw new IllegalArgumentException("Native connection provider cannot be null");
         }
 
-        if (myHostStates == null)
-        {
-            throw new IllegalArgumentException("Host states cannot be null");
-        }
-
         return new CASLockFactory(this);
     }
 
     public final DistributedNativeConnectionProvider getNativeConnectionProvider()
     {
         return myNativeConnectionProvider;
-    }
-
-    public final HostStates getHostStates()
-    {
-        return myHostStates;
     }
 
     public final String getKeyspaceName()
@@ -103,16 +103,5 @@ public class CASLockFactoryBuilder
     public final ConsistencyType getConsistencyType()
     {
         return myConsistencyType;
-    }
-
-    public final CASLockFactoryBuilder withLocalDatacenter(final String localDatacenter)
-    {
-        myLocalDatacenter = localDatacenter;
-        return this;
-    }
-
-    public final String getLocalDatacenter()
-    {
-        return myLocalDatacenter;
     }
 }

--- a/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/RepairLockFactoryImpl.java
+++ b/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/RepairLockFactoryImpl.java
@@ -67,15 +67,6 @@ public class RepairLockFactoryImpl implements RepairLockFactory
                                                      final int priority,
                                                      final UUID nodeId) throws LockException
     {
-        int locksPerResource = getLocksPerResource();
-        for (RepairResource repairResource : repairResources)
-        {
-            if (!lockFactory.sufficientNodesForLocking(repairResource.getResourceName(locksPerResource)))
-            {
-                throw new LockException(repairResource + " not lockable. Repair will be retried later.");
-            }
-        }
-
         if (repairResources.isEmpty())
         {
             String msg = String.format("No datacenters to lock for %s", this);

--- a/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/incremental/IncrementalRepairJob.java
+++ b/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/incremental/IncrementalRepairJob.java
@@ -54,7 +54,6 @@ public class IncrementalRepairJob extends ScheduledRepairJob
     private final ReplicationState myReplicationState;
     private final CassandraMetrics myCassandraMetrics;
 
-    @SuppressWarnings("PMD.ConstructorCallsOverridableMethod")
     IncrementalRepairJob(final Builder builder)
     {
         super(builder.myConfiguration, builder.myNodeId, builder.myTableReference, builder.myJmxProxyFactory,

--- a/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/incremental/IncrementalRepairJob.java
+++ b/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/incremental/IncrementalRepairJob.java
@@ -61,12 +61,7 @@ public class IncrementalRepairJob extends ScheduledRepairJob
         myNode = Preconditions.checkNotNull(builder.myNode, "Node must be set");
         myReplicationState = Preconditions.checkNotNull(builder.myReplicationState, "Replication state must be set");
         myCassandraMetrics = Preconditions.checkNotNull(builder.myCassandraMetrics, "Cassandra metrics must be set");
-        setLastSuccessfulRun();
-    }
-
-    private void setLastSuccessfulRun()
-    {
-        myLastSuccessfulRun = myCassandraMetrics.getMaxRepairedAt(myNode.getHostId(), getTableReference());
+        myLastSuccessfulRun = myCassandraMetrics.getMaxRepairedAt(myNode.getHostId(), builder.myTableReference);
         LOG.debug("{} - last successful run: {}", this, myLastSuccessfulRun);
     }
 

--- a/core.impl/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/TestRepairLockFactoryImpl.java
+++ b/core.impl/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/TestRepairLockFactoryImpl.java
@@ -83,7 +83,6 @@ public class TestRepairLockFactoryImpl
         Map<String, String> metadata = Collections.singletonMap("metadatakey", "metadatavalue");
         int priority = 1;
 
-        withSufficientNodesForLocking(repairResource);
         withSuccessfulLocking(repairResource, priority, metadata);
 
         verifyLocksAreTriedWhenGettingLock(repairLockFactory, priority, metadata, repairResource);
@@ -97,8 +96,7 @@ public class TestRepairLockFactoryImpl
         Map<String, String> metadata = Collections.singletonMap("metadatakey", "metadatavalue");
         int priority = 1;
 
-        withoutSufficientNodesForLocking(repairResource);
-        withSuccessfulLocking(repairResource, priority, metadata);
+        withUnsuccessfulLocking(repairResource, priority, metadata);
 
         verifyExceptionIsThrownWhenGettingLock(repairLockFactory, priority, metadata, repairResource);
         verify(mockLock, never()).close();
@@ -111,7 +109,6 @@ public class TestRepairLockFactoryImpl
         Map<String, String> metadata = Collections.singletonMap("metadatakey", "metadatavalue");
         int priority = 1;
 
-        withSufficientNodesForLocking(repairResource);
         withUnsuccessfulLocking(repairResource, priority, metadata);
 
         verifyExceptionIsThrownWhenGettingLock(repairLockFactory, priority, metadata, repairResource);
@@ -126,8 +123,6 @@ public class TestRepairLockFactoryImpl
         Map<String, String> metadata = Collections.singletonMap("metadatakey", "metadatavalue");
         int priority = 1;
 
-        withSufficientNodesForLocking(repairResource);
-        withSufficientNodesForLocking(repairResource2);
         withSuccessfulLocking(repairResource, priority, metadata);
         withUnexpectedLockingFailure(repairResource2, priority, metadata, NullPointerException.class);
 
@@ -143,28 +138,10 @@ public class TestRepairLockFactoryImpl
         Map<String, String> metadata = Collections.singletonMap("metadatakey", "metadatavalue");
         int priority = 1;
 
-        withSufficientNodesForLocking(repairResourceDc1);
-        withSufficientNodesForLocking(repairResourceDc2);
-
         withSuccessfulLocking(repairResourceDc1, priority, metadata);
         withSuccessfulLocking(repairResourceDc2, priority, metadata);
 
         verifyLocksAreTriedWhenGettingLock(repairLockFactory, priority, metadata, repairResourceDc1, repairResourceDc2);
-        verify(mockLock, never()).close();
-    }
-
-    @Test
-    public void testMultipleLocksNotSufficientNodes()
-    {
-        RepairResource repairResourceDc1 = new RepairResource("DC1", "my-resource-dc1");
-        RepairResource repairResourceDc2 = new RepairResource("DC2", "my-resource-dc2");
-        Map<String, String> metadata = Collections.singletonMap("metadatakey", "metadatavalue");
-        int priority = 1;
-
-        withSufficientNodesForLocking(repairResourceDc1);
-        withoutSufficientNodesForLocking(repairResourceDc2);
-
-        verifyExceptionIsThrownWhenGettingLock(repairLockFactory, priority, metadata, repairResourceDc1, repairResourceDc2);
         verify(mockLock, never()).close();
     }
 
@@ -176,10 +153,7 @@ public class TestRepairLockFactoryImpl
         Map<String, String> metadata = Collections.singletonMap("metadatakey", "metadatavalue");
         int priority = 1;
 
-        withSufficientNodesForLocking(repairResourceDc1);
         withSuccessfulLocking(repairResourceDc1, priority, metadata);
-
-        withSufficientNodesForLocking(repairResourceDc2);
         withUnsuccessfulLocking(repairResourceDc2, priority, metadata);
 
         verifyExceptionIsThrownWhenGettingLock(repairLockFactory, priority, metadata, repairResourceDc1, repairResourceDc2);
@@ -196,10 +170,7 @@ public class TestRepairLockFactoryImpl
 
         withUnsuccessfulCachedLock(repairResourceDc1);
 
-        withSufficientNodesForLocking(repairResourceDc1);
         withSuccessfulLocking(repairResourceDc1, priority, metadata);
-
-        withSufficientNodesForLocking(repairResourceDc2);
         withSuccessfulLocking(repairResourceDc2, priority, metadata);
 
         verifyExceptionIsThrownWhenGettingLock(repairLockFactory, priority, metadata, repairResourceDc1, repairResourceDc2);
@@ -217,10 +188,7 @@ public class TestRepairLockFactoryImpl
 
         withUnsuccessfulCachedLock(repairResourceDc2);
 
-        withSufficientNodesForLocking(repairResourceDc1);
         withSuccessfulLocking(repairResourceDc1, priority, metadata);
-
-        withSufficientNodesForLocking(repairResourceDc2);
         withSuccessfulLocking(repairResourceDc2, priority, metadata);
 
         verifyExceptionIsThrownWhenGettingLock(repairLockFactory, priority, metadata, repairResourceDc1, repairResourceDc2);
@@ -274,13 +242,4 @@ public class TestRepairLockFactoryImpl
         when(mockLockFactory.tryLock(eq(repairResource.getDataCenter()), eq(repairResource.getResourceName(LOCKS_PER_RESOURCE)), eq(priority), eq(metadata), any())).thenThrow(exceptionClass);
     }
 
-    private void withSufficientNodesForLocking(RepairResource repairResource)
-    {
-        when(mockLockFactory.sufficientNodesForLocking(eq(repairResource.getResourceName(LOCKS_PER_RESOURCE)))).thenReturn(true);
-    }
-
-    private void withoutSufficientNodesForLocking(RepairResource repairResource)
-    {
-        when(mockLockFactory.sufficientNodesForLocking(eq(repairResource.getResourceName(LOCKS_PER_RESOURCE)))).thenReturn(false);
-    }
 }

--- a/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/locks/LockFactory.java
+++ b/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/locks/LockFactory.java
@@ -57,15 +57,6 @@ public interface LockFactory
     Map<String, String> getLockMetadata(String resource) throws LockException;
 
     /**
-     * Checks if local_quorum is met.
-     *
-     * @param resource The data center resource.
-     *                 i.e "RepairResource-DC1-1".
-     * @return boolean Indicates if local_quorum is met.
-     */
-    boolean sufficientNodesForLocking(String resource);
-
-    /**
      * Utility method to return a cached lock exception if one is available.
      *
      * @param dataCenter The data center the lock is for or null if it's a global lock.


### PR DESCRIPTION
…s instead

  Changes Made
  
  1. LockFactory.java — Removed sufficientNodesForLocking(String resource) from the interface.
  2. CASLockFactory.java — Removed sufficientNodesForLocking(), liveNodes(), getNodesForResource(), and the myHostStates/myLocalDatacenter fields. Updated doTryLock() to catch DriverException and wrap it in LockException instead of pre-checking.
  3. CASLockFactoryBuilder.java — Removed HostStates as a required dependency. Kept withHostStates() and withLocalDatacenter() as @Deprecated no-ops for backward compatibility with existing callers.
  4. RepairLockFactoryImpl.java — Removed the sufficientNodesForLocking pre-check loop from getLock(). Lock failures now propagate naturally from tryLock().
  5. TestRepairLockFactoryImpl.java — Removed all withSufficientNodesForLocking/withoutSufficientNodesForLocking helper methods and calls. Removed the testMultipleLocksNotSufficientNodes test (now redundant — covered by the lock failure tests). Updated remaining tests to work without the pre-check.

Closes #1468 