### PR TITLE
Refactor ReloadingCertificateHandler to resolve GodClass violation

### DIFF
--- a/application/src/main/java/com/ericsson/bss/cassandra/ecchronos/application/config/security/CertificateLoader.java
+++ b/application/src/main/java/com/ericsson/bss/cassandra/ecchronos/application/config/security/CertificateLoader.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2026 Telefonaktiebolaget LM Ericsson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ericsson.bss.cassandra.ecchronos.application.config.security;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.security.KeyFactory;
+import java.security.NoSuchAlgorithmException;
+import java.security.PrivateKey;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateFactory;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.List;
+
+public final class CertificateLoader
+{
+    private static final Logger LOG = LoggerFactory.getLogger(CertificateLoader.class);
+
+    private CertificateLoader()
+    {
+    }
+
+    /**
+     * Load X.509 certificates from a PEM file.
+     *
+     * @param file the certificate file (may contain a chain).
+     * @return list of certificates in file order.
+     */
+    public static List<Certificate> loadCertificates(final File file) throws IOException, CertificateException
+    {
+        CertificateFactory cf = CertificateFactory.getInstance("X.509");
+        try (FileInputStream fis = new FileInputStream(file))
+        {
+            List<Certificate> certs = new ArrayList<>(cf.generateCertificates(fis));
+            if (certs.isEmpty())
+            {
+                throw new CertificateException("No certificate(s) found in file: " + file);
+            }
+            return certs;
+        }
+    }
+
+    /**
+     * Load a PKCS8-encoded private key from a PEM file. Supports EC and RSA key types.
+     *
+     * @param file the private key file.
+     * @return the parsed private key.
+     */
+    @SuppressWarnings("PMD.PreserveStackTrace")
+    public static PrivateKey loadPrivateKey(final File file) throws IOException
+    {
+        try
+        {
+            String key = Files.readString(file.toPath());
+            String privateKeyPEM = key
+                    .replaceAll("-----BEGIN .*PRIVATE KEY-----", "")
+                    .replaceAll("-----END .*PRIVATE KEY-----", "")
+                    .replaceAll("\\s", "");
+
+            if (privateKeyPEM.contains("ECPARAMETERS"))
+            {
+                LOG.error("Old EC key format detected. Use new format instead!");
+                throw new IOException("Unsupported private key EC format");
+            }
+
+            byte[] decoded = Base64.getDecoder().decode(privateKeyPEM);
+            PKCS8EncodedKeySpec spec = new PKCS8EncodedKeySpec(decoded);
+
+            try
+            {
+                LOG.debug("Trying private key type EC");
+                KeyFactory kf = KeyFactory.getInstance("EC");
+                return kf.generatePrivate(spec);
+            }
+            catch (InvalidKeySpecException e1)
+            {
+                LOG.debug("Trying private key type RSA");
+                try
+                {
+                    KeyFactory kf = KeyFactory.getInstance("RSA");
+                    return kf.generatePrivate(spec);
+                }
+                catch (InvalidKeySpecException e2)
+                {
+                    throw new IOException("Unsupported private key format", e2);
+                }
+            }
+        }
+        catch (NoSuchAlgorithmException e)
+        {
+            throw new IOException("Failed to load the private key file", e);
+        }
+    }
+}

--- a/application/src/main/java/com/ericsson/bss/cassandra/ecchronos/application/config/security/KeyStoreFactory.java
+++ b/application/src/main/java/com/ericsson/bss/cassandra/ecchronos/application/config/security/KeyStoreFactory.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2026 Telefonaktiebolaget LM Ericsson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ericsson.bss.cassandra.ecchronos.application.config.security;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.TrustManagerFactory;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.PrivateKey;
+import java.security.UnrecoverableKeyException;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateException;
+import java.util.List;
+
+public final class KeyStoreFactory
+{
+    private static final Logger LOG = LoggerFactory.getLogger(KeyStoreFactory.class);
+    private static final String DEFAULT_STORE_TYPE = "JKS";
+
+    private KeyStoreFactory()
+    {
+    }
+
+    /**
+     * Create a KeyManagerFactory from PEM certificate and private key files.
+     */
+    public static KeyManagerFactory createPemKeyManagerFactory(final TLSConfig tlsConfig, final String storeType)
+            throws IOException, CertificateException, KeyStoreException, NoSuchAlgorithmException,
+            UnrecoverableKeyException
+    {
+        File certificateFile = new File(tlsConfig.getCertificatePath().get());
+        File keyFile = new File(tlsConfig.getCertificatePrivateKeyPath().get());
+
+        List<Certificate> certs = CertificateLoader.loadCertificates(certificateFile);
+        Certificate[] certChain = certs.toArray(new Certificate[0]);
+        LOG.debug("Number of certificates in certificate chain: {}", certChain.length);
+
+        PrivateKey privateKey = CertificateLoader.loadPrivateKey(keyFile);
+        LOG.debug("Private key algorithm: {}", privateKey.getAlgorithm());
+
+        KeyStore keyStore = KeyStore.getInstance(storeType);
+        keyStore.load(null, null);
+        keyStore.setKeyEntry("client-certs", privateKey, "".toCharArray(), certChain);
+
+        KeyManagerFactory kmf = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
+        kmf.init(keyStore, "".toCharArray());
+        return kmf;
+    }
+
+    /**
+     * Create a TrustManagerFactory from a PEM trust certificate file.
+     */
+    public static TrustManagerFactory createPemTrustManagerFactory(final TLSConfig tlsConfig, final String storeType)
+            throws IOException, CertificateException, KeyStoreException, NoSuchAlgorithmException
+    {
+        File trustCertFile = new File(tlsConfig.getTrustCertificatePath().get());
+        List<Certificate> trustedCerts = CertificateLoader.loadCertificates(trustCertFile);
+        LOG.debug("Number of certificates in trusted certificate chain: {}", trustedCerts.size());
+
+        KeyStore trustStore = KeyStore.getInstance(storeType);
+        trustStore.load(null, null);
+        for (int i = 0; i < trustedCerts.size(); i++)
+        {
+            trustStore.setCertificateEntry("trusted-certs" + i, trustedCerts.get(i));
+        }
+
+        TrustManagerFactory tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+        tmf.init(trustStore);
+        return tmf;
+    }
+
+    /**
+     * Create a KeyManagerFactory from a keystore file (JKS/PKCS12).
+     */
+    public static KeyManagerFactory createKeyManagerFactory(final TLSConfig tlsConfig)
+            throws IOException, NoSuchAlgorithmException, KeyStoreException, CertificateException,
+            UnrecoverableKeyException
+    {
+        String algorithm = tlsConfig.getAlgorithm().orElse(KeyManagerFactory.getDefaultAlgorithm());
+        char[] password = tlsConfig.getKeyStorePassword().toCharArray();
+        String storeType = tlsConfig.getStoreType().orElse(DEFAULT_STORE_TYPE);
+
+        try (InputStream is = new FileInputStream(tlsConfig.getKeyStorePath()))
+        {
+            KeyManagerFactory kmf = KeyManagerFactory.getInstance(algorithm);
+            KeyStore keyStore = KeyStore.getInstance(storeType);
+            keyStore.load(is, password);
+            kmf.init(keyStore, password);
+            return kmf;
+        }
+    }
+
+    /**
+     * Create a TrustManagerFactory from a truststore file (JKS/PKCS12).
+     */
+    public static TrustManagerFactory createTrustManagerFactory(final TLSConfig tlsConfig)
+            throws IOException, NoSuchAlgorithmException, KeyStoreException, CertificateException
+    {
+        String algorithm = tlsConfig.getAlgorithm().orElse(TrustManagerFactory.getDefaultAlgorithm());
+        char[] password = tlsConfig.getTrustStorePassword().toCharArray();
+        String storeType = tlsConfig.getStoreType().orElse(DEFAULT_STORE_TYPE);
+
+        try (InputStream is = new FileInputStream(tlsConfig.getTrustStorePath()))
+        {
+            TrustManagerFactory tmf = TrustManagerFactory.getInstance(algorithm);
+            KeyStore keyStore = KeyStore.getInstance(storeType);
+            keyStore.load(is, password);
+            tmf.init(keyStore);
+            return tmf;
+        }
+    }
+}

