### PR TITLE
Refactor OnDemandRepairSchedulerImpl into separate components

### DIFF
--- a/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/scheduler/OnDemandJobPoller.java
+++ b/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/scheduler/OnDemandJobPoller.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright 2026 Telefonaktiebolaget LM Ericsson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ericsson.bss.cassandra.ecchronos.core.impl.repair.scheduler;
+
+import com.ericsson.bss.cassandra.ecchronos.core.impl.repair.OnDemandRepairJob;
+import com.ericsson.bss.cassandra.ecchronos.core.impl.repair.OnDemandStatus;
+import com.ericsson.bss.cassandra.ecchronos.core.impl.repair.OngoingJob;
+import com.ericsson.bss.cassandra.ecchronos.core.metadata.DriverNode;
+import com.ericsson.bss.cassandra.ecchronos.core.repair.scheduler.ScheduleManager;
+import com.ericsson.bss.cassandra.ecchronos.core.state.LongTokenRange;
+import com.ericsson.bss.cassandra.ecchronos.core.state.ReplicationState;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.Closeable;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+
+/**
+ * Periodically polls for ongoing on-demand repair jobs and schedules them.
+ */
+public final class OnDemandJobPoller implements Closeable
+{
+    private static final Logger LOG = LoggerFactory.getLogger(OnDemandJobPoller.class);
+    private static final int ONGOING_JOBS_PERIOD_SECONDS = 10;
+
+    private final OnDemandStatus myOnDemandStatus;
+    private final ReplicationState myReplicationState;
+    private final ScheduleManager myScheduleManager;
+    private final OnDemandRepairJobFactory myJobFactory;
+    private final Function<OnDemandRepairJob, Boolean> myTryAddJob;
+    private final Runnable myRemoveFinishedJobs;
+
+    private final ScheduledExecutorService myExecutor = Executors.newSingleThreadScheduledExecutor(
+            new ThreadFactoryBuilder().setNameFormat("OngoingJobsScheduler-%d").build());
+
+    private OnDemandJobPoller(final Builder builder)
+    {
+        myOnDemandStatus = builder.myOnDemandStatus;
+        myReplicationState = builder.myReplicationState;
+        myScheduleManager = builder.myScheduleManager;
+        myJobFactory = builder.myJobFactory;
+        myTryAddJob = builder.myTryAddJob;
+        myRemoveFinishedJobs = builder.myRemoveFinishedJobs;
+        myExecutor.scheduleAtFixedRate(this::pollOngoingJobs, 0, ONGOING_JOBS_PERIOD_SECONDS, TimeUnit.SECONDS);
+    }
+
+    /**
+     * Retrieves and schedules ongoing on-demand repair jobs for a specific host.
+     *
+     * @param hostId The host for which to schedule ongoing jobs.
+     */
+    public void scheduleOngoingJobs(final UUID hostId)
+    {
+        try
+        {
+            Set<OngoingJob> ongoingJobs = myOnDemandStatus.getOngoingJobs(myReplicationState, hostId);
+            ongoingJobs.forEach(this::scheduleOngoingJob);
+        }
+        catch (Exception e)
+        {
+            LOG.warn("Failed to get ongoing on demand jobs, automatic retry in {}s", ONGOING_JOBS_PERIOD_SECONDS, e);
+        }
+    }
+
+    @Override
+    public void close()
+    {
+        myExecutor.shutdown();
+        try
+        {
+            if (!myExecutor.awaitTermination(ONGOING_JOBS_PERIOD_SECONDS, TimeUnit.SECONDS))
+            {
+                myExecutor.shutdownNow();
+            }
+        }
+        catch (InterruptedException e)
+        {
+            myExecutor.shutdownNow();
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    private void pollOngoingJobs()
+    {
+        try
+        {
+            myRemoveFinishedJobs.run();
+            Map<UUID, Set<OngoingJob>> allOngoingJobs = myOnDemandStatus.getOngoingStartedJobsForAllNodes(myReplicationState);
+            allOngoingJobs.values().forEach(jobs -> jobs.forEach(this::scheduleOngoingJob));
+        }
+        catch (Exception e)
+        {
+            LOG.warn("Failed to get ongoing on demand jobs, automatic retry in {}s", ONGOING_JOBS_PERIOD_SECONDS, e);
+        }
+    }
+
+    private void scheduleOngoingJob(final OngoingJob ongoingJob)
+    {
+        if (isAlreadyCompleted(ongoingJob))
+        {
+            LOG.debug("Skipping already completed ongoing job: {}", ongoingJob.getJobId());
+            ongoingJob.finishJob();
+            return;
+        }
+        OnDemandRepairJob job = myJobFactory.createFromOngoingJob(ongoingJob);
+        if (Boolean.TRUE.equals(myTryAddJob.apply(job)))
+        {
+            LOG.info("Scheduling ongoing job: {}", job.getJobId());
+            myScheduleManager.schedule(ongoingJob.getHostId(), job);
+        }
+    }
+
+    private boolean isAlreadyCompleted(final OngoingJob ongoingJob)
+    {
+        Map<LongTokenRange, ImmutableSet<DriverNode>> tokens = ongoingJob.getTokens();
+        Set<LongTokenRange> repairedTokens = ongoingJob.getRepairedTokens();
+        return tokens != null && !tokens.isEmpty()
+                && repairedTokens != null && repairedTokens.containsAll(tokens.keySet());
+    }
+
+    /**
+     * Create a new Builder instance.
+     *
+     * @return Builder
+     */
+    public static Builder builder()
+    {
+        return new Builder();
+    }
+
+    /**
+     * Builder for constructing {@link OnDemandJobPoller}.
+     */
+    public static final class Builder
+    {
+        private OnDemandStatus myOnDemandStatus;
+        private ReplicationState myReplicationState;
+        private ScheduleManager myScheduleManager;
+        private OnDemandRepairJobFactory myJobFactory;
+        private Function<OnDemandRepairJob, Boolean> myTryAddJob;
+        private Runnable myRemoveFinishedJobs;
+
+        public Builder withOnDemandStatus(final OnDemandStatus onDemandStatus)
+        {
+            myOnDemandStatus = onDemandStatus;
+            return this;
+        }
+
+        public Builder withReplicationState(final ReplicationState replicationState)
+        {
+            myReplicationState = replicationState;
+            return this;
+        }
+
+        public Builder withScheduleManager(final ScheduleManager scheduleManager)
+        {
+            myScheduleManager = scheduleManager;
+            return this;
+        }
+
+        public Builder withJobFactory(final OnDemandRepairJobFactory jobFactory)
+        {
+            myJobFactory = jobFactory;
+            return this;
+        }
+
+        public Builder withTryAddJob(final Function<OnDemandRepairJob, Boolean> tryAddJob)
+        {
+            myTryAddJob = tryAddJob;
+            return this;
+        }
+
+        public Builder withRemoveFinishedJobs(final Runnable removeFinishedJobs)
+        {
+            myRemoveFinishedJobs = removeFinishedJobs;
+            return this;
+        }
+
+        public OnDemandJobPoller build()
+        {
+            return new OnDemandJobPoller(this);
+        }
+    }
+}

--- a/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/scheduler/OnDemandRepairJobFactory.java
+++ b/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/scheduler/OnDemandRepairJobFactory.java
@@ -1,0 +1,214 @@
+/*
+ * Copyright 2026 Telefonaktiebolaget LM Ericsson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ericsson.bss.cassandra.ecchronos.core.impl.repair.scheduler;
+
+import com.datastax.oss.driver.api.core.metadata.Node;
+import com.ericsson.bss.cassandra.ecchronos.core.impl.locks.RepairLockType;
+import com.ericsson.bss.cassandra.ecchronos.core.impl.repair.IncrementalOnDemandRepairJob;
+import com.ericsson.bss.cassandra.ecchronos.core.impl.repair.OnDemandRepairJob;
+import com.ericsson.bss.cassandra.ecchronos.core.impl.repair.OnDemandStatus;
+import com.ericsson.bss.cassandra.ecchronos.core.impl.repair.OngoingJob;
+import com.ericsson.bss.cassandra.ecchronos.core.impl.repair.VnodeOnDemandRepairJob;
+import com.ericsson.bss.cassandra.ecchronos.core.jmx.DistributedJmxProxyFactory;
+import com.ericsson.bss.cassandra.ecchronos.core.repair.config.RepairConfiguration;
+import com.ericsson.bss.cassandra.ecchronos.core.state.RepairHistory;
+import com.ericsson.bss.cassandra.ecchronos.core.state.ReplicationState;
+import com.ericsson.bss.cassandra.ecchronos.core.table.TableReference;
+import com.ericsson.bss.cassandra.ecchronos.core.table.TableRepairMetrics;
+import com.ericsson.bss.cassandra.ecchronos.utils.enums.repair.RepairType;
+
+import java.util.NoSuchElementException;
+import java.util.UUID;
+import java.util.function.BiConsumer;
+
+/**
+ * Factory responsible for creating {@link OnDemandRepairJob} instances.
+ */
+public final class OnDemandRepairJobFactory
+{
+    private final DistributedJmxProxyFactory myJmxProxyFactory;
+    private final TableRepairMetrics myTableRepairMetrics;
+    private final ReplicationState myReplicationState;
+    private final RepairLockType myRepairLockType;
+    private final RepairHistory myRepairHistory;
+    private final RepairConfiguration myRepairConfiguration;
+    private final OnDemandStatus myOnDemandStatus;
+    private final BiConsumer<UUID, UUID> myOnFinishedHook;
+
+    private OnDemandRepairJobFactory(final Builder builder)
+    {
+        myJmxProxyFactory = builder.myJmxProxyFactory;
+        myTableRepairMetrics = builder.myTableRepairMetrics;
+        myReplicationState = builder.myReplicationState;
+        myRepairLockType = builder.myRepairLockType;
+        myRepairHistory = builder.myRepairHistory;
+        myRepairConfiguration = builder.myRepairConfiguration;
+        myOnDemandStatus = builder.myOnDemandStatus;
+        myOnFinishedHook = builder.myOnFinishedHook;
+    }
+
+    /**
+     * Create an OnDemandRepairJob from an existing OngoingJob.
+     *
+     * @param ongoingJob The ongoing job to create a repair job for.
+     * @return A new OnDemandRepairJob.
+     */
+    public OnDemandRepairJob createFromOngoingJob(final OngoingJob ongoingJob)
+    {
+        Node node = getNodeByHostId(ongoingJob.getHostId());
+        RepairConfiguration repairConfiguration = RepairConfiguration.newBuilder(myRepairConfiguration)
+                .withRepairType(ongoingJob.getRepairType())
+                .build();
+        if (ongoingJob.getRepairType().equals(RepairType.INCREMENTAL))
+        {
+            return new IncrementalOnDemandRepairJob.Builder()
+                    .withJmxProxyFactory(myJmxProxyFactory)
+                    .withTableRepairMetrics(myTableRepairMetrics)
+                    .withRepairLockType(myRepairLockType)
+                    .withOnFinished(id -> myOnFinishedHook.accept(id, ongoingJob.getHostId()))
+                    .withRepairConfiguration(repairConfiguration)
+                    .withReplicationState(myReplicationState)
+                    .withOngoingJob(ongoingJob)
+                    .withNode(node)
+                    .build();
+        }
+        return new VnodeOnDemandRepairJob.Builder()
+                .withJmxProxyFactory(myJmxProxyFactory)
+                .withTableRepairMetrics(myTableRepairMetrics)
+                .withRepairLockType(myRepairLockType)
+                .withOnFinished(id -> myOnFinishedHook.accept(id, ongoingJob.getHostId()))
+                .withRepairConfiguration(repairConfiguration)
+                .withRepairHistory(myRepairHistory)
+                .withOngoingJob(ongoingJob)
+                .withNode(node)
+                .build();
+    }
+
+    /**
+     * Create a new OngoingJob and return the corresponding OnDemandRepairJob.
+     *
+     * @param tableReference The table to repair.
+     * @param isClusterWide Whether this is a cluster-wide job.
+     * @param repairType The repair type.
+     * @param hostId The host to run on.
+     * @return A new OnDemandRepairJob.
+     */
+    public OnDemandRepairJob createNewJob(final TableReference tableReference,
+                                          final boolean isClusterWide,
+                                          final RepairType repairType,
+                                          final UUID hostId)
+    {
+        OngoingJob ongoingJob = new OngoingJob.Builder()
+                .withOnDemandStatus(myOnDemandStatus)
+                .withTableReference(tableReference)
+                .withReplicationState(myReplicationState)
+                .withHostId(hostId)
+                .withRepairType(repairType)
+                .build();
+        if (isClusterWide)
+        {
+            ongoingJob.startClusterWideJob(repairType);
+        }
+        return createFromOngoingJob(ongoingJob);
+    }
+
+    private Node getNodeByHostId(final UUID hostId)
+    {
+        Node node = myOnDemandStatus.getNodes().get(hostId);
+        if (node == null)
+        {
+            throw new NoSuchElementException("No node found with host ID: " + hostId);
+        }
+        return node;
+    }
+
+    /**
+     * Create a new Builder instance.
+     *
+     * @return Builder
+     */
+    public static Builder builder()
+    {
+        return new Builder();
+    }
+
+    /**
+     * Builder for constructing {@link OnDemandRepairJobFactory}.
+     */
+    public static final class Builder
+    {
+        private DistributedJmxProxyFactory myJmxProxyFactory;
+        private TableRepairMetrics myTableRepairMetrics;
+        private ReplicationState myReplicationState;
+        private RepairLockType myRepairLockType;
+        private RepairHistory myRepairHistory;
+        private RepairConfiguration myRepairConfiguration;
+        private OnDemandStatus myOnDemandStatus;
+        private BiConsumer<UUID, UUID> myOnFinishedHook;
+
+        public Builder withJmxProxyFactory(final DistributedJmxProxyFactory jmxProxyFactory)
+        {
+            myJmxProxyFactory = jmxProxyFactory;
+            return this;
+        }
+
+        public Builder withTableRepairMetrics(final TableRepairMetrics tableRepairMetrics)
+        {
+            myTableRepairMetrics = tableRepairMetrics;
+            return this;
+        }
+
+        public Builder withReplicationState(final ReplicationState replicationState)
+        {
+            myReplicationState = replicationState;
+            return this;
+        }
+
+        public Builder withRepairLockType(final RepairLockType repairLockType)
+        {
+            myRepairLockType = repairLockType;
+            return this;
+        }
+
+        public Builder withRepairHistory(final RepairHistory repairHistory)
+        {
+            myRepairHistory = repairHistory;
+            return this;
+        }
+
+        public Builder withRepairConfiguration(final RepairConfiguration repairConfiguration)
+        {
+            myRepairConfiguration = repairConfiguration;
+            return this;
+        }
+
+        public Builder withOnDemandStatus(final OnDemandStatus onDemandStatus)
+        {
+            myOnDemandStatus = onDemandStatus;
+            return this;
+        }
+
+        public Builder withOnFinishedHook(final BiConsumer<UUID, UUID> onFinishedHook)
+        {
+            myOnFinishedHook = onFinishedHook;
+            return this;
+        }
+
+        public OnDemandRepairJobFactory build()
+        {
+            return new OnDemandRepairJobFactory(this);
+        }
+    }
+}

--- a/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/scheduler/OnDemandRepairSchedulerImpl.java
+++ b/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/scheduler/OnDemandRepairSchedulerImpl.java
@@ -16,20 +16,15 @@ package com.ericsson.bss.cassandra.ecchronos.core.impl.repair.scheduler;
 
 import com.datastax.oss.driver.api.core.metadata.Node;
 import com.ericsson.bss.cassandra.ecchronos.core.impl.locks.RepairLockType;
-import com.ericsson.bss.cassandra.ecchronos.core.impl.repair.IncrementalOnDemandRepairJob;
 import com.ericsson.bss.cassandra.ecchronos.core.impl.repair.OnDemandRepairJob;
 import com.ericsson.bss.cassandra.ecchronos.core.impl.repair.OnDemandStatus;
-import com.ericsson.bss.cassandra.ecchronos.core.impl.repair.OngoingJob;
-import com.ericsson.bss.cassandra.ecchronos.core.impl.repair.VnodeOnDemandRepairJob;
 import com.ericsson.bss.cassandra.ecchronos.core.jmx.DistributedJmxProxyFactory;
-import com.ericsson.bss.cassandra.ecchronos.core.metadata.DriverNode;
 import com.ericsson.bss.cassandra.ecchronos.core.metadata.Metadata;
 import com.ericsson.bss.cassandra.ecchronos.core.repair.config.RepairConfiguration;
 import com.ericsson.bss.cassandra.ecchronos.core.repair.scheduler.OnDemandRepairJobView;
 import com.ericsson.bss.cassandra.ecchronos.core.repair.scheduler.OnDemandRepairScheduler;
 import com.ericsson.bss.cassandra.ecchronos.core.repair.scheduler.ScheduleManager;
 import com.ericsson.bss.cassandra.ecchronos.core.repair.scheduler.ScheduledJob;
-import com.ericsson.bss.cassandra.ecchronos.core.state.LongTokenRange;
 import com.ericsson.bss.cassandra.ecchronos.core.state.RepairHistory;
 import com.ericsson.bss.cassandra.ecchronos.core.state.ReplicationState;
 import com.ericsson.bss.cassandra.ecchronos.core.table.TableReference;
@@ -40,75 +35,68 @@ import java.io.Closeable;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import com.datastax.oss.driver.api.core.CqlSession;
 import com.datastax.oss.driver.api.core.metadata.schema.KeyspaceMetadata;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.util.concurrent.ThreadFactoryBuilder;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * A factory creating {@link OnDemandRepairJob}'s for tables.
  */
-@SuppressWarnings("PMD.GodClass")
 public final class OnDemandRepairSchedulerImpl implements OnDemandRepairScheduler, Closeable
 {
-    private static final Logger LOG = LoggerFactory.getLogger(OnDemandRepairSchedulerImpl.class);
-    private static final int ONGOING_JOBS_PERIOD_SECONDS = 10;
 
     private final Map<UUID, OnDemandRepairJob> myScheduledJobs = new HashMap<>();
     private final Object myLock = new Object();
 
-    private final DistributedJmxProxyFactory myJmxProxyFactory;
-    private final TableRepairMetrics myTableRepairMetrics;
     private final ScheduleManager myScheduleManager;
-    private final ReplicationState myReplicationState;
-    private final RepairLockType myRepairLockType;
     private final CqlSession mySession;
-    private final RepairConfiguration myRepairConfiguration;
-    private final RepairHistory myRepairHistory;
     private final OnDemandStatus myOnDemandStatus;
+    private final ReplicationState myReplicationState;
+    private final RepairConfiguration myRepairConfiguration;
+    private final OnDemandRepairJobFactory myJobFactory;
+    private final OnDemandJobPoller myPoller;
     private final Function<TableReference, Set<RepairConfiguration>> myRepairConfigurationFunction;
-
-    private final ScheduledExecutorService myExecutor = Executors.newSingleThreadScheduledExecutor(
-            new ThreadFactoryBuilder().setNameFormat("OngoingJobsScheduler-%d").build());
 
     private OnDemandRepairSchedulerImpl(final Builder builder)
     {
-        myJmxProxyFactory = builder.myJmxProxyFactory;
-        myTableRepairMetrics = builder.myTableRepairMetrics;
         myScheduleManager = builder.myScheduleManager;
-        myReplicationState = builder.myReplicationState;
-        myRepairLockType = builder.repairLockType;
         mySession = builder.session;
-        myRepairConfiguration = builder.repairConfiguration;
-        myRepairHistory = builder.repairHistory;
         myOnDemandStatus = builder.onDemandStatus;
-        myExecutor.scheduleAtFixedRate(() -> getOngoingStartedJobsForAllNodes(), 0, ONGOING_JOBS_PERIOD_SECONDS, TimeUnit.SECONDS);
+        myReplicationState = builder.myReplicationState;
+        myRepairConfiguration = builder.repairConfiguration;
         myRepairConfigurationFunction = builder.myRepairConfigurationFunction;
+
+        myJobFactory = OnDemandRepairJobFactory.builder()
+                .withJmxProxyFactory(builder.myJmxProxyFactory)
+                .withTableRepairMetrics(builder.myTableRepairMetrics)
+                .withReplicationState(builder.myReplicationState)
+                .withRepairLockType(builder.repairLockType)
+                .withRepairHistory(builder.repairHistory)
+                .withRepairConfiguration(builder.repairConfiguration)
+                .withOnDemandStatus(builder.onDemandStatus)
+                .withOnFinishedHook(this::removeScheduledJob)
+                .build();
+
+        myPoller = OnDemandJobPoller.builder()
+                .withOnDemandStatus(builder.onDemandStatus)
+                .withReplicationState(builder.myReplicationState)
+                .withScheduleManager(builder.myScheduleManager)
+                .withJobFactory(myJobFactory)
+                .withTryAddJob(this::tryAddJob)
+                .withRemoveFinishedJobs(this::removeFinishedJobs)
+                .build();
     }
 
-    private void getOngoingStartedJobsForAllNodes()
+    private Boolean tryAddJob(final OnDemandRepairJob job)
     {
-        try
+        synchronized (myLock)
         {
-            removeFinishedJobs();
-            Map<UUID, Set<OngoingJob>> allOngoingJobs = myOnDemandStatus.getOngoingStartedJobsForAllNodes(myReplicationState);
-            allOngoingJobs.values().forEach(jobs -> jobs.forEach(this::scheduleOngoingJob));
-        }
-        catch (Exception e)
-        {
-            logFailureMessage(e);
+            return myScheduledJobs.putIfAbsent(job.getJobId(), job) == null;
         }
     }
 
@@ -124,11 +112,6 @@ public final class OnDemandRepairSchedulerImpl implements OnDemandRepairSchedule
         }
     }
 
-    private static void logFailureMessage(final Exception e)
-    {
-        LOG.warn("Failed to get ongoing on demand jobs, automatic retry in {}s", ONGOING_JOBS_PERIOD_SECONDS, e);
-    }
-
     /**
      * Retrieves and schedules ongoing on-demand repair jobs for a specific host.
      *
@@ -136,15 +119,7 @@ public final class OnDemandRepairSchedulerImpl implements OnDemandRepairSchedule
      */
     public void scheduleOngoingJobs(final UUID hostId)
     {
-        try
-        {
-            Set<OngoingJob> ongoingJobs = myOnDemandStatus.getOngoingJobs(myReplicationState, hostId);
-            ongoingJobs.forEach(this::scheduleOngoingJob);
-        }
-        catch (Exception e)
-        {
-            logFailureMessage(e);
-        }
+        myPoller.scheduleOngoingJobs(hostId);
     }
 
     /**
@@ -153,6 +128,7 @@ public final class OnDemandRepairSchedulerImpl implements OnDemandRepairSchedule
     @Override
     public void close()
     {
+        myPoller.close();
         synchronized (myLock)
         {
             for (OnDemandRepairJob job : myScheduledJobs.values())
@@ -160,19 +136,6 @@ public final class OnDemandRepairSchedulerImpl implements OnDemandRepairSchedule
                 descheduleTable(job);
             }
             myScheduledJobs.clear();
-            myExecutor.shutdown();
-        }
-        try
-        {
-            if (!myExecutor.awaitTermination(ONGOING_JOBS_PERIOD_SECONDS, TimeUnit.SECONDS))
-            {
-                myExecutor.shutdownNow();
-            }
-        }
-        catch (InterruptedException e)
-        {
-            myExecutor.shutdownNow();
-            Thread.currentThread().interrupt();
         }
     }
 
@@ -191,9 +154,7 @@ public final class OnDemandRepairSchedulerImpl implements OnDemandRepairSchedule
         {
             scheduleJob(tableReference, true, repairType, node.getHostId());
         }
-        List<OnDemandRepairJobView> jobViews = getAllClusterWideRepairJobs().stream()
-                .collect(Collectors.toList());
-        return jobViews;
+        return getAllClusterWideRepairJobs().stream().collect(Collectors.toList());
     }
 
     /**
@@ -219,12 +180,13 @@ public final class OnDemandRepairSchedulerImpl implements OnDemandRepairSchedule
         synchronized (myLock)
         {
             validateTableReference(tableReference);
-            OnDemandRepairJob job = getRepairJob(tableReference, isClusterWide, repairType, nodeId);
+            OnDemandRepairJob job = myJobFactory.createNewJob(tableReference, isClusterWide, repairType, nodeId);
             myScheduledJobs.put(job.getJobId(), job);
             myScheduleManager.schedule(nodeId, job);
             return job.getView();
         }
     }
+
     @Override
     public boolean checkTableEnabled(final TableReference tableReference, final boolean forceRepairDisabled)
     {
@@ -257,33 +219,6 @@ public final class OnDemandRepairSchedulerImpl implements OnDemandRepairSchedule
         }
     }
 
-    private void scheduleOngoingJob(final OngoingJob ongoingJob)
-    {
-        if (isAlreadyCompleted(ongoingJob))
-        {
-            LOG.debug("Skipping already completed ongoing job: {}", ongoingJob.getJobId());
-            ongoingJob.finishJob();
-            return;
-        }
-        synchronized (myLock)
-        {
-            OnDemandRepairJob job = getOngoingRepairJob(ongoingJob);
-            if (myScheduledJobs.putIfAbsent(job.getJobId(), job) == null)
-            {
-                LOG.info("Scheduling ongoing job: {}", job.getJobId());
-                myScheduleManager.schedule(ongoingJob.getHostId(), job);
-            }
-        }
-    }
-
-    private boolean isAlreadyCompleted(final OngoingJob ongoingJob)
-    {
-        Map<LongTokenRange, ImmutableSet<DriverNode>> tokens = ongoingJob.getTokens();
-        Set<LongTokenRange> repairedTokens = ongoingJob.getRepairedTokens();
-        return tokens != null && !tokens.isEmpty()
-                && repairedTokens != null && repairedTokens.containsAll(tokens.keySet());
-    }
-
     public List<OnDemandRepairJobView> getActiveRepairJobs()
     {
         synchronized (myLock)
@@ -305,7 +240,7 @@ public final class OnDemandRepairSchedulerImpl implements OnDemandRepairSchedule
     {
         return myOnDemandStatus.getAllClusterWideJobs()
                 .stream()
-                .map(this::getOngoingRepairJob)
+                .map(myJobFactory::createFromOngoingJob)
                 .map(OnDemandRepairJob::getView)
                 .collect(Collectors.toList());
     }
@@ -320,7 +255,7 @@ public final class OnDemandRepairSchedulerImpl implements OnDemandRepairSchedule
     {
         return myOnDemandStatus.getAllJobs(myReplicationState, hostId)
                 .stream()
-                .map(this::getOngoingRepairJob)
+                .map(myJobFactory::createFromOngoingJob)
                 .map(OnDemandRepairJob::getView)
                 .collect(Collectors.toList());
     }
@@ -345,98 +280,11 @@ public final class OnDemandRepairSchedulerImpl implements OnDemandRepairSchedule
         }
     }
 
-    private OnDemandRepairJob getRepairJob(final TableReference tableReference,
-                                           final boolean isClusterWide,
-                                           final RepairType repairType,
-                                           final UUID hostId)
-    {
-        OngoingJob ongoingJob = createOngoingJob(tableReference, repairType, hostId);
-        if (isClusterWide)
-        {
-            ongoingJob.startClusterWideJob(repairType);
-        }
-        return getOngoingRepairJob(ongoingJob);
-    }
-
-    private OngoingJob createOngoingJob(final TableReference tableReference,
-                                        final RepairType repairType,
-                                        final UUID hostId)
-    {
-        return new OngoingJob.Builder()
-                .withOnDemandStatus(myOnDemandStatus)
-                .withTableReference(tableReference)
-                .withReplicationState(myReplicationState)
-                .withHostId(hostId)
-                .withRepairType(repairType)
-                .build();
-    }
-
-    private OnDemandRepairJob getOngoingRepairJob(final OngoingJob ongoingJob)
-    {
-        OnDemandRepairJob job;
-        Node node = getNodeByHostId(ongoingJob.getHostId());
-
-        RepairConfiguration repairConfiguration = RepairConfiguration.newBuilder(myRepairConfiguration)
-                .withRepairType(ongoingJob.getRepairType())
-                .build();
-        if (ongoingJob.getRepairType().equals(RepairType.INCREMENTAL))
-        {
-            job = buildIncrementalOnDemandRepairJob(ongoingJob, repairConfiguration, node);
-        }
-        else
-        {
-            job = buildVnodeOnDemandRepairJob(ongoingJob, repairConfiguration, node);
-        }
-        return job;
-    }
-
-    private VnodeOnDemandRepairJob buildVnodeOnDemandRepairJob(final OngoingJob ongoingJob,
-                                                               final RepairConfiguration repairConfiguration,
-                                                               final Node node)
-    {
-        return new VnodeOnDemandRepairJob.Builder()
-                .withJmxProxyFactory(myJmxProxyFactory)
-                .withTableRepairMetrics(myTableRepairMetrics)
-                .withRepairLockType(myRepairLockType)
-                .withOnFinished(id -> removeScheduledJob(id, ongoingJob.getHostId()))
-                .withRepairConfiguration(repairConfiguration)
-                .withRepairHistory(myRepairHistory)
-                .withOngoingJob(ongoingJob)
-                .withNode(node)
-                .build();
-    }
-
-    private IncrementalOnDemandRepairJob buildIncrementalOnDemandRepairJob(final OngoingJob ongoingJob,
-                                                                           final RepairConfiguration repairConfiguration,
-                                                                           final Node node)
-    {
-        return new IncrementalOnDemandRepairJob.Builder()
-                .withJmxProxyFactory(myJmxProxyFactory)
-                .withTableRepairMetrics(myTableRepairMetrics)
-                .withRepairLockType(myRepairLockType)
-                .withOnFinished(id -> removeScheduledJob(id, ongoingJob.getHostId()))
-                .withRepairConfiguration(repairConfiguration)
-                .withReplicationState(myReplicationState)
-                .withOngoingJob(ongoingJob)
-                .withNode(node)
-                .build();
-    }
-
-    private Node getNodeByHostId(final UUID hostId)
-    {
-        Node node = myOnDemandStatus.getNodes().get(hostId);
-        if (node == null)
-        {
-            throw new NoSuchElementException("No node found with host ID: " + hostId);
-        }
-        return node;
-    }
     @Override
     public RepairConfiguration getRepairConfiguration()
     {
         return myRepairConfiguration;
     }
-
 
     public static Builder builder()
     {
@@ -551,6 +399,7 @@ public final class OnDemandRepairSchedulerImpl implements OnDemandRepairSchedule
             this.repairHistory = theRepairHistory;
             return this;
         }
+
         /**
          * Build on demand repair scheduler with repair configuration function.
          *

--- a/core.impl/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/scheduler/TestOnDemandJobPoller.java
+++ b/core.impl/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/scheduler/TestOnDemandJobPoller.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2026 Telefonaktiebolaget LM Ericsson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ericsson.bss.cassandra.ecchronos.core.impl.repair.scheduler;
+
+import com.ericsson.bss.cassandra.ecchronos.core.impl.repair.OnDemandRepairJob;
+import com.ericsson.bss.cassandra.ecchronos.core.impl.repair.OnDemandStatus;
+import com.ericsson.bss.cassandra.ecchronos.core.impl.repair.OngoingJob;
+import com.ericsson.bss.cassandra.ecchronos.core.metadata.DriverNode;
+import com.ericsson.bss.cassandra.ecchronos.core.repair.scheduler.ScheduleManager;
+import com.ericsson.bss.cassandra.ecchronos.core.state.LongTokenRange;
+import com.ericsson.bss.cassandra.ecchronos.core.state.ReplicationState;
+import com.ericsson.bss.cassandra.ecchronos.core.table.TableReference;
+import com.google.common.collect.ImmutableSet;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+import static com.ericsson.bss.cassandra.ecchronos.core.impl.table.MockTableReferenceFactory.tableReference;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.Silent.class)
+public class TestOnDemandJobPoller
+{
+    private static final TableReference TABLE_REFERENCE = tableReference("keyspace1", "table1");
+
+    @Mock
+    private OnDemandStatus myOnDemandStatus;
+    @Mock
+    private ReplicationState myReplicationState;
+    @Mock
+    private ScheduleManager myScheduleManager;
+    @Mock
+    private OnDemandRepairJobFactory myJobFactory;
+    @Mock
+    private OngoingJob myOngoingJob;
+    @Mock
+    private OnDemandRepairJob myRepairJob;
+
+    private OnDemandJobPoller myPoller;
+    private final UUID myNodeId = UUID.randomUUID();
+    private final UUID myJobId = UUID.randomUUID();
+
+    @After
+    public void teardown()
+    {
+        if (myPoller != null)
+        {
+            myPoller.close();
+        }
+    }
+
+    @Test
+    public void testPollSchedulesOngoingJobs()
+    {
+        when(myOngoingJob.getTableReference()).thenReturn(TABLE_REFERENCE);
+        when(myOngoingJob.getHostId()).thenReturn(myNodeId);
+        when(myOngoingJob.getJobId()).thenReturn(myJobId);
+        when(myRepairJob.getJobId()).thenReturn(myJobId);
+        when(myJobFactory.createFromOngoingJob(myOngoingJob)).thenReturn(myRepairJob);
+
+        Map<UUID, Set<OngoingJob>> allOngoingJobs = new HashMap<>();
+        Set<OngoingJob> jobs = new HashSet<>();
+        jobs.add(myOngoingJob);
+        allOngoingJobs.put(myNodeId, jobs);
+        when(myOnDemandStatus.getOngoingStartedJobsForAllNodes(myReplicationState)).thenReturn(allOngoingJobs);
+
+        myPoller = OnDemandJobPoller.builder()
+                .withOnDemandStatus(myOnDemandStatus)
+                .withReplicationState(myReplicationState)
+                .withScheduleManager(myScheduleManager)
+                .withJobFactory(myJobFactory)
+                .withTryAddJob(job -> true)
+                .withRemoveFinishedJobs(() -> { })
+                .build();
+
+        verify(myScheduleManager, timeout(1000)).schedule(eq(myNodeId), eq(myRepairJob));
+    }
+
+    @Test
+    public void testPollSkipsCompletedJobs()
+    {
+        Map<LongTokenRange, ImmutableSet<DriverNode>> tokens = new HashMap<>();
+        LongTokenRange range = new LongTokenRange(1, 2);
+        tokens.put(range, ImmutableSet.of(mock(DriverNode.class)));
+        Set<LongTokenRange> repairedTokens = new HashSet<>();
+        repairedTokens.add(range);
+
+        when(myOngoingJob.getTokens()).thenReturn(tokens);
+        when(myOngoingJob.getRepairedTokens()).thenReturn(repairedTokens);
+        when(myOngoingJob.getJobId()).thenReturn(myJobId);
+
+        Map<UUID, Set<OngoingJob>> allOngoingJobs = new HashMap<>();
+        Set<OngoingJob> jobs = new HashSet<>();
+        jobs.add(myOngoingJob);
+        allOngoingJobs.put(myNodeId, jobs);
+        when(myOnDemandStatus.getOngoingStartedJobsForAllNodes(myReplicationState)).thenReturn(allOngoingJobs);
+
+        myPoller = OnDemandJobPoller.builder()
+                .withOnDemandStatus(myOnDemandStatus)
+                .withReplicationState(myReplicationState)
+                .withScheduleManager(myScheduleManager)
+                .withJobFactory(myJobFactory)
+                .withTryAddJob(job -> true)
+                .withRemoveFinishedJobs(() -> { })
+                .build();
+
+        verify(myOngoingJob, timeout(1000)).finishJob();
+    }
+}

--- a/core.impl/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/scheduler/TestOnDemandRepairJobFactory.java
+++ b/core.impl/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/scheduler/TestOnDemandRepairJobFactory.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2026 Telefonaktiebolaget LM Ericsson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ericsson.bss.cassandra.ecchronos.core.impl.repair.scheduler;
+
+import com.datastax.oss.driver.api.core.metadata.Node;
+import com.ericsson.bss.cassandra.ecchronos.core.impl.locks.RepairLockType;
+import com.ericsson.bss.cassandra.ecchronos.core.impl.repair.IncrementalOnDemandRepairJob;
+import com.ericsson.bss.cassandra.ecchronos.core.impl.repair.OnDemandRepairJob;
+import com.ericsson.bss.cassandra.ecchronos.core.impl.repair.OnDemandStatus;
+import com.ericsson.bss.cassandra.ecchronos.core.impl.repair.OngoingJob;
+import com.ericsson.bss.cassandra.ecchronos.core.impl.repair.VnodeOnDemandRepairJob;
+import com.ericsson.bss.cassandra.ecchronos.core.jmx.DistributedJmxProxyFactory;
+import com.ericsson.bss.cassandra.ecchronos.core.metadata.DriverNode;
+import com.ericsson.bss.cassandra.ecchronos.core.repair.config.RepairConfiguration;
+import com.ericsson.bss.cassandra.ecchronos.core.state.RepairHistory;
+import com.ericsson.bss.cassandra.ecchronos.core.state.ReplicationState;
+import com.ericsson.bss.cassandra.ecchronos.core.table.TableReference;
+import com.ericsson.bss.cassandra.ecchronos.core.table.TableRepairMetrics;
+import com.ericsson.bss.cassandra.ecchronos.utils.enums.repair.RepairType;
+import com.google.common.collect.ImmutableSet;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import java.util.function.BiConsumer;
+
+import static com.ericsson.bss.cassandra.ecchronos.core.impl.table.MockTableReferenceFactory.tableReference;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.Silent.class)
+public class TestOnDemandRepairJobFactory
+{
+    private static final TableReference TABLE_REFERENCE = tableReference("keyspace1", "table1");
+
+    @Mock
+    private DistributedJmxProxyFactory myJmxProxyFactory;
+    @Mock
+    private TableRepairMetrics myTableRepairMetrics;
+    @Mock
+    private ReplicationState myReplicationState;
+    @Mock
+    private RepairHistory myRepairHistory;
+    @Mock
+    private OnDemandStatus myOnDemandStatus;
+    @Mock
+    private Node myNode;
+    @Mock
+    private OngoingJob myOngoingJob;
+    @Mock
+    private BiConsumer<UUID, UUID> myOnFinishedHook;
+
+    private OnDemandRepairJobFactory myFactory;
+    private final UUID myNodeId = UUID.randomUUID();
+
+    @Before
+    public void setup()
+    {
+        Map<UUID, Node> nodeMap = new HashMap<>();
+        nodeMap.put(myNodeId, myNode);
+        when(myOnDemandStatus.getNodes()).thenReturn(nodeMap);
+        when(myNode.getHostId()).thenReturn(myNodeId);
+        when(myOngoingJob.getTableReference()).thenReturn(TABLE_REFERENCE);
+        when(myOngoingJob.getHostId()).thenReturn(myNodeId);
+        when(myOngoingJob.getJobId()).thenReturn(UUID.randomUUID());
+
+        myFactory = OnDemandRepairJobFactory.builder()
+                .withJmxProxyFactory(myJmxProxyFactory)
+                .withTableRepairMetrics(myTableRepairMetrics)
+                .withReplicationState(myReplicationState)
+                .withRepairLockType(RepairLockType.VNODE)
+                .withRepairHistory(myRepairHistory)
+                .withRepairConfiguration(RepairConfiguration.DEFAULT)
+                .withOnDemandStatus(myOnDemandStatus)
+                .withOnFinishedHook(myOnFinishedHook)
+                .build();
+    }
+
+    @Test
+    public void testCreateVnodeJobFromOngoingJob()
+    {
+        when(myOngoingJob.getRepairType()).thenReturn(RepairType.VNODE);
+
+        OnDemandRepairJob job = myFactory.createFromOngoingJob(myOngoingJob);
+
+        assertThat(job).isInstanceOf(VnodeOnDemandRepairJob.class);
+        assertThat(job.getOngoingJob()).isEqualTo(myOngoingJob);
+    }
+
+    @Test
+    public void testCreateIncrementalJobFromOngoingJob()
+    {
+        when(myOngoingJob.getRepairType()).thenReturn(RepairType.INCREMENTAL);
+        when(myReplicationState.getReplicas(TABLE_REFERENCE, myNode)).thenReturn(ImmutableSet.of(mock(DriverNode.class)));
+
+        OnDemandRepairJob job = myFactory.createFromOngoingJob(myOngoingJob);
+
+        assertThat(job).isInstanceOf(IncrementalOnDemandRepairJob.class);
+        assertThat(job.getOngoingJob()).isEqualTo(myOngoingJob);
+    }
+}


### PR DESCRIPTION
  Extract OnDemandJobPoller and OnDemandRepairJobFactory from
  OnDemandRepairSchedulerImpl to improve separation of concerns.

  Add unit tests for the new classes.