### PR TITLE
Clean up unused HostStates

### DIFF
--- a/application/src/main/java/com/ericsson/bss/cassandra/ecchronos/application/spring/ECChronosInternals.java
+++ b/application/src/main/java/com/ericsson/bss/cassandra/ecchronos/application/spring/ECChronosInternals.java
@@ -143,11 +143,9 @@ public class ECChronosInternals implements Closeable
 
         myLockFactory = CASLockFactory.builder()
                 .withNativeConnectionProvider(nativeConnectionProvider)
-                .withHostStates(myHostStatesImpl)
                 .withKeyspaceName(casLockFactoryConfig.getKeyspaceName())
                 .withCacheExpiryInSeconds(casLockFactoryConfig.getFailureCacheExpiryTimeInSeconds())
                 .withConsistencySerial(casLockFactoryConfig.getConsistencySerial())
-                .withLocalDatacenter(configuration.getConnectionConfig().getCqlConnection().getLocalDatacenter())
                 .build();
 
         myScheduleManagerImpl = ScheduleManagerImpl.builder()

--- a/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/locks/CASLockFactoryBuilder.java
+++ b/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/locks/CASLockFactoryBuilder.java
@@ -16,7 +16,6 @@ package com.ericsson.bss.cassandra.ecchronos.core.impl.locks;
 
 import com.ericsson.bss.cassandra.ecchronos.connection.DistributedNativeConnectionProvider;
 import com.ericsson.bss.cassandra.ecchronos.core.impl.utils.ConsistencyType;
-import com.ericsson.bss.cassandra.ecchronos.core.state.HostStates;
 
 /**
  * Represents a container for builder configurations and state for the CASLockFactory.
@@ -36,24 +35,6 @@ public class CASLockFactoryBuilder
     public final CASLockFactoryBuilder withNativeConnectionProvider(final DistributedNativeConnectionProvider nativeConnectionProvider)
     {
         myNativeConnectionProvider = nativeConnectionProvider;
-        return this;
-    }
-
-    /**
-     * @deprecated HostStates is no longer used by CASLockFactory. This method is a no-op.
-     */
-    @Deprecated
-    public final CASLockFactoryBuilder withHostStates(final HostStates hostStates)
-    {
-        return this;
-    }
-
-    /**
-     * @deprecated Local datacenter is no longer used by CASLockFactory. This method is a no-op.
-     */
-    @Deprecated
-    public final CASLockFactoryBuilder withLocalDatacenter(final String localDatacenter)
-    {
         return this;
     }
 

--- a/core.impl/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/impl/locks/TestCASLockFactory.java
+++ b/core.impl/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/impl/locks/TestCASLockFactory.java
@@ -18,7 +18,6 @@ import static com.datastax.oss.driver.api.querybuilder.QueryBuilder.bindMarker;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.junit.Assert.assertEquals;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -27,7 +26,6 @@ import com.ericsson.bss.cassandra.ecchronos.connection.DistributedNativeConnecti
 import com.ericsson.bss.cassandra.ecchronos.core.impl.AbstractCassandraContainerTest;
 import com.ericsson.bss.cassandra.ecchronos.core.impl.utils.ConsistencyType;
 import com.ericsson.bss.cassandra.ecchronos.core.locks.LockFactory;
-import com.ericsson.bss.cassandra.ecchronos.core.state.HostStates;
 import com.ericsson.bss.cassandra.ecchronos.utils.enums.connection.ConnectionType;
 import com.ericsson.bss.cassandra.ecchronos.utils.exceptions.LockException;
 import java.io.IOException;
@@ -96,8 +94,6 @@ public class TestCASLockFactory extends AbstractCassandraContainerTest
     private static PreparedStatement myGetPrioritiesStatement;
     private UUID myNodeID;
 
-    private static HostStates hostStates;
-
     @Parameterized.Parameter
     public String myKeyspaceName;
 
@@ -113,11 +109,8 @@ public class TestCASLockFactory extends AbstractCassandraContainerTest
                 "CREATE TABLE IF NOT EXISTS %s.lock_priority (resource text, node uuid, priority int, PRIMARY KEY(resource, node)) WITH default_time_to_live = 600 AND gc_grace_seconds = 0",
                 myKeyspaceName));
 