--- a/application/src/main/java/com/ericsson/bss/cassandra/ecchronos/application/config/security/ReloadingCertificateHandler.java
+++ b/application/src/main/java/com/ericsson/bss/cassandra/ecchronos/application/config/security/ReloadingCertificateHandler.java
@@ -15,12 +15,9 @@
 package com.ericsson.bss.cassandra.ecchronos.application.config.security;
 
 import com.datastax.oss.driver.api.core.metadata.EndPoint;
-import com.ericsson.bss.cassandra.ecchronos.application.CustomCRLValidator;
-import com.ericsson.bss.cassandra.ecchronos.application.CustomX509TrustManager;
 import com.ericsson.bss.cassandra.ecchronos.connection.CertificateHandler;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.handler.ssl.SslContext;
-import io.netty.handler.ssl.SslContextBuilder;
 import jakarta.xml.bind.DatatypeConverter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -31,64 +28,38 @@ import javax.net.ssl.SSLEngine;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.TrustManagerFactory;
 import javax.net.ssl.X509ExtendedTrustManager;
-import javax.net.ssl.X509TrustManager;
-import java.io.File;
-import java.io.FileInputStream;
+import java.security.KeyManagementException;
 import java.io.IOException;
-import java.io.InputStream;
 import java.net.InetSocketAddress;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-
+import java.security.KeyStoreException;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.security.UnrecoverableKeyException;
-import java.security.KeyStoreException;
-import java.security.KeyManagementException;
-import java.security.InvalidAlgorithmParameterException;
-import java.security.KeyFactory;
-import java.security.KeyStore;
 import java.security.cert.CRLException;
 import java.security.cert.CertificateException;
-import java.security.PrivateKey;
-import java.security.cert.Certificate;
-import java.security.cert.CertificateFactory;
-import java.security.spec.InvalidKeySpecException;
-import java.security.spec.PKCS8EncodedKeySpec;
-
-import java.util.Map;
-import java.util.List;
+import java.security.InvalidAlgorithmParameterException;
 import java.util.HashMap;
-import java.util.Arrays;
-import java.util.ArrayList;
-import java.util.Base64;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 
-@SuppressWarnings("PMD.GodClass")
 public class ReloadingCertificateHandler implements CertificateHandler
 {
     private static final Logger LOG = LoggerFactory.getLogger(ReloadingCertificateHandler.class);
+    private static final String DEFAULT_STORE_TYPE_JKS = "JKS";
 
     private final AtomicReference<Context> currentContext = new AtomicReference<>();
     private final Supplier<TLSConfig> myTLSConfigSupplier;
-
-    private static final String DEFAULT_STORE_TYPE_JKS = "JKS";
 
     public ReloadingCertificateHandler(final Supplier<TLSConfig> tlsConfigSupplier)
     {
         this.myTLSConfigSupplier = tlsConfigSupplier;
     }
 
-    /**
-     * Create new SSL Engine.
-     *
-     * @param remoteEndpoint
-     *         the remote endpoint.
-     * @return The SSLEngine.
-     */
     @Override
-    public SSLEngine newSslEngine(final EndPoint remoteEndpoint)
+    public final SSLEngine newSslEngine(final EndPoint remoteEndpoint)
     {
         Context context = getContext();
         TLSConfig tlsConfig = context.getTlsConfig();
@@ -106,7 +77,6 @@ public class ReloadingCertificateHandler implements CertificateHandler
             sslEngine = sslContext.newEngine(ByteBufAllocator.DEFAULT);
         }
         sslEngine.setUseClientMode(true);
-
         tlsConfig.getCipherSuites().ifPresent(sslEngine::setEnabledCipherSuites);
         return sslEngine;
     }
