### PR TITLE
Track lock-contention backoff separately from job state

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Version 1.0.0 (Not yet Released)
 
+* Fix job status incorrectly changing to BLOCKED on lock contention backoff - Issue #1548
 * On-Demand Repairs Stuck in IN_QUEUE at 100% Due to Re-Scheduling Loop, Blocking New Repairs - Issue #1553
 * HTTP errors in logs with shared HttpClient under concurrent load - Issue #1549
 * Improve memory management - Issue 1539

--- a/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/scheduler/ScheduleManagerImpl.java
+++ b/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/scheduler/ScheduleManagerImpl.java
@@ -57,6 +57,7 @@ public final class ScheduleManagerImpl implements ScheduleManager, Closeable
 
     private final Map<UUID, ScheduledJobQueue> myQueue = new ConcurrentHashMap<>();
     private final ConcurrentHashMap<UUID, ScheduledJob> currentExecutingJobs = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<ScheduledJob, Long> myContentionBackoff = new ConcurrentHashMap<>();
     private final Set<RunPolicy> myRunPolicies = Sets.newConcurrentHashSet();
     private final Map<UUID, ScheduledFuture<?>> myRunFuture = new ConcurrentHashMap<>();
     private final Map<UUID, JobRunTask> myRunTasks = new ConcurrentHashMap<>();
@@ -176,6 +177,7 @@ public final class ScheduleManagerImpl implements ScheduleManager, Closeable
         {
             queue.remove(job);
         }
+        myContentionBackoff.remove(job);
     }
 
     @Override
@@ -204,6 +206,7 @@ public final class ScheduleManagerImpl implements ScheduleManager, Closeable
         myRunTasks.clear();
         myQueue.clear();
         currentExecutingJobs.clear();
+        myContentionBackoff.clear();
         myRunPolicies.clear();
     }
 
@@ -309,6 +312,15 @@ public final class ScheduleManagerImpl implements ScheduleManager, Closeable
                 {
                     break;
                 }
+                Long backoffUntil = myContentionBackoff.get(next);
+                if (backoffUntil != null)
+                {
+                    if (System.currentTimeMillis() < backoffUntil)
+                    {
+                        continue;
+                    }
+                    myContentionBackoff.remove(next);
+                }
                 if (validate(next))
                 {
                     currentExecutingJobs.put(nodeID, next);
@@ -389,7 +401,8 @@ public final class ScheduleManagerImpl implements ScheduleManager, Closeable
                 {
                     LOG.warn("Unable to get schedule lock on task {} in node {}", task, nodeID, e);
                 }
-                job.setRunnableIn(ThreadLocalRandom.current().nextLong(myRunIntervalInMs, myRunIntervalInMs * JITTER_NUMBER));
+                myContentionBackoff.put(job, System.currentTimeMillis()
+                        + ThreadLocalRandom.current().nextLong(myRunIntervalInMs, myRunIntervalInMs * JITTER_NUMBER));
                 return false;
             }
             catch (Exception e)
@@ -398,7 +411,8 @@ public final class ScheduleManagerImpl implements ScheduleManager, Closeable
                 {
                     LOG.warn("Unable to get schedule lock on task {} in node {}", task, nodeID, e);
                 }
-                job.setRunnableIn(ThreadLocalRandom.current().nextLong(myRunIntervalInMs, myRunIntervalInMs * JITTER_NUMBER));
+                myContentionBackoff.put(job, System.currentTimeMillis()
+                        + ThreadLocalRandom.current().nextLong(myRunIntervalInMs, myRunIntervalInMs * JITTER_NUMBER));
                 return false;
             }
         }


### PR DESCRIPTION
  The backoff introduced in eb03d43 called setRunnableIn() on lock
  failure, which caused getStatus() to report BLOCKED. Move the
  contention backoff into a local ConcurrentHashMap in
  ScheduleManagerImpl so the job's runnable state is not modified.
  Jobs are skipped during the backoff window without affecting their
  externally visible status.

Closes #1548 