### PR TITLE
Fix node token ranges being shared across nodes

### DIFF
--- a/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/state/ReplicationStateImpl.java
+++ b/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/state/ReplicationStateImpl.java
@@ -160,7 +160,7 @@ public class ReplicationStateImpl implements ReplicationState
     {
         TokenMap tokenMap = mySession.getMetadata().getTokenMap()
                 .orElseThrow(() -> new IllegalStateException("Cannot determine ranges, is metadata/tokenMap disabled?"));
-        String cacheKey = keyspace + ":" + System.identityHashCode(tokenMap);
+        String cacheKey = keyspace + ":" + currentNode.getHostId() + ":" + System.identityHashCode(tokenMap);
         return KEYSPACE_REPLICATION_CACHE.get(cacheKey, k -> buildTokenMap(keyspace, false, currentNode, tokenMap));
     }
 
@@ -185,7 +185,7 @@ public class ReplicationStateImpl implements ReplicationState
     {
         TokenMap tokenMap = mySession.getMetadata().getTokenMap()
                 .orElseThrow(() -> new IllegalStateException("Cannot determine ranges, is metadata/tokenMap disabled?"));
-        String cacheKey = keyspace + ":" + System.identityHashCode(tokenMap);
+        String cacheKey = keyspace + ":" + currentNode.getHostId() + ":" + System.identityHashCode(tokenMap);
         return CLUSTER_WIDE_KEYSPACE_REPLICATION_CACHE.get(cacheKey, k -> buildTokenMap(keyspace, true, currentNode, tokenMap));
     }
 


### PR DESCRIPTION
The KEYSPACE_REPLICATION_CACHE incorrectly shared node-specific token ranges across multiple NodeWorkers, causing repairs to fail because nodes received ranges belonging to other nodes.
The fix adds node ID to the cache key, ensuring each node maintains its own cache entry.