@@ -144,310 +114,6 @@ public class ReloadingCertificateHandler implements CertificateHandler
     @Override
     public void close() throws Exception
     {
-
-    }
-
-    protected static final class Context
-    {
-        private final TLSConfig myTlsConfig;
-        private final SslContext mySslContext;
-        private final Map<String, String> myChecksums = new HashMap<>();
-        private KeyManagerFactory myKeyManagerFactory;
-        private TrustManagerFactory myTrustManagerFactory;
-
-        Context(final TLSConfig tlsConfig)
-                throws NoSuchAlgorithmException, IOException, UnrecoverableKeyException, CertificateException,
-                KeyStoreException, KeyManagementException, InvalidAlgorithmParameterException, CRLException
-        {
-            myTlsConfig = tlsConfig;
-            mySslContext = createSSLContext(myTlsConfig, this);
-            myChecksums.putAll(calculateChecksums(myTlsConfig));
-        }
-
-        KeyManagerFactory getKeyManagerFactory()
-        {
-            return myKeyManagerFactory;
-        }
-
-        TrustManagerFactory getTrustManagerFactory()
-        {
-            return myTrustManagerFactory;
-        }
-
-        TLSConfig getTlsConfig()
-        {
-            return myTlsConfig;
-        }
-
-        boolean sameConfig(final TLSConfig newTLSConfig) throws IOException, NoSuchAlgorithmException
-        {
-            return myTlsConfig.equals(newTLSConfig) && checksumSame(newTLSConfig);
-        }
-
-        private boolean checksumSame(final TLSConfig newTLSConfig) throws IOException, NoSuchAlgorithmException
-        {
-            return myChecksums.equals(calculateChecksums(newTLSConfig));
-        }
-
-        private Map<String, String> calculateChecksums(final TLSConfig tlsConfig)
-                throws IOException, NoSuchAlgorithmException
-        {
-            Map<String, String> checksums = new HashMap<>();
-            if (tlsConfig.isCertificateConfigured())
-            {
-                String certificate = tlsConfig.getCertificatePath().get();
-                checksums.put(certificate, getChecksum(certificate));
-                String certificatePrivateKey = tlsConfig.getCertificatePrivateKeyPath().get();
-                checksums.put(certificatePrivateKey, getChecksum(certificatePrivateKey));
-                String trustCertificate = tlsConfig.getTrustCertificatePath().get();
-                checksums.put(trustCertificate, getChecksum(trustCertificate));
-            }
-            else
-            {
-                String keyStore = tlsConfig.getKeyStorePath();
-                checksums.put(keyStore, getChecksum(keyStore));
-                String trustStore = tlsConfig.getTrustStorePath();
-                checksums.put(trustStore, getChecksum(trustStore));
-            }
-            return checksums;
-        }
-
-        private String getChecksum(final String file) throws IOException, NoSuchAlgorithmException
-        {
-            MessageDigest md5 = MessageDigest.getInstance("MD5");
-            byte[] digestBytes = md5.digest(Files.readAllBytes(Paths.get(file)));
-            return DatatypeConverter.printHexBinary(digestBytes);
-        }
-
-        SslContext getSSLContext()
-        {
-            return mySslContext;
-        }
-    }
-
-    protected static SslContext createSSLContext(final TLSConfig tlsConfig, final Context context) throws IOException,
-            NoSuchAlgorithmException,
-            KeyStoreException,
-            CertificateException,
-            UnrecoverableKeyException
-    {
-
-        SslContextBuilder builder = SslContextBuilder.forClient();
-        String storeType = tlsConfig.getStoreType().orElse(DEFAULT_STORE_TYPE_JKS);
-
-        if (tlsConfig.isCertificateConfigured())
-        {
-             LOG.info("Will use PEM certificates for connections, using internal store type {}", storeType);
-
-            // Get certificate and key files from config
-            File certificateFile = new File(tlsConfig.getCertificatePath().get());
-            File certificatePrivateKeyFile = new File(tlsConfig.getCertificatePrivateKeyPath().get());
-            File trustCertificateFile = new File(tlsConfig.getTrustCertificatePath().get());
-
-            // Put client certificate(s) and its private key into an internal keystore
-            KeyStore keyStore = KeyStore.getInstance(storeType);
-            keyStore.load(null, null);
-
-
-            CertificateFactory cf = CertificateFactory.getInstance("X.509");
-
-            // Read up all certificates in the file given (chained or not)
-            try (FileInputStream fis = new FileInputStream(certificateFile))
-            {
-                List<Certificate> clientCertificates = new ArrayList<>(cf.generateCertificates(fis));
-                if (clientCertificates.isEmpty())
-                {
-                    throw new CertificateException("No certificate(s) found in the certificate file!");
-                }
-                else
-                {
-                    // Order certs from leaf to root (the client cert will be at index 0 of the certificate array)
-                    Certificate[] certChain = clientCertificates.toArray(new Certificate[0]);
-                    LOG.debug("Number of certificates in certificate chain: {}", certChain.length);
-
-                    // Load and parse the private key
-                    PrivateKey privateKey = loadPrivateKey(certificatePrivateKeyFile);
-                    LOG.debug("Private key algorithm: {}", privateKey.getAlgorithm());
-
-                    // Finally, set the key/certs entry in the keystore
-                    keyStore.setKeyEntry("client-certs", privateKey, "".toCharArray(), certChain);
-                }
-            }
-
-            // Set trusted certificates
-            // Create KeyManagerFactory
-            KeyManagerFactory kmf = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
-            kmf.init(keyStore, "".toCharArray());
-
-            // Create TrustManagerFactory and load the trusted certificate into it
-            TrustManagerFactory tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
-            KeyStore trustStore = KeyStore.getInstance(storeType);
-            trustStore.load(null, null);
-
-            try (FileInputStream fis = new FileInputStream(trustCertificateFile))
-            {
-                List<Certificate> trustedCertificates = new ArrayList<>(cf.generateCertificates(fis));
-                if (trustedCertificates.isEmpty())
-                {
-                    throw new CertificateException("No certificate(s) found in the trusted certificate file!");
-                }
-                else
-                {
-                    LOG.debug("Number of certificates in trusted certificate chain: {}", trustedCertificates.size());
-                    // Add all certificates in the trusted chain to the internal truststore
-                    for (int i = 0; i < trustedCertificates.size(); i++)
-                    {
-                        trustStore.setCertificateEntry("trusted-certs" + i, trustedCertificates.get(i));
-                    }
-
-                    tmf.init(trustStore);
-                }
-            }
-
-            context.myKeyManagerFactory = kmf;
-            context.myTrustManagerFactory = tmf;
-            // Finally, set the managers in the builder
-            builder.keyManager(kmf);
-            setTrustManagers(builder, tlsConfig, tmf);
-        }
-        else
-        {
-            LOG.info("Will use keystore/truststore for connections, expecting store type {}", storeType);
-
-            KeyManagerFactory keyManagerFactory = getKeyManagerFactory(tlsConfig);
-            builder.keyManager(keyManagerFactory);
-             setTrustManagers(builder, tlsConfig, getTrustManagerFactory(tlsConfig));
-        }
-        if (tlsConfig.requiresEndpointVerification())
-        {
-            LOG.info("Endpoint verification enabled");
-            builder.endpointIdentificationAlgorithm("HTTPS");
-        }
-        else
-        {
-            LOG.info("Endpoint verification disabled");
-            builder.endpointIdentificationAlgorithm("");
-        }
-        if (tlsConfig.getCipherSuites().isPresent())
-        {
-            builder.ciphers(Arrays.asList(tlsConfig.getCipherSuites().get()));
-        }
-        return builder.protocols(tlsConfig.getProtocols()).build();
-    }
-    protected static void setTrustManagers(final SslContextBuilder builder,
-                                           final TLSConfig config,
-                                           final TrustManagerFactory tmf)
-    {
-        if (config.getCRLConfig().getEnabled())
-        {
-            // If CRL is enabled, use the CustomX509TrustManager (CRL checking is added to the SSL context)
-            LOG.info("CRL enabled using strict mode: {}", config.getCRLConfig().getStrict());
-            TrustManager[] trustManagers = tmf.getTrustManagers();
-            for (int i = 0; i < trustManagers.length; i++)
-            {
-                if (trustManagers[i] instanceof X509TrustManager)
-                {
-                    CustomCRLValidator validator = new CustomCRLValidator(config.getCRLConfig());
-                    trustManagers[i] = new CustomX509TrustManager(
-                            (X509TrustManager) trustManagers[i],
-                            validator
-                    );
-                    builder.trustManager(trustManagers[i]);
-                }
-            }
-        }
-
-        else
-        {
-            // No CRL, use TrustManagerFactory as-isAdd commentMore actions
-            LOG.info("CRL not enabled");
-            builder.trustManager(tmf);
-        }
-
-    }
-    @SuppressWarnings("PMD.PreserveStackTrace")
-    protected static PrivateKey loadPrivateKey(final File file) throws IOException
-    {
-        try
-        {
-            // Supported key types are EC and RSA (DSA is legacy and should not be used)
-
-            // Read key file and remove the PEM header and any whitespaces
-            String key = Files.readString(file.toPath());
-            String privateKeyPEM = key
-                    .replaceAll("-----BEGIN .*PRIVATE KEY-----", "")
-                    .replaceAll("-----END .*PRIVATE KEY-----", "")
-                    .replaceAll("\\s", "");
-
-            // Sanity check; no support for old style EC keys
-            if (privateKeyPEM.contains("ECPARAMETERS"))
-            {
-                LOG.error("Old EC key format detected. Use new format instead!");
-                throw new IOException("Unsupported private key EC format");
-            }
-
-
-            // Decode the key into a nice byte array
-            byte[] decoded = Base64.getDecoder().decode(privateKeyPEM);
-            PKCS8EncodedKeySpec spec = new PKCS8EncodedKeySpec(decoded);
-
-            try
-            {
-                LOG.debug("Trying private key type EC");
-                KeyFactory kf = KeyFactory.getInstance("EC");
-                return kf.generatePrivate(spec);
-            }
-            catch (InvalidKeySpecException e1)
-            {
-                LOG.debug("Trying private key type RSA");
-                try
-                {
-                    KeyFactory kf = KeyFactory.getInstance("RSA");
-                    return kf.generatePrivate(spec);
-                }
-                catch (InvalidKeySpecException e2)
-                {
-                    throw new IOException("Unsupported private key format", e2);
-                }
-            }
-        }
-        catch (NoSuchAlgorithmException e)
-        {
-            throw new IOException("Failed to load the private key file", e);
-        }
-
-    }
-
-    protected static KeyManagerFactory getKeyManagerFactory(final TLSConfig tlsConfig) throws IOException,
-            NoSuchAlgorithmException, KeyStoreException, CertificateException, UnrecoverableKeyException
-    {
-        String algorithm = tlsConfig.getAlgorithm().orElse(KeyManagerFactory.getDefaultAlgorithm());
-        char[] keystorePassword = tlsConfig.getKeyStorePassword().toCharArray();
-
-        try (InputStream keystoreFile = new FileInputStream(tlsConfig.getKeyStorePath()))
-        {
-            KeyManagerFactory keyManagerFactory = KeyManagerFactory.getInstance(algorithm);
-            KeyStore keyStore = KeyStore.getInstance(tlsConfig.getStoreType().orElse(DEFAULT_STORE_TYPE_JKS));
-            keyStore.load(keystoreFile, keystorePassword);
-            keyManagerFactory.init(keyStore, keystorePassword);
-            return keyManagerFactory;
-        }
-    }
-
-    protected static TrustManagerFactory getTrustManagerFactory(final TLSConfig tlsConfig)
-            throws IOException, NoSuchAlgorithmException, KeyStoreException, CertificateException
-    {
-        String algorithm = tlsConfig.getAlgorithm().orElse(TrustManagerFactory.getDefaultAlgorithm());
-        char[] truststorePassword = tlsConfig.getTrustStorePassword().toCharArray();
-
-        try (InputStream truststoreFile = new FileInputStream(tlsConfig.getTrustStorePath()))
-        {
-            TrustManagerFactory trustManagerFactory = TrustManagerFactory.getInstance(algorithm);
-            KeyStore keyStore = KeyStore.getInstance(tlsConfig.getStoreType().orElse(DEFAULT_STORE_TYPE_JKS));
-            keyStore.load(truststoreFile, truststorePassword);
-            trustManagerFactory.init(keyStore);
-            return trustManagerFactory;
-        }
     }
 
     @Override
