### PR TITLE
Refactor DistributedJmxBuilder to resolve GodClass violation

### DIFF
--- a/connection.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/connection/impl/builders/DistributedJmxBuilder.java
+++ b/connection.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/connection/impl/builders/DistributedJmxBuilder.java
@@ -14,59 +14,42 @@
  */
 package com.ericsson.bss.cassandra.ecchronos.connection.impl.builders;
 
-import com.datastax.oss.driver.api.core.AllNodesFailedException;
 import com.datastax.oss.driver.api.core.CqlSession;
-import com.datastax.oss.driver.api.core.cql.Row;
-import com.datastax.oss.driver.api.core.cql.SimpleStatement;
 import com.datastax.oss.driver.api.core.metadata.Node;
-import com.datastax.oss.driver.api.core.servererrors.QueryExecutionException;
 import com.ericsson.bss.cassandra.ecchronos.connection.DistributedJmxConnectionProvider;
 import com.ericsson.bss.cassandra.ecchronos.connection.DistributedNativeConnectionProvider;
 import com.ericsson.bss.cassandra.ecchronos.connection.impl.providers.DistributedJmxConnectionProviderImpl;
 import com.ericsson.bss.cassandra.ecchronos.data.iptranslator.IpTranslator;
 import com.ericsson.bss.cassandra.ecchronos.data.sync.EccNodesSync;
-import com.ericsson.bss.cassandra.ecchronos.utils.dns.ReverseDNS;
 import com.ericsson.bss.cassandra.ecchronos.utils.enums.sync.NodeStatus;
 import com.ericsson.bss.cassandra.ecchronos.utils.exceptions.EcChronosException;
-import org.jolokia.client.jmxadapter.JolokiaJmxConnectionProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.management.remote.JMXConnector;
-import javax.management.remote.JMXConnectorFactory;
-import javax.management.remote.JMXServiceURL;
-import javax.rmi.ssl.SslRMIClientSocketFactory;
-
 import java.io.IOException;
 import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
-import java.util.HashMap;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
-import java.util.concurrent.ExecutionException;
 import java.util.function.Supplier;
 