-        hostStates = mock(HostStates.class);
-        when(hostStates.isUp(any(Node.class))).thenReturn(true);
         myLockFactory = new CASLockFactoryBuilder()
                 .withNativeConnectionProvider(getNativeConnectionProvider())
-                .withHostStates(hostStates)
                 .withKeyspaceName(myKeyspaceName)
                 .build();
 
@@ -156,7 +149,6 @@ public class TestCASLockFactory extends AbstractCassandraContainerTest
         when(node.getHostId()).thenReturn(UUID.randomUUID());
         myLockFactory = new CASLockFactoryBuilder()
                 .withNativeConnectionProvider(getNativeConnectionProvider())
-                .withHostStates(hostStates)
                 .withKeyspaceName(myKeyspaceName)
                 .build();
         assertThat(myLockFactory.getCasLockFactoryCacheContext().getFailedLockRetryAttempts()).isEqualTo(9);
@@ -273,7 +265,6 @@ public class TestCASLockFactory extends AbstractCassandraContainerTest
         execute(myCompeteStatement.bind("lock", myNodeID, 2));
         CASLockFactory lockFactory = new CASLockFactoryBuilder()
                 .withNativeConnectionProvider(getNativeConnectionProvider())
-                .withHostStates(hostStates)
                 .withKeyspaceName(myKeyspaceName)
                 .build();
 
@@ -291,7 +282,6 @@ public class TestCASLockFactory extends AbstractCassandraContainerTest
         execute(myCompeteStatement.bind("lock", myNodeID, 1));
         CASLockFactory lockFactory = new CASLockFactoryBuilder()
                 .withNativeConnectionProvider(getNativeConnectionProvider())
-                .withHostStates(hostStates)
                 .withKeyspaceName(myKeyspaceName)
                 .build();
         try (LockFactory.DistributedLock lock = lockFactory.tryLock(DATA_CENTER, "lock", 2, new HashMap<>(), myNodeID))
@@ -390,7 +380,6 @@ public class TestCASLockFactory extends AbstractCassandraContainerTest
         assertThatExceptionOfType(IllegalStateException.class)
                 .isThrownBy(() -> new CASLockFactoryBuilder()
                         .withNativeConnectionProvider(getNativeConnectionProvider())
-                        .withHostStates(hostStates)
                         .withKeyspaceName(myKeyspaceName)
                         .build());
 
@@ -412,7 +401,6 @@ public class TestCASLockFactory extends AbstractCassandraContainerTest
         assertThatExceptionOfType(IllegalStateException.class)
                 .isThrownBy(() -> new CASLockFactoryBuilder()
                         .withNativeConnectionProvider(getNativeConnectionProvider())
-                        .withHostStates(hostStates)
                         .withKeyspaceName(myKeyspaceName)
                         .build());
 
@@ -429,7 +417,6 @@ public class TestCASLockFactory extends AbstractCassandraContainerTest
         assertThatExceptionOfType(IllegalStateException.class)
                 .isThrownBy(() -> new CASLockFactoryBuilder()
                         .withNativeConnectionProvider(getNativeConnectionProvider())
-                        .withHostStates(hostStates)
                         .withKeyspaceName(myKeyspaceName)
                         .build());
 
@@ -485,7 +472,6 @@ public class TestCASLockFactory extends AbstractCassandraContainerTest
                                 return null;
                             }
                         })
-                        .withHostStates(hostStates)
                         .withKeyspaceName(myKeyspaceName)
                         .build());
     }
@@ -503,7 +489,6 @@ public class TestCASLockFactory extends AbstractCassandraContainerTest
 
         myLockFactory = new CASLockFactoryBuilder()
                 .withNativeConnectionProvider(connectionProviderMock)
-                .withHostStates(hostStates)
                 .withKeyspaceName(myKeyspaceName)
                 .withConsistencySerial(ConsistencyType.LOCAL)
                 .build();
@@ -524,7 +509,6 @@ public class TestCASLockFactory extends AbstractCassandraContainerTest
 
         myLockFactory = new CASLockFactoryBuilder()
                 .withNativeConnectionProvider(connectionProviderMock)
-                .withHostStates(hostStates)
                 .withKeyspaceName(myKeyspaceName)
                 .withConsistencySerial(ConsistencyType.SERIAL)
                 .build();