@@ -522,5 +188,102 @@ public class ReloadingCertificateHandler implements CertificateHandler
             }
         }
         return trustManagers;
+    }
+
+    protected static final class Context
+    {
+        private final TLSConfig myTlsConfig;
+        private final SslContext mySslContext;
+        private final Map<String, String> myChecksums = new HashMap<>();
+        private KeyManagerFactory myKeyManagerFactory;
+        private TrustManagerFactory myTrustManagerFactory;
+
+        Context(final TLSConfig tlsConfig)
+                throws NoSuchAlgorithmException, IOException, UnrecoverableKeyException, CertificateException,
+                KeyStoreException, KeyManagementException, InvalidAlgorithmParameterException, CRLException
+        {
+            myTlsConfig = tlsConfig;
+            buildManagers();
+            mySslContext = SslContextFactory.create(myTlsConfig, myKeyManagerFactory, myTrustManagerFactory);
+            myChecksums.putAll(calculateChecksums(myTlsConfig));
+        }
+
+        private void buildManagers() throws IOException, CertificateException, KeyStoreException,
+                NoSuchAlgorithmException, UnrecoverableKeyException
+        {
+            String storeType = myTlsConfig.getStoreType().orElse(DEFAULT_STORE_TYPE_JKS);
+            if (myTlsConfig.isCertificateConfigured())
+            {
+                LOG.info("Will use PEM certificates for connections, using internal store type {}", storeType);
+                myKeyManagerFactory = KeyStoreFactory.createPemKeyManagerFactory(myTlsConfig, storeType);
+                myTrustManagerFactory = KeyStoreFactory.createPemTrustManagerFactory(myTlsConfig, storeType);
+            }
+            else
+            {
+                LOG.info("Will use keystore/truststore for connections, expecting store type {}", storeType);
+                myKeyManagerFactory = KeyStoreFactory.createKeyManagerFactory(myTlsConfig);
+                myTrustManagerFactory = KeyStoreFactory.createTrustManagerFactory(myTlsConfig);
+            }
+        }
+
+        KeyManagerFactory getKeyManagerFactory()
+        {
+            return myKeyManagerFactory;
+        }
+
+        TrustManagerFactory getTrustManagerFactory()
+        {
+            return myTrustManagerFactory;
+        }
+
+        TLSConfig getTlsConfig()
+        {
+            return myTlsConfig;
+        }
+
+        SslContext getSSLContext()
+        {
+            return mySslContext;
+        }
+
+        boolean sameConfig(final TLSConfig newTLSConfig) throws IOException, NoSuchAlgorithmException
+        {
+            return myTlsConfig.equals(newTLSConfig) && checksumSame(newTLSConfig);
+        }
+
+        private boolean checksumSame(final TLSConfig newTLSConfig) throws IOException, NoSuchAlgorithmException
+        {
+            return myChecksums.equals(calculateChecksums(newTLSConfig));
+        }
+
+        private Map<String, String> calculateChecksums(final TLSConfig tlsConfig)
+                throws IOException, NoSuchAlgorithmException
+        {
+            Map<String, String> checksums = new HashMap<>();
+            if (tlsConfig.isCertificateConfigured())
+            {
+                String certificate = tlsConfig.getCertificatePath().get();
+                checksums.put(certificate, getChecksum(certificate));
+                String certificatePrivateKey = tlsConfig.getCertificatePrivateKeyPath().get();
+                checksums.put(certificatePrivateKey, getChecksum(certificatePrivateKey));
+                String trustCertificate = tlsConfig.getTrustCertificatePath().get();
+                checksums.put(trustCertificate, getChecksum(trustCertificate));
+            }
+            else
+            {
+                String keyStore = tlsConfig.getKeyStorePath();
+                checksums.put(keyStore, getChecksum(keyStore));
+                String trustStore = tlsConfig.getTrustStorePath();
+                checksums.put(trustStore, getChecksum(trustStore));
+            }
+            return checksums;
+        }
+
+        private String getChecksum(final String file) throws IOException, NoSuchAlgorithmException
+        {
+            MessageDigest md5 = MessageDigest.getInstance("MD5");
+            byte[] digestBytes = md5.digest(Files.readAllBytes(Paths.get(file)));
+            return DatatypeConverter.printHexBinary(digestBytes);
+        }
     }
 }