-public class DistributedJmxBuilder //NOPMD Possible God Class
+public class DistributedJmxBuilder
 {
     private static final Logger LOG = LoggerFactory.getLogger(DistributedJmxBuilder.class);
-    private static final String JMX_FORMAT_URL = "service:jmx:rmi:///jndi/rmi://%s:%d/jmxrmi";
-    private static final String JMX_JOLOKIA_FORMAT_URL = "service:jmx:%s://%s:%d/jolokia/";
-    private static final Integer JMX_JOLOKIA_CONNECTION_TIMEOUT = 20;
     private static final int DEFAULT_JOLOKIA_PORT = 8778;
-    private static final int DEFAULT_PORT = 7199;
     private static final int MAX_PARALLEL_CONNECTIONS = 10;
-    public static final String NO_BROADCAST_ADDRESS = "0.0.0.0"; //NOPMD AvoidUsingHardCodedIP
+    private static final int CONNECTION_TIMEOUT_EXTRA_SECONDS = 10;
+
+    public static final String ECCHRONOS_JOLOKIA_SSL_ENABLED_PROPERTY = "ecchronos.jolokia.ssl.enabled";
     public static final String JOLOKIA_CA_CERTIFICATE_PROPERTY = "jolokia.caCertificate";
     public static final String JOLOKIA_CLIENT_CERTIFICATE_PROPERTY = "jolokia.clientCertificate";
     public static final String JOLOKIA_CLIENT_KEY_CERTIFICATE_PROPERTY = "jolokia.clientKey";
     public static final String JOLOKIA_CLIENT_KEY_ALGORITHM_CERTIFICATE_PROPERTY = "jolokia.clientKeyAlgorithm";
     public static final String JDK_DISABLE_HOSTNAME_VERIFICATION_PROPERTY = "jdk.internal.httpclient.disableHostnameVerification";
-    public static final String ECCHRONOS_JOLOKIA_SSL_ENABLED_PROPERTY = "ecchronos.jolokia.ssl.enabled";
 
     private CqlSession mySession;
     private DistributedNativeConnectionProvider myNativeConnectionProvider;
@@ -178,9 +161,7 @@ public class DistributedJmxBuilder //NOPMD Possible God Class
     public final DistributedJmxConnectionProvider build() throws IOException
     {
         createConnections();
-        return new DistributedJmxConnectionProviderImpl(
-                this
-        );
+        return new DistributedJmxConnectionProviderImpl(this);
     }
 
     private void createConnections() throws IOException
@@ -211,7 +192,9 @@ public class DistributedJmxBuilder //NOPMD Possible God Class
             pool.shutdown();
             try
             {
-                if (!pool.awaitTermination(JMX_JOLOKIA_CONNECTION_TIMEOUT + MAX_PARALLEL_CONNECTIONS, TimeUnit.SECONDS))
+                if (!pool.awaitTermination(
+                        JolokiaJmxConnectionFactory.CONNECTION_TIMEOUT_SECONDS + CONNECTION_TIMEOUT_EXTRA_SECONDS,
+                        TimeUnit.SECONDS))
                 {
                     pool.shutdownNow();
                 }
@@ -228,88 +211,34 @@ public class DistributedJmxBuilder //NOPMD Possible God Class
      * Creates a JMX connection to the host.
      * @param node the node to connect with.
      */
-    public void reconnect(final Node node) throws EcChronosException //NOPMD CyclomaticComplexity
+    public void reconnect(final Node node) throws EcChronosException
     {
         try
         {
-            String host = node.getBroadcastRpcAddress().get().getAddress().getHostAddress();
-            if (NO_BROADCAST_ADDRESS.equals(host))
-            {
-                host = node.getListenAddress().get().getHostString();
-            }
-            if (myIpTranslator.isActive())
-            {
-                host = myIpTranslator.getInternalIp(host);
-            }
-            JMXServiceURL jmxUrl;
-            Integer port;
+            JmxHostResolver hostResolver = new JmxHostResolver(myIpTranslator, myReverseDNSResolution);
+            String host = hostResolver.resolve(node);
+            Map<String, Object> env = JmxEnvironmentFactory.create(myCredentialsSupplier, myTLSSupplier, isJolokiaEnabled);
+            int port;
             JMXConnector jmxConnector;
-
-            if (myReverseDNSResolution)
-            {
-                host = ReverseDNS.fromHostString(host);
-            }
-            if (host.contains(":") && !host.startsWith("[") && !host.endsWith("]"))
-            {
-                // Use square brackets to surround IPv6 addresses
-                host = "[" + host + "]";
-            }
 
             if (isJolokiaEnabled)
             {
                 port = myJolokiaPort;
-                String protocol = String.valueOf(true).equals(getTLSConfig().get(ECCHRONOS_JOLOKIA_SSL_ENABLED_PROPERTY)) ? "jolokia+https" : "jolokia";
-                jmxUrl = new JMXServiceURL(String.format(JMX_JOLOKIA_FORMAT_URL, protocol, host, port));
-                JolokiaJmxConnectionProvider jolokiaJmxConnectionProvider = new JolokiaJmxConnectionProvider();
-                LOG.info("Creating Jolokia JMXConnection with host: {} and port: {}", host, port);
-                jmxConnector = jolokiaJmxConnectionProvider.newJMXConnector(jmxUrl, createJMXEnv());
-
-                ExecutorService exec = Executors.newSingleThreadExecutor();
-                try
-                {
-                    Future<?> future = exec.submit(() ->
-                    {
-                        try
-                        {
-                            jmxConnector.connect();
-                        }
-                        catch (IOException e)
-                        {
-                            LOG.error("Jolokia connection IOException during connect()", e);
-                            throw new IllegalStateException("Failed to connect to Jolokia", e);
-                        }
-                    });
-                    future.get(JMX_JOLOKIA_CONNECTION_TIMEOUT, TimeUnit.SECONDS);
-                }
-                catch (TimeoutException | InterruptedException | ExecutionException e)
-                {
-                    LOG.error("Jolokia connection failed with timeout or execution error", e);
-                    closeQuietly(jmxConnector);
-                    throw new IOException("Jolokia connection failed", e);
-                }
-                finally
-                {
-                    exec.shutdownNow();
-                }
-               // Verify MBeanServerConnection is available
-                if (jmxConnector.getMBeanServerConnection() == null)
-                {
-                    closeQuietly(jmxConnector);
-                    throw new IOException("MBeanServerConnection is null after Jolokia connection");
-                }
+                boolean sslEnabled = String.valueOf(true).equals(
+                        myTLSSupplier != null ? myTLSSupplier.get().get(ECCHRONOS_JOLOKIA_SSL_ENABLED_PROPERTY) : null);
+                jmxConnector = new JolokiaJmxConnectionFactory(sslEnabled).connect(host, port, env);
             }
             else
             {
-                port = getJMXPort(node);
-                jmxUrl = new JMXServiceURL(String.format(JMX_FORMAT_URL, host, port));
-                LOG.info("Starting to instantiate JMXService with host: {} and port: {}", host, port);
-                jmxConnector = JMXConnectorFactory.connect(jmxUrl, createJMXEnv());
+                port = JmxPortDiscovery.getPort(mySession, node);
+                jmxConnector = new RmiJmxConnectionFactory().connect(host, port, env);
             }
 
-            LOG.debug("Connecting JMX through {}, credentials: {}, tls: {}", jmxUrl, isAuthEnabled(), isTLSEnabled());
+            LOG.debug("Connecting JMX through {}:{}, credentials: {}, tls: {}",
+                    host, port, myCredentialsSupplier != null, myTLSSupplier != null);
             if (isConnected(jmxConnector))
             {
-                LOG.info("Connected JMX for {}", jmxUrl);
+                LOG.info("Connected JMX for {}:{}", host, port);
                 myEccNodesSync.updateNodeStatus(NodeStatus.AVAILABLE, node.getDatacenter(), node.getHostId());
                 JMXConnector oldConnector = myJMXConnections.put(Objects.requireNonNull(node.getHostId()), jmxConnector);
                 closeQuietly(oldConnector);
@@ -320,128 +249,10 @@ public class DistributedJmxBuilder //NOPMD Possible God Class
                 myEccNodesSync.updateNodeStatus(NodeStatus.UNAVAILABLE, node.getDatacenter(), node.getHostId());
             }
         }
-        catch
-        (
-                AllNodesFailedException | QueryExecutionException | IOException | SecurityException e)
+        catch (IOException | SecurityException e)
         {
             LOG.error("Failed to create JMX connection with node {} because of", node.getHostId(), e);
             myEccNodesSync.updateNodeStatus(NodeStatus.UNAVAILABLE, node.getDatacenter(), node.getHostId());
-        }
-    }
-
-
-    private Map<String, Object> createJMXEnv()
-    {
-        Map<String, Object> env = new HashMap<>();
-        String[] credentials = getCredentialsConfig();
-        Map<String, String> tls = getTLSConfig();
-        if (credentials != null)
-        {
-            env.put(JMXConnector.CREDENTIALS, credentials);
-        }
-        if (isJolokiaEnabled && String.valueOf(true).equals(tls.get(ECCHRONOS_JOLOKIA_SSL_ENABLED_PROPERTY)))
-        {
-            LOG.info("Setting Jolokia client with PEM certificates");
-            String caCert = tls.get(JOLOKIA_CA_CERTIFICATE_PROPERTY);
-            String clientCert = tls.get(JOLOKIA_CLIENT_CERTIFICATE_PROPERTY);
-            String clientKey = tls.get(JOLOKIA_CLIENT_KEY_CERTIFICATE_PROPERTY);
-            String keyAlgorithm = tls.get(JOLOKIA_CLIENT_KEY_ALGORITHM_CERTIFICATE_PROPERTY);
-            String disableHostnameVerification = tls.get(JDK_DISABLE_HOSTNAME_VERIFICATION_PROPERTY);
-
-            setSystemPropertyIfNotNull(JOLOKIA_CA_CERTIFICATE_PROPERTY, caCert);
-            setSystemPropertyIfNotNull(JOLOKIA_CLIENT_CERTIFICATE_PROPERTY, clientCert);
-            setSystemPropertyIfNotNull(JOLOKIA_CLIENT_KEY_CERTIFICATE_PROPERTY, clientKey);
-            setSystemPropertyIfNotNull(JOLOKIA_CLIENT_KEY_ALGORITHM_CERTIFICATE_PROPERTY, keyAlgorithm);
-            setSystemPropertyIfNotNull(JDK_DISABLE_HOSTNAME_VERIFICATION_PROPERTY, disableHostnameVerification);
-        }
-        else if (!tls.isEmpty())
-        {
-            for (Map.Entry<String, String> configEntry : tls.entrySet())
-            {
-                String key = configEntry.getKey();
-                String value = configEntry.getValue();
-
-                if (value != null && !value.isEmpty())
-                {
-                    System.setProperty(key, value);
-                }
-                else
-                {
-                    System.clearProperty(key);
-                }
-            }
-            env.put("com.sun.jndi.rmi.factory.socket", new SslRMIClientSocketFactory());
-        }
-        return env;
-    }
-
-    private void setSystemPropertyIfNotNull(final String key, final String value)
-    {
-        if (value != null)
-        {
-            System.setProperty(key, value);
-        }
-    }
-
-    private String[] getCredentialsConfig()
-    {
-        if (myCredentialsSupplier == null)
-        {
-            return null;
-        }
-        return myCredentialsSupplier.get();
-    }
-
-    private Map<String, String> getTLSConfig()
-    {
-        if (myTLSSupplier == null)
-        {
-            return new HashMap<>();
-        }
-        return myTLSSupplier.get();
-    }
-
-    private boolean isAuthEnabled()
-    {
-        return getCredentialsConfig() != null;
-    }
-
-    private boolean isTLSEnabled()
-    {
-        return !getTLSConfig().isEmpty();
-    }
-
-
-    private Integer getJMXPort(final Node node)
-    {
-        try
-        {
-            SimpleStatement simpleStatement = SimpleStatement
-                    .builder("SELECT value FROM system_views.system_properties WHERE name = 'cassandra.jmx.remote.port';")
-                    .setNode(node)
-                    .build();
-            Row row = mySession.execute(simpleStatement).one();
-            if ((row == null) || (row.getString("value") == null))
-            {
-                simpleStatement = SimpleStatement
-                        .builder("SELECT value FROM system_views.system_properties WHERE name = 'cassandra.jmx.local.port';")
-                        .setNode(node)
-                        .build();
-                row = mySession.execute(simpleStatement).one();
-
-            }
-            if ((row != null) && (row.getString("value") != null))
-            {
-                return Integer.parseInt(Objects.requireNonNull(row.getString("value")));
-            }
-            else
-            {
-                return DEFAULT_PORT;
-            }
-        }
-        catch (AllNodesFailedException e)
-        {
-            return DEFAULT_PORT;
         }
     }
 
@@ -450,14 +261,14 @@ public class DistributedJmxBuilder //NOPMD Possible God Class
         try
         {
             jmxConnector.getConnectionId();
+            return true;
         }
         catch (IOException e)
         {
             return false;
         }
-
-        return true;
     }
+
     private static void closeQuietly(final JMXConnector connector)
     {
         if (connector != null)

--- a/connection.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/connection/impl/builders/JmxConnectionFactory.java
+++ b/connection.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/connection/impl/builders/JmxConnectionFactory.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2026 Telefonaktiebolaget LM Ericsson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ericsson.bss.cassandra.ecchronos.connection.impl.builders;
+
+import javax.management.remote.JMXConnector;
+import java.io.IOException;
+import java.util.Map;
+
+public interface JmxConnectionFactory
+{
+    /**
+     * Create a JMX connection to the given host and port.
+     *
+     * @param host the resolved host address.
+     * @param port the JMX port.
+     * @param env  the JMX environment (credentials, TLS settings).
+     * @return a connected JMXConnector.
+     * @throws IOException if connection fails.
+     */
+    JMXConnector connect(String host, int port, Map<String, Object> env) throws IOException;
+}

--- a/connection.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/connection/impl/builders/JmxEnvironmentFactory.java
+++ b/connection.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/connection/impl/builders/JmxEnvironmentFactory.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2026 Telefonaktiebolaget LM Ericsson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ericsson.bss.cassandra.ecchronos.connection.impl.builders;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.management.remote.JMXConnector;
+import javax.rmi.ssl.SslRMIClientSocketFactory;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Supplier;
+
+import static com.ericsson.bss.cassandra.ecchronos.connection.impl.builders.DistributedJmxBuilder.ECCHRONOS_JOLOKIA_SSL_ENABLED_PROPERTY;
+import static com.ericsson.bss.cassandra.ecchronos.connection.impl.builders.DistributedJmxBuilder.JOLOKIA_CA_CERTIFICATE_PROPERTY;
+import static com.ericsson.bss.cassandra.ecchronos.connection.impl.builders.DistributedJmxBuilder.JOLOKIA_CLIENT_CERTIFICATE_PROPERTY;
+import static com.ericsson.bss.cassandra.ecchronos.connection.impl.builders.DistributedJmxBuilder.JOLOKIA_CLIENT_KEY_CERTIFICATE_PROPERTY;
+import static com.ericsson.bss.cassandra.ecchronos.connection.impl.builders.DistributedJmxBuilder.JOLOKIA_CLIENT_KEY_ALGORITHM_CERTIFICATE_PROPERTY;
+import static com.ericsson.bss.cassandra.ecchronos.connection.impl.builders.DistributedJmxBuilder.JDK_DISABLE_HOSTNAME_VERIFICATION_PROPERTY;
+
+public final class JmxEnvironmentFactory
+{
+    private static final Logger LOG = LoggerFactory.getLogger(JmxEnvironmentFactory.class);
+
+    private JmxEnvironmentFactory()
+    {
+    }
+
+    /**
+     * Create the JMX environment map with credentials and TLS configuration.
+     */
+    public static Map<String, Object> create(final Supplier<String[]> credentialsSupplier,
+                                             final Supplier<Map<String, String>> tlsSupplier,
+                                             final boolean jolokiaEnabled)
+    {
+        Map<String, Object> env = new HashMap<>();
+        String[] credentials = credentialsSupplier != null ? credentialsSupplier.get() : null;
+        Map<String, String> tls = tlsSupplier != null ? tlsSupplier.get() : new HashMap<>();
+
+        if (credentials != null)
+        {
+            env.put(JMXConnector.CREDENTIALS, credentials);
+        }
+
+        if (jolokiaEnabled && String.valueOf(true).equals(tls.get(ECCHRONOS_JOLOKIA_SSL_ENABLED_PROPERTY)))
+        {
+            configureJolokiaSsl(tls);
+        }
+        else if (!tls.isEmpty())
+        {
+            configureRmiTls(env, tls);
+        }
+        return env;
+    }
+
+    private static void configureJolokiaSsl(final Map<String, String> tls)
+    {
+        LOG.info("Setting Jolokia client with PEM certificates");
+        setSystemPropertyIfNotNull(JOLOKIA_CA_CERTIFICATE_PROPERTY, tls.get(JOLOKIA_CA_CERTIFICATE_PROPERTY));
+        setSystemPropertyIfNotNull(JOLOKIA_CLIENT_CERTIFICATE_PROPERTY, tls.get(JOLOKIA_CLIENT_CERTIFICATE_PROPERTY));
+        setSystemPropertyIfNotNull(JOLOKIA_CLIENT_KEY_CERTIFICATE_PROPERTY, tls.get(JOLOKIA_CLIENT_KEY_CERTIFICATE_PROPERTY));
+        setSystemPropertyIfNotNull(JOLOKIA_CLIENT_KEY_ALGORITHM_CERTIFICATE_PROPERTY, tls.get(JOLOKIA_CLIENT_KEY_ALGORITHM_CERTIFICATE_PROPERTY));
+        setSystemPropertyIfNotNull(JDK_DISABLE_HOSTNAME_VERIFICATION_PROPERTY, tls.get(JDK_DISABLE_HOSTNAME_VERIFICATION_PROPERTY));
+    }
+
+    private static void configureRmiTls(final Map<String, Object> env, final Map<String, String> tls)
+    {
+        for (Map.Entry<String, String> configEntry : tls.entrySet())
+        {
+            String key = configEntry.getKey();
+            String value = configEntry.getValue();
+            if (value != null && !value.isEmpty())
+            {
+                System.setProperty(key, value);
+            }
+            else
+            {
+                System.clearProperty(key);
+            }
+        }
+        env.put("com.sun.jndi.rmi.factory.socket", new SslRMIClientSocketFactory());
+    }
+
+    private static void setSystemPropertyIfNotNull(final String key, final String value)
+    {
+        if (value != null)
+        {
+            System.setProperty(key, value);
+        }
+    }
+}

--- a/connection.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/connection/impl/builders/JmxHostResolver.java
+++ b/connection.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/connection/impl/builders/JmxHostResolver.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2026 Telefonaktiebolaget LM Ericsson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ericsson.bss.cassandra.ecchronos.connection.impl.builders;
+
+import com.datastax.oss.driver.api.core.metadata.Node;
+import com.ericsson.bss.cassandra.ecchronos.data.iptranslator.IpTranslator;
+import com.ericsson.bss.cassandra.ecchronos.utils.dns.ReverseDNS;
+
+import java.net.UnknownHostException;
+
+public final class JmxHostResolver
+{
+    public static final String NO_BROADCAST_ADDRESS = "0.0.0.0"; //NOPMD AvoidUsingHardCodedIP
+
+    private final IpTranslator myIpTranslator;
+    private final boolean myReverseDNSResolution;
+
+    public JmxHostResolver(final IpTranslator ipTranslator, final boolean reverseDNSResolution)
+    {
+        myIpTranslator = ipTranslator;
+        myReverseDNSResolution = reverseDNSResolution;
+    }
+
+    /**
+     * Resolve the JMX host address for a node, applying IP translation, reverse DNS, and IPv6 formatting.
+     */
+    public String resolve(final Node node) throws UnknownHostException
+    {
+        String host = node.getBroadcastRpcAddress().get().getAddress().getHostAddress();
+        if (NO_BROADCAST_ADDRESS.equals(host))
+        {
+            host = node.getListenAddress().get().getHostString();
+        }
+        if (myIpTranslator.isActive())
+        {
+            host = myIpTranslator.getInternalIp(host);
+        }
+        if (myReverseDNSResolution)
+        {
+            host = ReverseDNS.fromHostString(host);
+        }
+        if (host.contains(":") && !host.startsWith("[") && !host.endsWith("]"))
+        {
+            host = "[" + host + "]";
+        }
+        return host;
+    }
+}

--- a/connection.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/connection/impl/builders/JmxPortDiscovery.java
+++ b/connection.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/connection/impl/builders/JmxPortDiscovery.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2026 Telefonaktiebolaget LM Ericsson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ericsson.bss.cassandra.ecchronos.connection.impl.builders;
+
+import com.datastax.oss.driver.api.core.AllNodesFailedException;
+import com.datastax.oss.driver.api.core.CqlSession;
+import com.datastax.oss.driver.api.core.cql.Row;
+import com.datastax.oss.driver.api.core.cql.SimpleStatement;
+import com.datastax.oss.driver.api.core.metadata.Node;
+
+import java.util.Objects;
+
+public final class JmxPortDiscovery
+{
+    private static final int DEFAULT_PORT = 7199;
+
+    private JmxPortDiscovery()
+    {
+    }
+
+    /**
+     * Discover the JMX port for a node by querying system_views.system_properties.
+     * Falls back to the default port (7199) if the query fails.
+     */
+    public static int getPort(final CqlSession session, final Node node)
+    {
+        try
+        {
+            SimpleStatement stmt = SimpleStatement
+                    .builder("SELECT value FROM system_views.system_properties WHERE name = 'cassandra.jmx.remote.port';")
+                    .setNode(node)
+                    .build();
+            Row row = session.execute(stmt).one();
+            if (row == null || row.getString("value") == null)
+            {
+                stmt = SimpleStatement
+                        .builder("SELECT value FROM system_views.system_properties WHERE name = 'cassandra.jmx.local.port';")
+                        .setNode(node)
+                        .build();
+                row = session.execute(stmt).one();
+            }
+            if (row != null && row.getString("value") != null)
+            {
+                return Integer.parseInt(Objects.requireNonNull(row.getString("value")));
+            }
+            return DEFAULT_PORT;
+        }
+        catch (AllNodesFailedException e)
+        {
+            return DEFAULT_PORT;
+        }
+    }
+}

--- a/connection.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/connection/impl/builders/JolokiaJmxConnectionFactory.java
+++ b/connection.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/connection/impl/builders/JolokiaJmxConnectionFactory.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2026 Telefonaktiebolaget LM Ericsson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ericsson.bss.cassandra.ecchronos.connection.impl.builders;
+
+import org.jolokia.client.jmxadapter.JolokiaJmxConnectionProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.management.remote.JMXConnector;
+import javax.management.remote.JMXServiceURL;
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+public final class JolokiaJmxConnectionFactory implements JmxConnectionFactory
+{
+    private static final Logger LOG = LoggerFactory.getLogger(JolokiaJmxConnectionFactory.class);
+    private static final String JMX_JOLOKIA_FORMAT_URL = "service:jmx:%s://%s:%d/jolokia/";
+    static final int CONNECTION_TIMEOUT_SECONDS = 20;
+
+    private final boolean mySslEnabled;
+
+    public JolokiaJmxConnectionFactory(final boolean sslEnabled)
+    {
+        mySslEnabled = sslEnabled;
+    }
+
+    @Override
+    public JMXConnector connect(final String host, final int port, final Map<String, Object> env) throws IOException
+    {
+        String protocol = mySslEnabled ? "jolokia+https" : "jolokia";
+        JMXServiceURL jmxUrl = new JMXServiceURL(String.format(JMX_JOLOKIA_FORMAT_URL, protocol, host, port));
+        LOG.info("Creating Jolokia JMXConnection with host: {} and port: {}", host, port);
+
+        JolokiaJmxConnectionProvider provider = new JolokiaJmxConnectionProvider();
+        JMXConnector jmxConnector = provider.newJMXConnector(jmxUrl, env);
+
+        ExecutorService exec = Executors.newSingleThreadExecutor();
+        try
+        {
+            Future<?> future = exec.submit(() ->
+            {
+                try
+                {
+                    jmxConnector.connect();
+                }
+                catch (IOException e)
+                {
+                    LOG.error("Jolokia connection IOException during connect()", e);
+                    throw new IllegalStateException("Failed to connect to Jolokia", e);
+                }
+            });
+            future.get(CONNECTION_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        }
+        catch (TimeoutException | InterruptedException | ExecutionException e)
+        {
+            LOG.error("Jolokia connection failed with timeout or execution error", e);
+            closeQuietly(jmxConnector);
+            throw new IOException("Jolokia connection failed", e);
+        }
+        finally
+        {
+            exec.shutdownNow();
+        }
+
+        if (jmxConnector.getMBeanServerConnection() == null)
+        {
+            closeQuietly(jmxConnector);
+            throw new IOException("MBeanServerConnection is null after Jolokia connection");
+        }
+
+        return jmxConnector;
+    }
+
+    private static void closeQuietly(final JMXConnector connector)
+    {
+        try
+        {
+            connector.close();
+        }
+        catch (IOException | NullPointerException e)
+        {
+            LOG.debug("Failed to close JMX connector", e);
+        }
+    }
+}

--- a/connection.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/connection/impl/builders/RmiJmxConnectionFactory.java
+++ b/connection.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/connection/impl/builders/RmiJmxConnectionFactory.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2026 Telefonaktiebolaget LM Ericsson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ericsson.bss.cassandra.ecchronos.connection.impl.builders;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.management.remote.JMXConnector;
+import javax.management.remote.JMXConnectorFactory;
+import javax.management.remote.JMXServiceURL;
+import java.io.IOException;
+import java.util.Map;
+
+public final class RmiJmxConnectionFactory implements JmxConnectionFactory
+{
+    private static final Logger LOG = LoggerFactory.getLogger(RmiJmxConnectionFactory.class);
+    private static final String JMX_FORMAT_URL = "service:jmx:rmi:///jndi/rmi://%s:%d/jmxrmi";
+
+    @Override
+    public JMXConnector connect(final String host, final int port, final Map<String, Object> env) throws IOException
+    {
+        JMXServiceURL jmxUrl = new JMXServiceURL(String.format(JMX_FORMAT_URL, host, port));
+        LOG.info("Starting to instantiate JMXService with host: {} and port: {}", host, port);
+        return JMXConnectorFactory.connect(jmxUrl, env);
+    }
+}

--- a/connection.impl/src/test/java/com/ericsson/bss/cassandra/ecchronos/connection/impl/builders/TestJmxEnvironmentFactory.java
+++ b/connection.impl/src/test/java/com/ericsson/bss/cassandra/ecchronos/connection/impl/builders/TestJmxEnvironmentFactory.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2026 Telefonaktiebolaget LM Ericsson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ericsson.bss.cassandra.ecchronos.connection.impl.builders;
+
+import org.junit.After;
+import org.junit.Test;
+
+import javax.management.remote.JMXConnector;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestJmxEnvironmentFactory
+{
+    @After
+    public void clearSystemProperties()
+    {
+        System.clearProperty(DistributedJmxBuilder.JOLOKIA_CA_CERTIFICATE_PROPERTY);
+        System.clearProperty(DistributedJmxBuilder.JOLOKIA_CLIENT_CERTIFICATE_PROPERTY);
+        System.clearProperty(DistributedJmxBuilder.JOLOKIA_CLIENT_KEY_CERTIFICATE_PROPERTY);
+        System.clearProperty(DistributedJmxBuilder.JOLOKIA_CLIENT_KEY_ALGORITHM_CERTIFICATE_PROPERTY);
+        System.clearProperty(DistributedJmxBuilder.JDK_DISABLE_HOSTNAME_VERIFICATION_PROPERTY);
+    }
+
+    @Test
+    public void testNoCredentialsNoTls()
+    {
+        Map<String, Object> env = JmxEnvironmentFactory.create(null, null, false);
+        assertThat(env).isEmpty();
+    }
+
+    @Test
+    public void testCredentialsAdded()
+    {
+        String[] creds = {"user", "pass"};
+        Map<String, Object> env = JmxEnvironmentFactory.create(() -> creds, null, false);
+        assertThat(env).containsKey(JMXConnector.CREDENTIALS);
+        assertThat((String[]) env.get(JMXConnector.CREDENTIALS)).containsExactly("user", "pass");
+    }
+
+    @Test
+    public void testJolokiaSslSetsSystemProperties()
+    {
+        Map<String, String> tls = new HashMap<>();
+        tls.put(DistributedJmxBuilder.ECCHRONOS_JOLOKIA_SSL_ENABLED_PROPERTY, "true");
+        tls.put(DistributedJmxBuilder.JOLOKIA_CA_CERTIFICATE_PROPERTY, "/ca.crt");
+        tls.put(DistributedJmxBuilder.JOLOKIA_CLIENT_CERTIFICATE_PROPERTY, "/client.crt");
+        tls.put(DistributedJmxBuilder.JOLOKIA_CLIENT_KEY_CERTIFICATE_PROPERTY, "/client.key");
+        tls.put(DistributedJmxBuilder.JOLOKIA_CLIENT_KEY_ALGORITHM_CERTIFICATE_PROPERTY, "RSA");
+        tls.put(DistributedJmxBuilder.JDK_DISABLE_HOSTNAME_VERIFICATION_PROPERTY, "true");
+
+        JmxEnvironmentFactory.create(null, () -> tls, true);
+
+        assertThat(System.getProperty(DistributedJmxBuilder.JOLOKIA_CA_CERTIFICATE_PROPERTY)).isEqualTo("/ca.crt");
+        assertThat(System.getProperty(DistributedJmxBuilder.JOLOKIA_CLIENT_CERTIFICATE_PROPERTY)).isEqualTo("/client.crt");
+        assertThat(System.getProperty(DistributedJmxBuilder.JOLOKIA_CLIENT_KEY_CERTIFICATE_PROPERTY)).isEqualTo("/client.key");
+    }
+
+    @Test
+    public void testRmiTlsSetsSocketFactory()
+    {
+        Map<String, String> tls = new HashMap<>();
+        tls.put("javax.net.ssl.keyStore", "/keystore.jks");
+        tls.put("javax.net.ssl.keyStorePassword", "secret");
+
+        Map<String, Object> env = JmxEnvironmentFactory.create(null, () -> tls, false);
+
+        assertThat(env).containsKey("com.sun.jndi.rmi.factory.socket");
+        assertThat(System.getProperty("javax.net.ssl.keyStore")).isEqualTo("/keystore.jks");
+
+        // Cleanup
+        System.clearProperty("javax.net.ssl.keyStore");
+        System.clearProperty("javax.net.ssl.keyStorePassword");
+    }
+
+    @Test
+    public void testNullCredentialsSupplierReturnsNoCredentials()
+    {
+        Map<String, String> tls = new HashMap<>();
+        Map<String, Object> env = JmxEnvironmentFactory.create(null, () -> tls, false);
+        assertThat(env).doesNotContainKey(JMXConnector.CREDENTIALS);
+    }
+}

--- a/connection.impl/src/test/java/com/ericsson/bss/cassandra/ecchronos/connection/impl/builders/TestJmxHostResolver.java
+++ b/connection.impl/src/test/java/com/ericsson/bss/cassandra/ecchronos/connection/impl/builders/TestJmxHostResolver.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2026 Telefonaktiebolaget LM Ericsson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ericsson.bss.cassandra.ecchronos.connection.impl.builders;
+
+import com.datastax.oss.driver.api.core.metadata.Node;
+import com.ericsson.bss.cassandra.ecchronos.data.iptranslator.IpTranslator;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class TestJmxHostResolver
+{
+    @Mock
+    private Node mockNode;
+
+    @Mock
+    private IpTranslator mockIpTranslator;
+
+    @Test
+    public void testResolvesFromBroadcastRpcAddress() throws Exception
+    {
+        InetSocketAddress address = new InetSocketAddress(InetAddress.getByName("10.0.0.1"), 9042);
+        when(mockNode.getBroadcastRpcAddress()).thenReturn(Optional.of(address));
+        when(mockIpTranslator.isActive()).thenReturn(false);
+
+        JmxHostResolver resolver = new JmxHostResolver(mockIpTranslator, false);
+        assertThat(resolver.resolve(mockNode)).isEqualTo("10.0.0.1");
+    }
+
+    @Test
+    public void testFallsBackToListenAddressWhenBroadcastIsZero() throws Exception
+    {
+        InetSocketAddress broadcastAddr = new InetSocketAddress(InetAddress.getByName("0.0.0.0"), 9042);
+        InetSocketAddress listenAddr = new InetSocketAddress(InetAddress.getByName("192.168.1.5"), 7000);
+        when(mockNode.getBroadcastRpcAddress()).thenReturn(Optional.of(broadcastAddr));
+        when(mockNode.getListenAddress()).thenReturn(Optional.of(listenAddr));
+        when(mockIpTranslator.isActive()).thenReturn(false);
+
+        JmxHostResolver resolver = new JmxHostResolver(mockIpTranslator, false);
+        assertThat(resolver.resolve(mockNode)).isEqualTo("192.168.1.5");
+    }
+
+    @Test
+    public void testAppliesIpTranslation() throws Exception
+    {
+        InetSocketAddress address = new InetSocketAddress(InetAddress.getByName("10.0.0.1"), 9042);
+        when(mockNode.getBroadcastRpcAddress()).thenReturn(Optional.of(address));
+        when(mockIpTranslator.isActive()).thenReturn(true);
+        when(mockIpTranslator.getInternalIp("10.0.0.1")).thenReturn("172.16.0.1");
+
+        JmxHostResolver resolver = new JmxHostResolver(mockIpTranslator, false);
+        assertThat(resolver.resolve(mockNode)).isEqualTo("172.16.0.1");
+    }
+
+    @Test
+    public void testWrapsIpv6InBrackets() throws Exception
+    {
+        InetSocketAddress address = new InetSocketAddress(InetAddress.getByName("::1"), 9042);
+        when(mockNode.getBroadcastRpcAddress()).thenReturn(Optional.of(address));
+        when(mockIpTranslator.isActive()).thenReturn(false);
+
+        JmxHostResolver resolver = new JmxHostResolver(mockIpTranslator, false);
+        String resolved = resolver.resolve(mockNode);
+        assertThat(resolved).startsWith("[").endsWith("]");
+    }
+
+    @Test
+    public void testDoesNotDoubleWrapIpv6() throws Exception
+    {
+        InetSocketAddress address = new InetSocketAddress(InetAddress.getByName("::1"), 9042);
+        when(mockNode.getBroadcastRpcAddress()).thenReturn(Optional.of(address));
+        when(mockIpTranslator.isActive()).thenReturn(false);
+
+        JmxHostResolver resolver = new JmxHostResolver(mockIpTranslator, false);
+        String resolved = resolver.resolve(mockNode);
+        // Should only have one set of brackets
+        assertThat(resolved.chars().filter(c -> c == '[').count()).isEqualTo(1);
+    }
+}


### PR DESCRIPTION
Extract distinct responsibilities into focused classes:
- JmxHostResolver: IP translation, reverse DNS, IPv6 formatting
- JmxConnectionFactory: interface for JMX connection creation
- RmiJmxConnectionFactory: traditional RMI JMX connection
- JolokiaJmxConnectionFactory: Jolokia connection with timeout
- JmxEnvironmentFactory: credentials and TLS env setup
- JmxPortDiscovery: CQL-based JMX port lookup

DistributedJmxBuilder is now a thin orchestrator. No public API changes. Add unit tests for JmxHostResolver and JmxEnvironmentFactory.