### PR TITLE
Refactor RepairSchedulerImpl to resolve PMD GodClass violation

### DIFF
--- a/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/scheduler/RepairConfigurationComparator.java
+++ b/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/scheduler/RepairConfigurationComparator.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2026 Telefonaktiebolaget LM Ericsson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ericsson.bss.cassandra.ecchronos.core.impl.repair.scheduler;
+
+import com.ericsson.bss.cassandra.ecchronos.core.impl.repair.ScheduledRepairJob;
+import com.ericsson.bss.cassandra.ecchronos.core.repair.config.RepairConfiguration;
+
+import java.util.Set;
+
+/**
+ * Utility class to determine if repair configurations have changed compared to currently scheduled jobs.
+ */
+public final class RepairConfigurationComparator
+{
+    private RepairConfigurationComparator()
+    {
+        // Utility class
+    }
+
+    /**
+     * Determine if the given repair configurations differ from the currently scheduled jobs.
+     *
+     * @param currentJobs The currently scheduled jobs (may be null or empty).
+     * @param newConfigurations The new repair configurations.
+     * @return true if the configurations have changed and jobs need to be recreated.
+     */
+    public static boolean hasChanged(
+            final Set<ScheduledRepairJob> currentJobs,
+            final Set<RepairConfiguration> newConfigurations)
+    {
+        if (newConfigurations == null || newConfigurations.isEmpty())
+        {
+            return false;
+        }
+        if (currentJobs == null || currentJobs.isEmpty())
+        {
+            return true;
+        }
+        int matching = 0;
+        for (ScheduledRepairJob job : currentJobs)
+        {
+            for (RepairConfiguration repairConfiguration : newConfigurations)
+            {
+                if (job.getRepairConfiguration().equals(repairConfiguration))
+                {
+                    matching++;
+                }
+            }
+        }
+        return matching != newConfigurations.size();
+    }
+}

--- a/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/scheduler/RepairSchedulerImpl.java
+++ b/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/scheduler/RepairSchedulerImpl.java
@@ -17,9 +17,6 @@ package com.ericsson.bss.cassandra.ecchronos.core.impl.repair.scheduler;
 import com.datastax.oss.driver.api.core.metadata.Node;
 import com.ericsson.bss.cassandra.ecchronos.core.impl.locks.RepairLockType;
 import com.ericsson.bss.cassandra.ecchronos.core.impl.metrics.CassandraMetrics;
-import com.ericsson.bss.cassandra.ecchronos.core.impl.repair.incremental.IncrementalRepairJob;
-import com.ericsson.bss.cassandra.ecchronos.core.impl.repair.state.AlarmPostUpdateHook;
-import com.ericsson.bss.cassandra.ecchronos.core.impl.table.TableRepairJob;
 import com.ericsson.bss.cassandra.ecchronos.core.impl.table.TimeBasedRunPolicy;
 import com.ericsson.bss.cassandra.ecchronos.core.jmx.DistributedJmxProxyFactory;
 import com.ericsson.bss.cassandra.ecchronos.core.repair.config.RepairConfiguration;
@@ -28,7 +25,6 @@ import com.ericsson.bss.cassandra.ecchronos.core.repair.scheduler.ScheduleManage
 import com.ericsson.bss.cassandra.ecchronos.core.impl.repair.ScheduledRepairJob;
 import com.ericsson.bss.cassandra.ecchronos.core.repair.scheduler.ScheduledRepairJobView;
 import com.ericsson.bss.cassandra.ecchronos.core.repair.scheduler.ScheduledJob;
-import com.ericsson.bss.cassandra.ecchronos.core.state.RepairState;
 import com.ericsson.bss.cassandra.ecchronos.core.state.RepairStateFactory;
 import com.ericsson.bss.cassandra.ecchronos.core.state.ReplicationState;
 import com.ericsson.bss.cassandra.ecchronos.core.table.TableReference;
@@ -37,7 +33,6 @@ import com.ericsson.bss.cassandra.ecchronos.core.table.TableRepairPolicy;
 import com.ericsson.bss.cassandra.ecchronos.core.table.TableStorageStates;
 import com.ericsson.bss.cassandra.ecchronos.data.repairhistory.RepairHistoryService;
 import com.ericsson.bss.cassandra.ecchronos.fm.RepairFaultReporter;
-import com.ericsson.bss.cassandra.ecchronos.utils.enums.repair.RepairType;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import java.io.Closeable;
 