--- a/application/src/main/java/com/ericsson/bss/cassandra/ecchronos/application/config/security/SslContextFactory.java
+++ b/application/src/main/java/com/ericsson/bss/cassandra/ecchronos/application/config/security/SslContextFactory.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2026 Telefonaktiebolaget LM Ericsson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ericsson.bss.cassandra.ecchronos.application.config.security;
+
+import com.ericsson.bss.cassandra.ecchronos.application.CustomCRLValidator;
+import com.ericsson.bss.cassandra.ecchronos.application.CustomX509TrustManager;
+import io.netty.handler.ssl.SslContext;
+import io.netty.handler.ssl.SslContextBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLException;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.TrustManagerFactory;
+import javax.net.ssl.X509TrustManager;
+import java.util.Arrays;
+
+public final class SslContextFactory
+{
+    private static final Logger LOG = LoggerFactory.getLogger(SslContextFactory.class);
+
+    private SslContextFactory()
+    {
+    }
+
+    /**
+     * Build a Netty SslContext from the given managers and TLS configuration.
+     */
+    public static SslContext create(final TLSConfig tlsConfig,
+                                    final KeyManagerFactory kmf,
+                                    final TrustManagerFactory tmf) throws SSLException
+    {
+        SslContextBuilder builder = SslContextBuilder.forClient();
+        builder.keyManager(kmf);
+        setTrustManagers(builder, tlsConfig, tmf);
+
+        if (tlsConfig.requiresEndpointVerification())
+        {
+            LOG.info("Endpoint verification enabled");
+            builder.endpointIdentificationAlgorithm("HTTPS");
+        }
+        else
+        {
+            LOG.info("Endpoint verification disabled");
+            builder.endpointIdentificationAlgorithm("");
+        }
+
+        if (tlsConfig.getCipherSuites().isPresent())
+        {
+            builder.ciphers(Arrays.asList(tlsConfig.getCipherSuites().get()));
+        }
+
+        return builder.protocols(tlsConfig.getProtocols()).build();
+    }
+
+    private static void setTrustManagers(final SslContextBuilder builder,
+                                         final TLSConfig config,
+                                         final TrustManagerFactory tmf)
+    {
+        if (config.getCRLConfig().getEnabled())
+        {
+            LOG.info("CRL enabled using strict mode: {}", config.getCRLConfig().getStrict());
+            TrustManager[] trustManagers = tmf.getTrustManagers();
+            for (int i = 0; i < trustManagers.length; i++)
+            {
+                if (trustManagers[i] instanceof X509TrustManager)
+                {
+                    CustomCRLValidator validator = new CustomCRLValidator(config.getCRLConfig());
+                    trustManagers[i] = new CustomX509TrustManager(
+                            (X509TrustManager) trustManagers[i],
+                            validator
+                    );
+                    builder.trustManager(trustManagers[i]);
+                }
+            }
+        }
+        else
+        {
+            LOG.info("CRL not enabled");
+            builder.trustManager(tmf);
+        }
+    }
+}