--- a/core.impl/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/scheduler/TestScheduleManager.java
+++ b/core.impl/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/scheduler/TestScheduleManager.java
@@ -33,7 +33,6 @@ import com.ericsson.bss.cassandra.ecchronos.core.impl.locks.DummyLock;
 import com.ericsson.bss.cassandra.ecchronos.core.repair.scheduler.RunPolicy;
 import com.ericsson.bss.cassandra.ecchronos.core.repair.scheduler.ScheduledJob;
 import com.ericsson.bss.cassandra.ecchronos.core.repair.scheduler.ScheduledTask;
-import com.ericsson.bss.cassandra.ecchronos.core.state.HostStates;
 import com.ericsson.bss.cassandra.ecchronos.utils.exceptions.LockException;
 import java.util.*;
 import java.util.concurrent.CountDownLatch;
@@ -56,8 +55,6 @@ public class TestScheduleManager
     private CASLockFactory myLockFactory;
     @Mock
     private DistributedNativeConnectionProvider myNativeConnectionProvider;
-    @Mock
-    private HostStates myHostStates;
 
     @Mock
     private RunPolicy myRunPolicy;
@@ -91,7 +88,6 @@ public class TestScheduleManager
 
         when(myRunPolicy.validate(any(ScheduledJob.class), any(Node.class))).thenReturn(-1L);
         doReturn(myLockFactoryBuilder).when(myLockFactoryBuilder).withNativeConnectionProvider(myNativeConnectionProvider);
-        doReturn(myLockFactoryBuilder).when(myLockFactoryBuilder).withHostStates(myHostStates);
         doReturn(myLockFactory).when(myLockFactoryBuilder).build();
     }
 

--- a/standalone-integration/src/test/java/com/ericsson/bss/cassandra/ecchronos/standalone/ITIncrementalOnDemandRepairJob.java
+++ b/standalone-integration/src/test/java/com/ericsson/bss/cassandra/ecchronos/standalone/ITIncrementalOnDemandRepairJob.java
@@ -97,7 +97,6 @@ public class ITIncrementalOnDemandRepairJob extends TestBase
 
         myLockFactory = CASLockFactory.builder()
                 .withNativeConnectionProvider(getNativeConnectionProvider())
-                .withHostStates(myHostStates)
                 .withConsistencySerial(ConsistencyType.SERIAL)
                 .build();
 

--- a/standalone-integration/src/test/java/com/ericsson/bss/cassandra/ecchronos/standalone/ITIncrementalSchedules.java
+++ b/standalone-integration/src/test/java/com/ericsson/bss/cassandra/ecchronos/standalone/ITIncrementalSchedules.java
@@ -108,7 +108,6 @@ public class ITIncrementalSchedules extends TestBase
 
         myLockFactory = CASLockFactory.builder()
                 .withNativeConnectionProvider(getNativeConnectionProvider())
-                .withHostStates(myHostStates)
                 .withConsistencySerial(ConsistencyType.SERIAL)
                 .build();
 

--- a/standalone-integration/src/test/java/com/ericsson/bss/cassandra/ecchronos/standalone/ITOnDemandRepairJob.java
+++ b/standalone-integration/src/test/java/com/ericsson/bss/cassandra/ecchronos/standalone/ITOnDemandRepairJob.java
@@ -122,7 +122,6 @@ public class ITOnDemandRepairJob extends TestBase
 
         myLockFactory = CASLockFactory.builder()
                 .withNativeConnectionProvider(getNativeConnectionProvider())
-                .withHostStates(myHostStates)
                 .withConsistencySerial(ConsistencyType.SERIAL)
                 .build();
 

--- a/standalone-integration/src/test/java/com/ericsson/bss/cassandra/ecchronos/standalone/ITSchedules.java
+++ b/standalone-integration/src/test/java/com/ericsson/bss/cassandra/ecchronos/standalone/ITSchedules.java
@@ -156,7 +156,6 @@ public class ITSchedules extends TestBase
 
         myLockFactory = CASLockFactory.builder()
                 .withNativeConnectionProvider(getNativeConnectionProvider())
-                .withHostStates(myHostStates)
                 .withConsistencySerial(ConsistencyType.SERIAL)
                 .build();
         // Only run ScheduleManager for the local node to avoid concurrency issues


### PR DESCRIPTION
Leftovers from "Remove sufficientNodesForLocking pre-check and catch driver exception… (#1538)".