@@ -65,7 +60,6 @@ import javax.management.RuntimeMBeanException;
 /**
  * Class used to construct repair scheduler.
  */
-@SuppressWarnings("PMD.GodClass")
 public final class RepairSchedulerImpl implements RepairScheduler, Closeable
 {
     private static final int DEFAULT_TERMINATION_WAIT_IN_SECONDS = 10;
@@ -76,18 +70,8 @@ public final class RepairSchedulerImpl implements RepairScheduler, Closeable
     private final java.util.concurrent.locks.ReadWriteLock myLock = new java.util.concurrent.locks.ReentrantReadWriteLock();
 
     private final ExecutorService myExecutor;
-    private final TableRepairMetrics myTableRepairMetrics;
-    private final RepairHistoryService myRepairHistoryService;
-    private final RepairFaultReporter myFaultReporter;
-    private final DistributedJmxProxyFactory myJmxProxyFactory;
     private final ScheduleManager myScheduleManager;
-    private final RepairStateFactory myRepairStateFactory;
-    private final ReplicationState myReplicationState;
-    private final CassandraMetrics myCassandraMetrics;
-    private final List<TableRepairPolicy> myRepairPolicies;
-    private final TableStorageStates myTableStorageStates;
-    private final RepairLockType myRepairLockType;
-    private final TimeBasedRunPolicy myTimeBasedRunPolicy;
+    private final ScheduledRepairJobFactory myJobFactory;
 
     private Set<ScheduledRepairJob> validateScheduleMap(final UUID nodeID, final TableReference tableReference)
     {
@@ -110,18 +94,20 @@ public final class RepairSchedulerImpl implements RepairScheduler, Closeable
     {
         myExecutor = Executors.newSingleThreadScheduledExecutor(
                 new ThreadFactoryBuilder().setNameFormat("RepairScheduler-%d").build());
-        myFaultReporter = builder.myFaultReporter;
-        myTableRepairMetrics = builder.myTableRepairMetrics;
-        myJmxProxyFactory = builder.myJmxProxyFactory;
         myScheduleManager = builder.myScheduleManager;
-        myRepairStateFactory = builder.myRepairStateFactory;
-        myReplicationState = builder.myReplicationState;
-        myRepairPolicies = new ArrayList<>(builder.myRepairPolicies);
-        myCassandraMetrics = builder.myCassandraMetrics;
-        myRepairHistoryService = builder.myRepairHistoryService;
-        myTableStorageStates = builder.myTableStorageStates;
-        myRepairLockType = builder.myRepairLockType;
-        myTimeBasedRunPolicy = builder.myTimeBasedRunPolicy;
+        myJobFactory = ScheduledRepairJobFactory.builder()
+                .withTableRepairMetrics(builder.myTableRepairMetrics)
+                .withRepairHistoryService(builder.myRepairHistoryService)
+                .withFaultReporter(builder.myFaultReporter)
+                .withJmxProxyFactory(builder.myJmxProxyFactory)
+                .withRepairStateFactory(builder.myRepairStateFactory)
+                .withReplicationState(builder.myReplicationState)
+                .withCassandraMetrics(builder.myCassandraMetrics)
+                .withRepairPolicies(builder.myRepairPolicies)
+                .withTableStorageStates(builder.myTableStorageStates)
+                .withRepairLockType(builder.myRepairLockType)
+                .withTimeBasedRunPolicy(builder.myTimeBasedRunPolicy)
+                .build();
     }
 
     @Override
@@ -232,7 +218,8 @@ public final class RepairSchedulerImpl implements RepairScheduler, Closeable
         myLock.writeLock().lock();
         try
         {
-            if (configurationHasChanged(node, tableReference, repairConfigurations))
+            Set<ScheduledRepairJob> jobs = validateScheduleMap(node.getHostId(), tableReference);
+            if (RepairConfigurationComparator.hasChanged(jobs, repairConfigurations))
             {
                 LOG.info("Creating schedule for table {} in node {}", tableReference, node.getHostId());
                 createTableSchedule(node, tableReference, repairConfigurations);
@@ -267,37 +254,6 @@ public final class RepairSchedulerImpl implements RepairScheduler, Closeable
         }
     }
 
-    private boolean configurationHasChanged(
-            final Node node,
-            final TableReference tableReference,
-            final Set<RepairConfiguration> repairConfigurations)
-    {
-        Set<ScheduledRepairJob> jobs = validateScheduleMap(node.getHostId(), tableReference);
-        if (repairConfigurations == null || repairConfigurations.isEmpty())
-        {
-            return false;
-        }
-
-        if (jobs == null || jobs.isEmpty())
-        {
-            return true;
-        }
-
-        int matching = 0;
-
-        for (ScheduledRepairJob job : jobs)
-        {
-            for (RepairConfiguration repairConfiguration : repairConfigurations)
-            {
-                if (job.getRepairConfiguration().equals(repairConfiguration))
-                {
-                    matching++;
-                }
-            }
-        }
-        return matching != repairConfigurations.size();
-    }
-
     private void createTableSchedule(
             final Node node,
             final TableReference tableReference,
@@ -319,7 +275,7 @@ public final class RepairSchedulerImpl implements RepairScheduler, Closeable
         Set<ScheduledRepairJob> newJobs = new HashSet<>();
         for (RepairConfiguration repairConfiguration : repairConfigurations)
         {
-            ScheduledRepairJob job = createScheduledRepairJob(node, tableReference, repairConfiguration);
+            ScheduledRepairJob job = myJobFactory.create(node, tableReference, repairConfiguration);
             newJobs.add(job);
             myScheduleManager.schedule(node.getHostId(), job);
         }
@@ -395,61 +351,6 @@ public final class RepairSchedulerImpl implements RepairScheduler, Closeable
         {
             myScheduleManager.deschedule(nodeID, job);
         }
-    }
-
-    private ScheduledRepairJob createScheduledRepairJob(
-            final Node node,
-            final TableReference tableReference,
-            final RepairConfiguration repairConfiguration)
-    {
-        ScheduledJob.Configuration configuration = new ScheduledJob.ConfigurationBuilder()
-                .withPriority(ScheduledJob.Priority.LOW)
-                .withRunInterval(repairConfiguration.getRepairIntervalInMs(), TimeUnit.MILLISECONDS)
-                .withBackoff(repairConfiguration.getBackoffInMs(), TimeUnit.MILLISECONDS)
-                .withPriorityGranularity(repairConfiguration.getPriorityGranularityUnit())
-                .build();
-        ScheduledRepairJob job;
-        if (repairConfiguration.getRepairType().equals(RepairType.INCREMENTAL))
-        {
-            LOG.info("Creating IncrementalRepairJob for node {}", node.getHostId());
-            job = new IncrementalRepairJob.Builder()
-                    .withConfiguration(configuration)
-                    .withNode(node)
-                    .withJmxProxyFactory(myJmxProxyFactory)
-                    .withTableReference(tableReference)
-                    .withRepairConfiguration(repairConfiguration)
-                    .withTableRepairMetrics(myTableRepairMetrics)
-                    .withCassandraMetrics(myCassandraMetrics)
-                    .withReplicationState(myReplicationState)
-                    .withRepairPolices(myRepairPolicies)
-                    .withRepairLockType(myRepairLockType)
-                    .build();
-        }
-        else
-        {
-            LOG.info("Creating TableRepairJob for table {}.{} in node {}",
-                    tableReference.getKeyspace(), tableReference.getTable(), node.getHostId());
-            AlarmPostUpdateHook alarmPostUpdateHook = new AlarmPostUpdateHook(tableReference, repairConfiguration,
-                    myFaultReporter);
-            RepairState repairState = myRepairStateFactory.create(node, tableReference, repairConfiguration,
-                    alarmPostUpdateHook);
-            job = new TableRepairJob.Builder()
-                    .withConfiguration(configuration)
-                    .withJmxProxyFactory(myJmxProxyFactory)
-                    .withTableReference(tableReference)
-                    .withRepairState(repairState)
-                    .withTableRepairMetrics(myTableRepairMetrics)
-                    .withRepairConfiguration(repairConfiguration)
-                    .withTableStorageStates(myTableStorageStates)
-                    .withRepairPolices(myRepairPolicies)
-                    .withRepairHistory(myRepairHistoryService)
-                    .withRepairLockType(myRepairLockType)
-                    .withNode(node)
-                    .withTimeBasedRunPolicy(myTimeBasedRunPolicy)
-                    .build();
-        }
-        job.refreshState();
-        return job;
     }
 
     /**
@@ -635,4 +536,3 @@ public final class RepairSchedulerImpl implements RepairScheduler, Closeable
         }
     }
 }
-

--- a/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/scheduler/ScheduledRepairJobFactory.java
+++ b/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/scheduler/ScheduledRepairJobFactory.java
@@ -1,0 +1,241 @@
+/*
+ * Copyright 2026 Telefonaktiebolaget LM Ericsson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ericsson.bss.cassandra.ecchronos.core.impl.repair.scheduler;
+
+import com.datastax.oss.driver.api.core.metadata.Node;
+import com.ericsson.bss.cassandra.ecchronos.core.impl.locks.RepairLockType;
+import com.ericsson.bss.cassandra.ecchronos.core.impl.metrics.CassandraMetrics;
+import com.ericsson.bss.cassandra.ecchronos.core.impl.repair.ScheduledRepairJob;
+import com.ericsson.bss.cassandra.ecchronos.core.impl.repair.incremental.IncrementalRepairJob;
+import com.ericsson.bss.cassandra.ecchronos.core.impl.repair.state.AlarmPostUpdateHook;
+import com.ericsson.bss.cassandra.ecchronos.core.impl.table.TableRepairJob;
+import com.ericsson.bss.cassandra.ecchronos.core.impl.table.TimeBasedRunPolicy;
+import com.ericsson.bss.cassandra.ecchronos.core.jmx.DistributedJmxProxyFactory;
+import com.ericsson.bss.cassandra.ecchronos.core.repair.config.RepairConfiguration;
+import com.ericsson.bss.cassandra.ecchronos.core.repair.scheduler.ScheduledJob;
+import com.ericsson.bss.cassandra.ecchronos.core.state.RepairState;
+import com.ericsson.bss.cassandra.ecchronos.core.state.RepairStateFactory;
+import com.ericsson.bss.cassandra.ecchronos.core.state.ReplicationState;
+import com.ericsson.bss.cassandra.ecchronos.core.table.TableReference;
+import com.ericsson.bss.cassandra.ecchronos.core.table.TableRepairMetrics;
+import com.ericsson.bss.cassandra.ecchronos.core.table.TableRepairPolicy;
+import com.ericsson.bss.cassandra.ecchronos.core.table.TableStorageStates;
+import com.ericsson.bss.cassandra.ecchronos.data.repairhistory.RepairHistoryService;
+import com.ericsson.bss.cassandra.ecchronos.fm.RepairFaultReporter;
+import com.ericsson.bss.cassandra.ecchronos.utils.enums.repair.RepairType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Factory responsible for creating {@link ScheduledRepairJob} instances.
+ */
+public final class ScheduledRepairJobFactory
+{
+    private static final Logger LOG = LoggerFactory.getLogger(ScheduledRepairJobFactory.class);
+
+    private final TableRepairMetrics myTableRepairMetrics;
+    private final RepairHistoryService myRepairHistoryService;
+    private final RepairFaultReporter myFaultReporter;
+    private final DistributedJmxProxyFactory myJmxProxyFactory;
+    private final RepairStateFactory myRepairStateFactory;
+    private final ReplicationState myReplicationState;
+    private final CassandraMetrics myCassandraMetrics;
+    private final List<TableRepairPolicy> myRepairPolicies;
+    private final TableStorageStates myTableStorageStates;
+    private final RepairLockType myRepairLockType;
+    private final TimeBasedRunPolicy myTimeBasedRunPolicy;
+
+    private ScheduledRepairJobFactory(final Builder builder)
+    {
+        myTableRepairMetrics = builder.myTableRepairMetrics;
+        myRepairHistoryService = builder.myRepairHistoryService;
+        myFaultReporter = builder.myFaultReporter;
+        myJmxProxyFactory = builder.myJmxProxyFactory;
+        myRepairStateFactory = builder.myRepairStateFactory;
+        myReplicationState = builder.myReplicationState;
+        myCassandraMetrics = builder.myCassandraMetrics;
+        myRepairPolicies = new ArrayList<>(builder.myRepairPolicies);
+        myTableStorageStates = builder.myTableStorageStates;
+        myRepairLockType = builder.myRepairLockType;
+        myTimeBasedRunPolicy = builder.myTimeBasedRunPolicy;
+    }
+
+    /**
+     * Create a scheduled repair job for the given node, table, and configuration.
+     *
+     * @param node The node to create the job for.
+     * @param tableReference The table reference.
+     * @param repairConfiguration The repair configuration.
+     * @return A new ScheduledRepairJob.
+     */
+    public ScheduledRepairJob create(
+            final Node node,
+            final TableReference tableReference,
+            final RepairConfiguration repairConfiguration)
+    {
+        ScheduledJob.Configuration configuration = new ScheduledJob.ConfigurationBuilder()
+                .withPriority(ScheduledJob.Priority.LOW)
+                .withRunInterval(repairConfiguration.getRepairIntervalInMs(), TimeUnit.MILLISECONDS)
+                .withBackoff(repairConfiguration.getBackoffInMs(), TimeUnit.MILLISECONDS)
+                .withPriorityGranularity(repairConfiguration.getPriorityGranularityUnit())
+                .build();
+        ScheduledRepairJob job;
+        if (repairConfiguration.getRepairType().equals(RepairType.INCREMENTAL))
+        {
+            LOG.info("Creating IncrementalRepairJob for node {}", node.getHostId());
+            job = new IncrementalRepairJob.Builder()
+                    .withConfiguration(configuration)
+                    .withNode(node)
+                    .withJmxProxyFactory(myJmxProxyFactory)
+                    .withTableReference(tableReference)
+                    .withRepairConfiguration(repairConfiguration)
+                    .withTableRepairMetrics(myTableRepairMetrics)
+                    .withCassandraMetrics(myCassandraMetrics)
+                    .withReplicationState(myReplicationState)
+                    .withRepairPolices(myRepairPolicies)
+                    .withRepairLockType(myRepairLockType)
+                    .build();
+        }
+        else
+        {
+            LOG.info("Creating TableRepairJob for table {}.{} in node {}",
+                    tableReference.getKeyspace(), tableReference.getTable(), node.getHostId());
+            AlarmPostUpdateHook alarmPostUpdateHook = new AlarmPostUpdateHook(tableReference, repairConfiguration,
+                    myFaultReporter);
+            RepairState repairState = myRepairStateFactory.create(node, tableReference, repairConfiguration,
+                    alarmPostUpdateHook);
+            job = new TableRepairJob.Builder()
+                    .withConfiguration(configuration)
+                    .withJmxProxyFactory(myJmxProxyFactory)
+                    .withTableReference(tableReference)
+                    .withRepairState(repairState)
+                    .withTableRepairMetrics(myTableRepairMetrics)
+                    .withRepairConfiguration(repairConfiguration)
+                    .withTableStorageStates(myTableStorageStates)
+                    .withRepairPolices(myRepairPolicies)
+                    .withRepairHistory(myRepairHistoryService)
+                    .withRepairLockType(myRepairLockType)
+                    .withNode(node)
+                    .withTimeBasedRunPolicy(myTimeBasedRunPolicy)
+                    .build();
+        }
+        job.refreshState();
+        return job;
+    }
+
+    /**
+     * Create a new Builder instance.
+     *
+     * @return Builder
+     */
+    public static Builder builder()
+    {
+        return new Builder();
+    }
+
+    /**
+     * Builder for constructing {@link ScheduledRepairJobFactory}.
+     */
+    public static final class Builder
+    {
+        private TableRepairMetrics myTableRepairMetrics;
+        private RepairHistoryService myRepairHistoryService;
+        private RepairFaultReporter myFaultReporter;
+        private DistributedJmxProxyFactory myJmxProxyFactory;
+        private RepairStateFactory myRepairStateFactory;
+        private ReplicationState myReplicationState;
+        private CassandraMetrics myCassandraMetrics;
+        private final List<TableRepairPolicy> myRepairPolicies = new ArrayList<>();
+        private TableStorageStates myTableStorageStates;
+        private RepairLockType myRepairLockType;
+        private TimeBasedRunPolicy myTimeBasedRunPolicy;
+
+        public Builder withTableRepairMetrics(final TableRepairMetrics tableRepairMetrics)
+        {
+            myTableRepairMetrics = tableRepairMetrics;
+            return this;
+        }
+
+        public Builder withRepairHistoryService(final RepairHistoryService repairHistoryService)
+        {
+            myRepairHistoryService = repairHistoryService;
+            return this;
+        }
+
+        public Builder withFaultReporter(final RepairFaultReporter faultReporter)
+        {
+            myFaultReporter = faultReporter;
+            return this;
+        }
+
+        public Builder withJmxProxyFactory(final DistributedJmxProxyFactory jmxProxyFactory)
+        {
+            myJmxProxyFactory = jmxProxyFactory;
+            return this;
+        }
+
+        public Builder withRepairStateFactory(final RepairStateFactory repairStateFactory)
+        {
+            myRepairStateFactory = repairStateFactory;
+            return this;
+        }
+
+        public Builder withReplicationState(final ReplicationState replicationState)
+        {
+            myReplicationState = replicationState;
+            return this;
+        }
+
+        public Builder withCassandraMetrics(final CassandraMetrics cassandraMetrics)
+        {
+            myCassandraMetrics = cassandraMetrics;
+            return this;
+        }
+
+        public Builder withRepairPolicies(final Collection<TableRepairPolicy> repairPolicies)
+        {
+            myRepairPolicies.addAll(repairPolicies);
+            return this;
+        }
+
+        public Builder withTableStorageStates(final TableStorageStates tableStorageStates)
+        {
+            myTableStorageStates = tableStorageStates;
+            return this;
+        }
+
+        public Builder withRepairLockType(final RepairLockType repairLockType)
+        {
+            myRepairLockType = repairLockType;
+            return this;
+        }
+
+        public Builder withTimeBasedRunPolicy(final TimeBasedRunPolicy timeBasedRunPolicy)
+        {
+            myTimeBasedRunPolicy = timeBasedRunPolicy;
+            return this;
+        }
+
+        public ScheduledRepairJobFactory build()
+        {
+            return new ScheduledRepairJobFactory(this);
+        }
+    }
+}

--- a/core.impl/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/scheduler/TestRepairConfigurationComparator.java
+++ b/core.impl/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/scheduler/TestRepairConfigurationComparator.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2026 Telefonaktiebolaget LM Ericsson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ericsson.bss.cassandra.ecchronos.core.impl.repair.scheduler;
+
+import com.ericsson.bss.cassandra.ecchronos.core.impl.repair.ScheduledRepairJob;
+import com.ericsson.bss.cassandra.ecchronos.core.repair.config.RepairConfiguration;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class TestRepairConfigurationComparator
+{
+    @Test
+    public void testNullNewConfigurationsReturnsFalse()
+    {
+        Set<ScheduledRepairJob> jobs = new HashSet<>();
+        assertThat(RepairConfigurationComparator.hasChanged(jobs, null)).isFalse();
+    }
+
+    @Test
+    public void testEmptyNewConfigurationsReturnsFalse()
+    {
+        Set<ScheduledRepairJob> jobs = new HashSet<>();
+        assertThat(RepairConfigurationComparator.hasChanged(jobs, Collections.emptySet())).isFalse();
+    }
+
+    @Test
+    public void testNullCurrentJobsReturnsTrue()
+    {
+        Set<RepairConfiguration> configs = Collections.singleton(RepairConfiguration.DEFAULT);
+        assertThat(RepairConfigurationComparator.hasChanged(null, configs)).isTrue();
+    }
+
+    @Test
+    public void testEmptyCurrentJobsReturnsTrue()
+    {
+        Set<RepairConfiguration> configs = Collections.singleton(RepairConfiguration.DEFAULT);
+        assertThat(RepairConfigurationComparator.hasChanged(new HashSet<>(), configs)).isTrue();
+    }
+
+    @Test
+    public void testMatchingConfigurationReturnsFalse()
+    {
+        ScheduledRepairJob job = mock(ScheduledRepairJob.class);
+        when(job.getRepairConfiguration()).thenReturn(RepairConfiguration.DEFAULT);
+
+        Set<ScheduledRepairJob> jobs = Collections.singleton(job);
+        Set<RepairConfiguration> configs = Collections.singleton(RepairConfiguration.DEFAULT);
+
+        assertThat(RepairConfigurationComparator.hasChanged(jobs, configs)).isFalse();
+    }
+
+    @Test
+    public void testDifferentConfigurationReturnsTrue()
+    {
+        ScheduledRepairJob job = mock(ScheduledRepairJob.class);
+        when(job.getRepairConfiguration()).thenReturn(RepairConfiguration.DEFAULT);
+
+        RepairConfiguration updatedConfig = RepairConfiguration.newBuilder()
+                .withRepairInterval(1, TimeUnit.DAYS)
+                .build();
+
+        Set<ScheduledRepairJob> jobs = Collections.singleton(job);
+        Set<RepairConfiguration> configs = Collections.singleton(updatedConfig);
+
+        assertThat(RepairConfigurationComparator.hasChanged(jobs, configs)).isTrue();
+    }
+
+    @Test
+    public void testMultipleConfigsAllMatchReturnsFalse()
+    {
+        RepairConfiguration config1 = RepairConfiguration.DEFAULT;
+        RepairConfiguration config2 = RepairConfiguration.newBuilder()
+                .withRepairInterval(1, TimeUnit.DAYS)
+                .build();
+
+        ScheduledRepairJob job1 = mock(ScheduledRepairJob.class);
+        when(job1.getRepairConfiguration()).thenReturn(config1);
+        ScheduledRepairJob job2 = mock(ScheduledRepairJob.class);
+        when(job2.getRepairConfiguration()).thenReturn(config2);
+
+        Set<ScheduledRepairJob> jobs = new HashSet<>();
+        jobs.add(job1);
+        jobs.add(job2);
+
+        Set<RepairConfiguration> configs = new HashSet<>();
+        configs.add(config1);
+        configs.add(config2);
+
+        assertThat(RepairConfigurationComparator.hasChanged(jobs, configs)).isFalse();
+    }
+
+    @Test
+    public void testMultipleConfigsPartialMatchReturnsTrue()
+    {
+        RepairConfiguration config1 = RepairConfiguration.DEFAULT;
+        RepairConfiguration config2 = RepairConfiguration.newBuilder()
+                .withRepairInterval(1, TimeUnit.DAYS)
+                .build();
+        RepairConfiguration config3 = RepairConfiguration.newBuilder()
+                .withRepairInterval(2, TimeUnit.DAYS)
+                .build();
+
+        ScheduledRepairJob job1 = mock(ScheduledRepairJob.class);
+        when(job1.getRepairConfiguration()).thenReturn(config1);
+
+        Set<ScheduledRepairJob> jobs = Collections.singleton(job1);
+
+        Set<RepairConfiguration> configs = new HashSet<>();
+        configs.add(config1);
+        configs.add(config3);
+
+        assertThat(RepairConfigurationComparator.hasChanged(jobs, configs)).isTrue();
+    }
+}

--- a/core.impl/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/scheduler/TestScheduledRepairJobFactory.java
+++ b/core.impl/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/scheduler/TestScheduledRepairJobFactory.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2026 Telefonaktiebolaget LM Ericsson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ericsson.bss.cassandra.ecchronos.core.impl.repair.scheduler;
+
+import com.datastax.oss.driver.api.core.metadata.Node;
+import com.ericsson.bss.cassandra.ecchronos.core.impl.locks.RepairLockType;
+import com.ericsson.bss.cassandra.ecchronos.core.impl.metrics.CassandraMetrics;
+import com.ericsson.bss.cassandra.ecchronos.core.impl.repair.ScheduledRepairJob;
+import com.ericsson.bss.cassandra.ecchronos.core.impl.repair.TestUtils;
+import com.ericsson.bss.cassandra.ecchronos.core.impl.repair.incremental.IncrementalRepairJob;
+import com.ericsson.bss.cassandra.ecchronos.core.impl.repair.vnode.VnodeRepairStatesImpl;
+import com.ericsson.bss.cassandra.ecchronos.core.impl.table.TableRepairJob;
+import com.ericsson.bss.cassandra.ecchronos.core.impl.table.TimeBasedRunPolicy;
+import com.ericsson.bss.cassandra.ecchronos.core.jmx.DistributedJmxProxyFactory;
+import com.ericsson.bss.cassandra.ecchronos.core.repair.config.RepairConfiguration;
+import com.ericsson.bss.cassandra.ecchronos.core.state.RepairState;
+import com.ericsson.bss.cassandra.ecchronos.core.state.RepairStateFactory;
+import com.ericsson.bss.cassandra.ecchronos.core.state.RepairStateSnapshot;
+import com.ericsson.bss.cassandra.ecchronos.core.state.ReplicationState;
+import com.ericsson.bss.cassandra.ecchronos.core.state.VnodeRepairState;
+import com.ericsson.bss.cassandra.ecchronos.core.table.TableReference;
+import com.ericsson.bss.cassandra.ecchronos.core.table.TableRepairMetrics;
+import com.ericsson.bss.cassandra.ecchronos.core.table.TableStorageStates;
+import com.ericsson.bss.cassandra.ecchronos.data.repairhistory.RepairHistoryService;
+import com.ericsson.bss.cassandra.ecchronos.fm.RepairFaultReporter;
+import com.ericsson.bss.cassandra.ecchronos.utils.enums.repair.RepairType;
+import com.google.common.collect.ImmutableSet;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.Mockito;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.UUID;
+
+import static com.ericsson.bss.cassandra.ecchronos.core.impl.table.MockTableReferenceFactory.tableReference;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class TestScheduledRepairJobFactory
+{
+    private static final TableReference TABLE_REFERENCE = tableReference("keyspace", "table1");
+    private static final VnodeRepairState VNODE_REPAIR_STATE = TestUtils.createVnodeRepairState(1, 2, ImmutableSet.of(), System.currentTimeMillis());
+
+    @Mock
+    private DistributedJmxProxyFactory myJmxProxyFactory;
+    @Mock
+    private RepairFaultReporter myFaultReporter;
+    @Mock
+    private RepairStateFactory myRepairStateFactory;
+    @Mock
+    private ReplicationState myReplicationState;
+    @Mock
+    private CassandraMetrics myCassandraMetrics;
+    @Mock
+    private TableRepairMetrics myTableRepairMetrics;
+    @Mock
+    private RepairHistoryService myRepairHistoryService;
+    @Mock
+    private TableStorageStates myTableStorageStates;
+    @Mock
+    private TimeBasedRunPolicy myTimeBasedRunPolicy;
+    @Mock
+    private Node myNode;
+    @Mock
+    private RepairState myRepairState;
+    @Mock
+    private RepairStateSnapshot myRepairStateSnapshot;
+
+    private ScheduledRepairJobFactory myFactory;
+    private final UUID myNodeId = UUID.randomUUID();
+
+    @Before
+    public void setup()
+    {
+        when(myNode.getHostId()).thenReturn(myNodeId);
+        Mockito.lenient().when(myRepairState.getSnapshot()).thenReturn(myRepairStateSnapshot);
+        Mockito.lenient().when(myRepairStateFactory.create(eq(myNode), eq(TABLE_REFERENCE), any(), any())).thenReturn(myRepairState);
+        VnodeRepairStatesImpl vnodeRepairStates = VnodeRepairStatesImpl.newBuilder(Arrays.asList(VNODE_REPAIR_STATE)).build();
+        Mockito.lenient().when(myRepairStateSnapshot.getVnodeRepairStates()).thenReturn(vnodeRepairStates);
+
+        myFactory = ScheduledRepairJobFactory.builder()
+                .withTableRepairMetrics(myTableRepairMetrics)
+                .withRepairHistoryService(myRepairHistoryService)
+                .withFaultReporter(myFaultReporter)
+                .withJmxProxyFactory(myJmxProxyFactory)
+                .withRepairStateFactory(myRepairStateFactory)
+                .withReplicationState(myReplicationState)
+                .withCassandraMetrics(myCassandraMetrics)
+                .withRepairPolicies(new ArrayList<>())
+                .withTableStorageStates(myTableStorageStates)
+                .withRepairLockType(RepairLockType.VNODE)
+                .withTimeBasedRunPolicy(myTimeBasedRunPolicy)
+                .build();
+    }
+
+    @Test
+    public void testCreateVnodeRepairJob()
+    {
+        ScheduledRepairJob job = myFactory.create(myNode, TABLE_REFERENCE, RepairConfiguration.DEFAULT);
+
+        assertThat(job).isInstanceOf(TableRepairJob.class);
+        assertThat(job.getTableReference()).isEqualTo(TABLE_REFERENCE);
+        assertThat(job.getRepairConfiguration()).isEqualTo(RepairConfiguration.DEFAULT);
+    }
+
+    @Test
+    public void testCreateIncrementalRepairJob()
+    {
+        RepairConfiguration incrementalConfig = RepairConfiguration.newBuilder()
+                .withRepairType(RepairType.INCREMENTAL)
+                .build();
+
+        ScheduledRepairJob job = myFactory.create(myNode, TABLE_REFERENCE, incrementalConfig);
+
+        assertThat(job).isInstanceOf(IncrementalRepairJob.class);
+        assertThat(job.getTableReference()).isEqualTo(TABLE_REFERENCE);
+        assertThat(job.getRepairConfiguration()).isEqualTo(incrementalConfig);
+    }
+}


### PR DESCRIPTION
  Extract job creation logic into ScheduledRepairJobFactory and
  configuration comparison into RepairConfigurationComparator, reducing
  RepairSchedulerImpl to schedule lifecycle management only.

  - Add ScheduledRepairJobFactory with builder pattern for creating TableRepairJob and IncrementalRepairJob instances
  - Add RepairConfigurationComparator utility for detecting config changes
  - Remove @SuppressWarnings("PMD.GodClass") from RepairSchedulerImpl
  - Add unit tests for both new classes