--- a/application/src/test/java/com/ericsson/bss/cassandra/ecchronos/application/config/security/TestCertificateLoader.java
+++ b/application/src/test/java/com/ericsson/bss/cassandra/ecchronos/application/config/security/TestCertificateLoader.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2026 Telefonaktiebolaget LM Ericsson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ericsson.bss.cassandra.ecchronos.application.config.security;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.security.PrivateKey;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateException;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Date;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class TestCertificateLoader
+{
+    private static final CertUtils CERT_UTILS = new CertUtils();
+    private static String rsaCert;
+    private static String rsaKey;
+    private static String ecCert;
+    private static String ecKey;
+
+    @BeforeClass
+    public static void setup() throws IOException
+    {
+        TemporaryFolder folder = new TemporaryFolder();
+        folder.create();
+        String dir = folder.getRoot().getPath();
+
+        Date notBefore = Date.from(Instant.now());
+        Date notAfter = Date.from(Instant.now().plus(Duration.ofHours(1)));
+
+        rsaCert = Paths.get(dir, "rsa-ca.crt").toString();
+        rsaKey = Paths.get(dir, "rsa-ca.key").toString();
+        CERT_UTILS.createSelfSignedCACertificate("rsaCA", notBefore, notAfter, "RSA", rsaCert, rsaKey);
+
+        ecCert = Paths.get(dir, "ec-ca.crt").toString();
+        ecKey = Paths.get(dir, "ec-ca.key").toString();
+        CERT_UTILS.createSelfSignedCACertificate("ecCA", notBefore, notAfter, "EC", ecCert, ecKey);
+    }
+
+    @Test
+    public void testLoadCertificatesRSA() throws Exception
+    {
+        List<Certificate> certs = CertificateLoader.loadCertificates(new File(rsaCert));
+        assertThat(certs).hasSize(1);
+        assertThat(certs.get(0).getType()).isEqualTo("X.509");
+    }
+
+    @Test
+    public void testLoadCertificatesEC() throws Exception
+    {
+        List<Certificate> certs = CertificateLoader.loadCertificates(new File(ecCert));
+        assertThat(certs).hasSize(1);
+    }
+
+    @Test
+    public void testLoadCertificatesEmptyFileThrows() throws Exception
+    {
+        File empty = File.createTempFile("empty", ".crt");
+        empty.deleteOnExit();
+
+        assertThatThrownBy(() -> CertificateLoader.loadCertificates(empty))
+                .isInstanceOf(CertificateException.class)
+                .hasMessageContaining("No certificate(s) found");
+    }
+
+    @Test
+    public void testLoadCertificatesNonExistentFileThrows()
+    {
+        assertThatThrownBy(() -> CertificateLoader.loadCertificates(new File("/nonexistent.crt")))
+                .isInstanceOf(IOException.class);
+    }
+
+    @Test
+    public void testLoadPrivateKeyRSA() throws Exception
+    {
+        PrivateKey key = CertificateLoader.loadPrivateKey(new File(rsaKey));
+        assertThat(key.getAlgorithm()).isEqualTo("RSA");
+    }
+
+    @Test
+    public void testLoadPrivateKeyEC() throws Exception
+    {
+        PrivateKey key = CertificateLoader.loadPrivateKey(new File(ecKey));
+        assertThat(key.getAlgorithm()).isEqualTo("EC");
+    }
+
+    @Test
+    public void testLoadPrivateKeyInvalidFormatThrows() throws Exception
+    {
+        File invalid = File.createTempFile("invalid", ".key");
+        invalid.deleteOnExit();
+        Files.writeString(invalid.toPath(), "-----BEGIN PRIVATE KEY-----\nnotvalidbase64!\n-----END PRIVATE KEY-----\n");
+
+        assertThatThrownBy(() -> CertificateLoader.loadPrivateKey(invalid))
+                .isInstanceOf(Exception.class);
+    }
+
+    @Test
+    public void testLoadPrivateKeyNonExistentFileThrows()
+    {
+        assertThatThrownBy(() -> CertificateLoader.loadPrivateKey(new File("/nonexistent.key")))
+                .isInstanceOf(IOException.class);
+    }
+}

--- a/application/src/test/java/com/ericsson/bss/cassandra/ecchronos/application/config/security/TestKeyStoreFactory.java
+++ b/application/src/test/java/com/ericsson/bss/cassandra/ecchronos/application/config/security/TestKeyStoreFactory.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2026 Telefonaktiebolaget LM Ericsson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ericsson.bss.cassandra.ecchronos.application.config.security;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.TrustManagerFactory;
+import java.io.IOException;
+import java.nio.file.Paths;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Date;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class TestKeyStoreFactory
+{
+    private static final String KEYSTORE_PASSWORD = "ecctest";
+    private static final String STORE_TYPE_JKS = "JKS";
+    private static final CertUtils CERT_UTILS = new CertUtils();
+
+    private static String caCert;
+    private static String clientCert;
+    private static String clientKey;
+    private static String keyStorePath;
+    private static String trustStorePath;
+
+    @BeforeClass
+    public static void setup() throws IOException
+    {
+        TemporaryFolder folder = new TemporaryFolder();
+        folder.create();
+        String dir = folder.getRoot().getPath();
+
+        Date notBefore = Date.from(Instant.now());
+        Date notAfter = Date.from(Instant.now().plus(Duration.ofHours(1)));
+
+        caCert = Paths.get(dir, "ca.crt").toString();
+        String caKey = Paths.get(dir, "ca.key").toString();
+        CERT_UTILS.createSelfSignedCACertificate("testCA", notBefore, notAfter, "RSA", caCert, caKey);
+
+        clientCert = Paths.get(dir, "client.crt").toString();
+        clientKey = Paths.get(dir, "client.key").toString();
+        CERT_UTILS.createCertificate("client", notBefore, notAfter, caCert, caKey, clientCert, clientKey);
+
+        keyStorePath = Paths.get(dir, "client.keystore").toString();
+        CERT_UTILS.createKeyStore(clientCert, clientKey, STORE_TYPE_JKS, KEYSTORE_PASSWORD, keyStorePath);
+
+        trustStorePath = Paths.get(dir, "client.truststore").toString();
+        CERT_UTILS.createTrustStore(caCert, STORE_TYPE_JKS, KEYSTORE_PASSWORD, trustStorePath);
+    }
+
+    @Test
+    public void testCreatePemKeyManagerFactory() throws Exception
+    {
+        TLSConfig config = createPemConfig();
+        KeyManagerFactory kmf = KeyStoreFactory.createPemKeyManagerFactory(config, STORE_TYPE_JKS);
+        assertThat(kmf).isNotNull();
+        assertThat(kmf.getKeyManagers()).isNotEmpty();
+    }
+
+    @Test
+    public void testCreatePemTrustManagerFactory() throws Exception
+    {
+        TLSConfig config = createPemConfig();
+        TrustManagerFactory tmf = KeyStoreFactory.createPemTrustManagerFactory(config, STORE_TYPE_JKS);
+        assertThat(tmf).isNotNull();
+        assertThat(tmf.getTrustManagers()).isNotEmpty();
+    }
+
+    @Test
+    public void testCreateKeyManagerFactory() throws Exception
+    {
+        TLSConfig config = createJksConfig();
+        KeyManagerFactory kmf = KeyStoreFactory.createKeyManagerFactory(config);
+        assertThat(kmf).isNotNull();
+        assertThat(kmf.getKeyManagers()).isNotEmpty();
+    }
+
+    @Test
+    public void testCreateTrustManagerFactory() throws Exception
+    {
+        TLSConfig config = createJksConfig();
+        TrustManagerFactory tmf = KeyStoreFactory.createTrustManagerFactory(config);
+        assertThat(tmf).isNotNull();
+        assertThat(tmf.getTrustManagers()).isNotEmpty();
+    }
+
+    @Test
+    public void testCreateKeyManagerFactoryInvalidPathThrows()
+    {
+        CqlTLSConfig config = new CqlTLSConfig(true, "/nonexistent.keystore", KEYSTORE_PASSWORD,
+                trustStorePath, KEYSTORE_PASSWORD);
+        config.setStoreType(STORE_TYPE_JKS);
+
+        assertThatThrownBy(() -> KeyStoreFactory.createKeyManagerFactory(config))
+                .isInstanceOf(IOException.class);
+    }
+
+    @Test
+    public void testCreateTrustManagerFactoryInvalidPathThrows()
+    {
+        CqlTLSConfig config = new CqlTLSConfig(true, keyStorePath, KEYSTORE_PASSWORD,
+                "/nonexistent.truststore", KEYSTORE_PASSWORD);
+        config.setStoreType(STORE_TYPE_JKS);
+
+        assertThatThrownBy(() -> KeyStoreFactory.createTrustManagerFactory(config))
+                .isInstanceOf(IOException.class);
+    }
+
+    private CqlTLSConfig createPemConfig()
+    {
+        CqlTLSConfig config = new CqlTLSConfig(true, clientCert, clientKey, caCert);
+        config.setProtocol("TLSv1.2");
+        return config;
+    }
+
+    private CqlTLSConfig createJksConfig()
+    {
+        CqlTLSConfig config = new CqlTLSConfig(true, keyStorePath, KEYSTORE_PASSWORD,
+                trustStorePath, KEYSTORE_PASSWORD);
+        config.setStoreType(STORE_TYPE_JKS);
+        config.setProtocol("TLSv1.2");
+        config.setCRLConfig(new CRLConfig());
+        return config;
+    }
+}

--- a/application/src/test/java/com/ericsson/bss/cassandra/ecchronos/application/config/security/TestSslContextFactory.java
+++ b/application/src/test/java/com/ericsson/bss/cassandra/ecchronos/application/config/security/TestSslContextFactory.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2026 Telefonaktiebolaget LM Ericsson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ericsson.bss.cassandra.ecchronos.application.config.security;
+
+import io.netty.handler.ssl.SslContext;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.TrustManagerFactory;
+import java.io.IOException;
+import java.nio.file.Paths;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Date;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestSslContextFactory
+{
+    private static final String KEYSTORE_PASSWORD = "ecctest";
+    private static final String STORE_TYPE_JKS = "JKS";
+    private static final CertUtils CERT_UTILS = new CertUtils();
+
+    private static String caCert;
+    private static String clientCert;
+    private static String clientKey;
+    private static String keyStorePath;
+    private static String trustStorePath;
+
+    @BeforeClass
+    public static void setup() throws IOException
+    {
+        TemporaryFolder folder = new TemporaryFolder();
+        folder.create();
+        String dir = folder.getRoot().getPath();
+
+        Date notBefore = Date.from(Instant.now());
+        Date notAfter = Date.from(Instant.now().plus(Duration.ofHours(1)));
+
+        caCert = Paths.get(dir, "ca.crt").toString();
+        String caKey = Paths.get(dir, "ca.key").toString();
+        CERT_UTILS.createSelfSignedCACertificate("testCA", notBefore, notAfter, "RSA", caCert, caKey);
+
+        clientCert = Paths.get(dir, "client.crt").toString();
+        clientKey = Paths.get(dir, "client.key").toString();
+        CERT_UTILS.createCertificate("client", notBefore, notAfter, caCert, caKey, clientCert, clientKey);
+
+        keyStorePath = Paths.get(dir, "client.keystore").toString();
+        CERT_UTILS.createKeyStore(clientCert, clientKey, STORE_TYPE_JKS, KEYSTORE_PASSWORD, keyStorePath);
+
+        trustStorePath = Paths.get(dir, "client.truststore").toString();
+        CERT_UTILS.createTrustStore(caCert, STORE_TYPE_JKS, KEYSTORE_PASSWORD, trustStorePath);
+    }
+
+    @Test
+    public void testCreateWithPemCertificates() throws Exception
+    {
+        CqlTLSConfig config = new CqlTLSConfig(true, clientCert, clientKey, caCert);
+        config.setProtocol("TLSv1.2");
+        config.setCRLConfig(new CRLConfig());
+
+        KeyManagerFactory kmf = KeyStoreFactory.createPemKeyManagerFactory(config, STORE_TYPE_JKS);
+        TrustManagerFactory tmf = KeyStoreFactory.createPemTrustManagerFactory(config, STORE_TYPE_JKS);
+
+        SslContext sslContext = SslContextFactory.create(config, kmf, tmf);
+        assertThat(sslContext).isNotNull();
+        assertThat(sslContext.isClient()).isTrue();
+    }
+
+    @Test
+    public void testCreateWithJksKeyStore() throws Exception
+    {
+        CqlTLSConfig config = new CqlTLSConfig(true, keyStorePath, KEYSTORE_PASSWORD,
+                trustStorePath, KEYSTORE_PASSWORD);
+        config.setStoreType(STORE_TYPE_JKS);
+        config.setProtocol("TLSv1.2");
+        config.setCRLConfig(new CRLConfig());
+
+        KeyManagerFactory kmf = KeyStoreFactory.createKeyManagerFactory(config);
+        TrustManagerFactory tmf = KeyStoreFactory.createTrustManagerFactory(config);
+
+        SslContext sslContext = SslContextFactory.create(config, kmf, tmf);
+        assertThat(sslContext).isNotNull();
+        assertThat(sslContext.isClient()).isTrue();
+    }
+
+    @Test
+    public void testCreateWithEndpointVerification() throws Exception
+    {
+        CqlTLSConfig config = new CqlTLSConfig(true, keyStorePath, KEYSTORE_PASSWORD,
+                trustStorePath, KEYSTORE_PASSWORD);
+        config.setStoreType(STORE_TYPE_JKS);
+        config.setProtocol("TLSv1.2");
+        config.setCRLConfig(new CRLConfig());
+        config.setRequireEndpointVerification(true);
+
+        KeyManagerFactory kmf = KeyStoreFactory.createKeyManagerFactory(config);
+        TrustManagerFactory tmf = KeyStoreFactory.createTrustManagerFactory(config);
+
+        SslContext sslContext = SslContextFactory.create(config, kmf, tmf);
+        assertThat(sslContext).isNotNull();
+    }
+
+    @Test
+    public void testCreateWithCipherSuites() throws Exception
+    {
+        CqlTLSConfig config = new CqlTLSConfig(true, keyStorePath, KEYSTORE_PASSWORD,
+                trustStorePath, KEYSTORE_PASSWORD);
+        config.setStoreType(STORE_TYPE_JKS);
+        config.setProtocol("TLSv1.2");
+        config.setCRLConfig(new CRLConfig());
+        config.setCipherSuites("TLS_AES_256_GCM_SHA384");
+
+        KeyManagerFactory kmf = KeyStoreFactory.createKeyManagerFactory(config);
+        TrustManagerFactory tmf = KeyStoreFactory.createTrustManagerFactory(config);
+
+        SslContext sslContext = SslContextFactory.create(config, kmf, tmf);
+        assertThat(sslContext).isNotNull();
+    }
+}


### PR DESCRIPTION
Extract distinct responsibilities into focused utility classes:
- CertificateLoader: PEM certificate and private key parsing (EC/RSA)
- KeyStoreFactory: KeyStore/TrustStore creation for PEM and JKS paths
- SslContextFactory: Netty SslContext building with CRL support

ReloadingCertificateHandler is now a thin orchestrator handling only config-change detection and SSL engine lifecycle. The PMD GodClass suppression is removed. No public API changes.

Add unit tests for each extracted class covering both happy paths and error cases.