### PR TITLE
Refactor DistributedNativeBuilder to resolve GodClass violation

### DIFF
--- a/connection.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/connection/impl/builders/CqlSessionFactory.java
+++ b/connection.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/connection/impl/builders/CqlSessionFactory.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2026 Telefonaktiebolaget LM Ericsson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ericsson.bss.cassandra.ecchronos.connection.impl.builders;
+
+import com.datastax.oss.driver.api.core.CqlSession;
+import com.datastax.oss.driver.api.core.CqlSessionBuilder;
+import com.datastax.oss.driver.api.core.auth.AuthProvider;
+import com.datastax.oss.driver.api.core.config.DefaultDriverOption;
+import com.datastax.oss.driver.api.core.config.DriverConfigLoader;
+import com.datastax.oss.driver.api.core.config.ProgrammaticDriverConfigLoaderBuilder;
+import com.datastax.oss.driver.api.core.metadata.NodeStateListener;
+import com.datastax.oss.driver.api.core.metadata.schema.SchemaChangeListener;
+import com.datastax.oss.driver.api.core.metrics.DefaultSessionMetric;
+import com.datastax.oss.driver.api.core.ssl.SslEngineFactory;
+import com.google.common.collect.ImmutableList;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+
+public final class CqlSessionFactory
+{
+    private static final Logger LOG = LoggerFactory.getLogger(CqlSessionFactory.class);
+
+    private static final List<String> SCHEMA_REFRESHED_KEYSPACES = ImmutableList.of("/.*/", "!system",
+            "!system_distributed", "!system_schema", "!system_traces", "!system_views", "!system_virtual_schema");
+
+    private static final List<String> SESSION_METRICS = Arrays.asList(DefaultSessionMetric.BYTES_RECEIVED.getPath(),
+            DefaultSessionMetric.BYTES_SENT.getPath(), DefaultSessionMetric.CONNECTED_NODES.getPath(),
+            DefaultSessionMetric.CQL_REQUESTS.getPath(), DefaultSessionMetric.CQL_CLIENT_TIMEOUTS.getPath(),
+            DefaultSessionMetric.CQL_PREPARED_CACHE_SIZE.getPath(), DefaultSessionMetric.THROTTLING_DELAY.getPath(),
+            DefaultSessionMetric.THROTTLING_QUEUE_SIZE.getPath(), DefaultSessionMetric.THROTTLING_ERRORS.getPath());
+
+    private CqlSessionFactory()
+    {
+    }
+
+    /**
+     * Create a CqlSession with the given configuration.
+     */
+    public static CqlSession create(final List<InetSocketAddress> contactPoints,
+                                    final String localDatacenter,
+                                    final AuthProvider authProvider,
+                                    final SslEngineFactory sslEngineFactory,
+                                    final SchemaChangeListener schemaChangeListener,
+                                    final Set<NodeStateListener> nodeStateListeners,
+                                    final boolean metricsEnabled)
+    {
+        CqlSessionBuilder sessionBuilder = CqlSession.builder()
+                .addContactPoints(resolveIfNeeded(contactPoints))
+                .withLocalDatacenter(localDatacenter)
+                .withAuthProvider(authProvider)
+                .withSslEngineFactory(sslEngineFactory)
+                .withSchemaChangeListener(schemaChangeListener);
+
+        for (NodeStateListener listener : nodeStateListeners)
+        {
+            sessionBuilder = sessionBuilder.addNodeStateListener(listener);
+        }
+
+        DriverConfigLoader configLoader = buildDriverConfig(metricsEnabled).build();
+        LOG.debug("Driver configuration: {}", configLoader.getInitialConfig().getDefaultProfile().entrySet());
+        sessionBuilder.withConfigLoader(configLoader);
+
+        return sessionBuilder.build();
+    }
+
+    private static ProgrammaticDriverConfigLoaderBuilder buildDriverConfig(final boolean metricsEnabled)
+    {
+        ProgrammaticDriverConfigLoaderBuilder loaderBuilder = DriverConfigLoader.programmaticBuilder()
+                .withStringList(DefaultDriverOption.METADATA_SCHEMA_REFRESHED_KEYSPACES, SCHEMA_REFRESHED_KEYSPACES);
+        if (metricsEnabled)
+        {
+            loaderBuilder.withStringList(DefaultDriverOption.METRICS_SESSION_ENABLED, SESSION_METRICS);
+            loaderBuilder.withString(DefaultDriverOption.METRICS_FACTORY_CLASS, "MicrometerMetricsFactory");
+            loaderBuilder.withString(DefaultDriverOption.METRICS_ID_GENERATOR_CLASS, "TaggingMetricIdGenerator");
+        }
+        return loaderBuilder;
+    }
+
+    private static Collection<InetSocketAddress> resolveIfNeeded(final List<InetSocketAddress> contactPoints)
+    {
+        List<InetSocketAddress> resolved = new ArrayList<>();
+        for (InetSocketAddress address : contactPoints)
+        {
+            if (address.isUnresolved())
+            {
+                resolved.add(new InetSocketAddress(address.getHostString(), address.getPort()));
+            }
+            else
+            {
+                resolved.add(address);
+            }
+        }
+        return resolved;
+    }
+}

--- a/connection.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/connection/impl/builders/DatacenterNodeFilter.java
+++ b/connection.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/connection/impl/builders/DatacenterNodeFilter.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2024 Telefonaktiebolaget LM Ericsson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ericsson.bss.cassandra.ecchronos.connection.impl.builders;
+
+import com.datastax.oss.driver.api.core.metadata.Node;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+public final class DatacenterNodeFilter implements NodeFilter
+{
+    private final Set<String> myDatacenterNames;
+
+    public DatacenterNodeFilter(final List<String> datacenterNames)
+    {
+        myDatacenterNames = new HashSet<>(datacenterNames);
+    }
+
+    @Override
+    public boolean isValid(final Node node)
+    {
+        return myDatacenterNames.contains(node.getDatacenter());
+    }
+}

--- a/connection.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/connection/impl/builders/DistributedNativeBuilder.java
+++ b/connection.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/connection/impl/builders/DistributedNativeBuilder.java
@@ -15,49 +15,31 @@
 package com.ericsson.bss.cassandra.ecchronos.connection.impl.builders;
 
 import com.datastax.oss.driver.api.core.CqlSession;
-import com.datastax.oss.driver.api.core.CqlSessionBuilder;
 import com.datastax.oss.driver.api.core.auth.AuthProvider;
-import com.datastax.oss.driver.api.core.config.DefaultDriverOption;
-import com.datastax.oss.driver.api.core.config.DriverConfigLoader;
-import com.datastax.oss.driver.api.core.config.ProgrammaticDriverConfigLoaderBuilder;
 import com.datastax.oss.driver.api.core.metadata.Node;
 import com.datastax.oss.driver.api.core.metadata.NodeStateListener;
 import com.datastax.oss.driver.api.core.metadata.schema.KeyspaceMetadata;
 import com.datastax.oss.driver.api.core.metadata.schema.SchemaChangeListener;
 import com.datastax.oss.driver.api.core.ssl.SslEngineFactory;
-import com.datastax.oss.driver.shaded.guava.common.annotations.VisibleForTesting;
-import com.datastax.oss.driver.api.core.metrics.DefaultSessionMetric;
 import com.ericsson.bss.cassandra.ecchronos.connection.impl.providers.DistributedNativeConnectionProviderImpl;
 import com.ericsson.bss.cassandra.ecchronos.utils.enums.connection.ConnectionType;
-import com.google.common.collect.ImmutableList;
 
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
-import java.util.Optional;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class DistributedNativeBuilder// NOPMD Possible God Class
+public class DistributedNativeBuilder
 {
     private static final Logger LOG = LoggerFactory.getLogger(DistributedNativeBuilder.class);
-
-    private static final List<String> SCHEMA_REFRESHED_KEYSPACES = ImmutableList.of("/.*/", "!system",
-            "!system_distributed", "!system_schema", "!system_traces", "!system_views", "!system_virtual_schema");
-
-    private static final List<String> SESSION_METRICS = Arrays.asList(DefaultSessionMetric.BYTES_RECEIVED.getPath(),
-            DefaultSessionMetric.BYTES_SENT.getPath(), DefaultSessionMetric.CONNECTED_NODES.getPath(),
-            DefaultSessionMetric.CQL_REQUESTS.getPath(), DefaultSessionMetric.CQL_CLIENT_TIMEOUTS.getPath(),
-            DefaultSessionMetric.CQL_PREPARED_CACHE_SIZE.getPath(), DefaultSessionMetric.THROTTLING_DELAY.getPath(),
-            DefaultSessionMetric.THROTTLING_QUEUE_SIZE.getPath(), DefaultSessionMetric.THROTTLING_ERRORS.getPath());
 
     private ConnectionType myType = ConnectionType.datacenterAware;
     private List<InetSocketAddress> myInitialContactPoints = new ArrayList<>();
@@ -91,7 +73,7 @@ public class DistributedNativeBuilder// NOPMD Possible God Class
      * Sets the type of the agent for the distributed native connection.
      *
      * @param type
-     *         the type of the agent as a {@link String}.
+     *         the type of the agent as a {@link ConnectionType}.
      * @return the current instance of {@link DistributedNativeBuilder}.
      */
     public final DistributedNativeBuilder withAgentType(final ConnectionType type)
@@ -112,6 +94,7 @@ public class DistributedNativeBuilder// NOPMD Possible God Class
         myLocalDatacenter = localDatacenter;
         return this;
     }
+
     public final DistributedNativeBuilder withEcchronosKeyspaceName(final String keySpace)
     {
         ecchronosKeyspaceName = keySpace;
@@ -234,7 +217,8 @@ public class DistributedNativeBuilder// NOPMD Possible God Class
         try
         {
             LOG.info("Creating Session With Initial Contact Points");
-            session = createSession(this);
+            session = CqlSessionFactory.create(myInitialContactPoints, myLocalDatacenter, myAuthProvider,
+                    mySslEngineFactory, mySchemaChangeListener, myNodeStateListeners, myIsMetricsEnabled);
             LOG.info("Requesting Nodes List");
             Map<UUID, Node> nodesList = createNodesMap(session);
             LOG.info("Nodes list was created with success");
@@ -260,6 +244,7 @@ public class DistributedNativeBuilder// NOPMD Possible God Class
         }
         return connectionProvider;
     }
+
     /**
      * Creates a map of nodes based on the connection type, reads the node list from the database.
      * @param session the connection information to the database
@@ -267,16 +252,8 @@ public class DistributedNativeBuilder// NOPMD Possible God Class
      */
     public Map<UUID, Node> createNodesMap(final CqlSession session)
     {
-        return switch (myType)
-        {
-            case datacenterAware -> generateNodesMap(resolveDatacenterNodes(session, myDatacenterAware));
-            case rackAware -> generateNodesMap(resolveRackNodes(session, myRackAware));
-            case hostAware -> generateNodesMap(resolveHostAware(session, myHostAware));
-        };
-    }
-
-    private Map<UUID, Node> generateNodesMap(final List<Node> nodes)
-    {
+        NodeFilter filter = createNodeFilter();
+        List<Node> nodes = filter.resolve(session);
         Map<UUID, Node> nodesMap = new HashMap<>();
         nodes.forEach(node -> nodesMap.put(node.getHostId(), node));
         return nodesMap;
@@ -289,210 +266,16 @@ public class DistributedNativeBuilder// NOPMD Possible God Class
      */
     public Boolean confirmNodeValid(final Node node)
     {
+        return createNodeFilter().isValid(node);
+    }
+
+    private NodeFilter createNodeFilter()
+    {
         return switch (myType)
         {
-            case datacenterAware -> confirmDatacenterNodeValid(node, myDatacenterAware);
-            case rackAware -> confirmRackNodeValid(node, myRackAware);
-            case hostAware -> confirmHostNodeValid(node, myHostAware);
+            case datacenterAware -> new DatacenterNodeFilter(myDatacenterAware);
+            case rackAware -> new RackNodeFilter(myRackAware);
+            case hostAware -> new HostNodeFilter(myHostAware);
         };
-    }
-
-    private Boolean confirmDatacenterNodeValid(final Node node, final List<String> datacenterNames)
-    {
-        return (datacenterNames.contains(node.getDatacenter()));
-    }
-
-    private Boolean confirmRackNodeValid(final Node node, final List<Map<String, String>> rackInfo)
-    {
-        Set<Map<String, String>> racksInfoSet = new HashSet<>(rackInfo);
-        Map<String, String> tmpRackInfo = new HashMap<>();
-        tmpRackInfo.put("datacenterName", node.getDatacenter());
-        tmpRackInfo.put("rackName", node.getRack());
-        return (racksInfoSet.contains(tmpRackInfo));
-    }
-
-    private Boolean confirmHostNodeValid(final Node node, final List<InetSocketAddress> hostsInfo)
-    {
-        Set<InetSocketAddress> hostsInfoSet = new HashSet<>(hostsInfo);
-
-        InetSocketAddress tmpAddress = (InetSocketAddress) node.getEndPoint().resolve();
-        return (hostsInfoSet.contains(tmpAddress));
-     }
-
-    private CqlSession createSession(final DistributedNativeBuilder builder)
-    {
-        CqlSessionBuilder sessionBuilder = fromBuilder(builder);
-
-        DriverConfigLoader driverConfigLoader = loaderBuilder(builder).build();
-        LOG.debug("Driver configuration: {}", driverConfigLoader.getInitialConfig().getDefaultProfile().entrySet());
-        sessionBuilder.withConfigLoader(driverConfigLoader);
-        return sessionBuilder.build();
-    }
-
-    private List<Node> resolveDatacenterNodes(final CqlSession session, final List<String> datacenterNames)
-    {
-        Set<String> datacenterNameSet = new HashSet<>(datacenterNames);
-        List<Node> nodesList = new ArrayList<>();
-        Collection<Node> nodes = session.getMetadata().getNodes().values();
-        LOG.debug("Total nodes found for DatacenterAware: {}", nodes.size());
-
-        for (Node node : nodes)
-        {
-            if (datacenterNameSet.contains(node.getDatacenter()))
-            {
-                nodesList.add(node);
-                LOG.debug("Processing Node added to nodesList {}", node.getHostId());
-            }
-            else
-            {
-                LOG.debug("Skipping Node {}", node.getHostId());
-            }
-        }
-        return nodesList;
-    }
-
-    private List<Node> resolveRackNodes(final CqlSession session, final List<Map<String, String>> rackInfo)
-    {
-        Set<Map<String, String>> racksInfoSet = new HashSet<>(rackInfo);
-        List<Node> nodesList = new ArrayList<>();
-        Collection<Node> nodes = session.getMetadata().getNodes().values();
-        LOG.debug("Total nodes found for RackAware: {}", nodes.size());
-
-        for (Node node : nodes)
-        {
-            Map<String, String> tmpRackInfo = new HashMap<>();
-            tmpRackInfo.put("datacenterName", node.getDatacenter());
-            tmpRackInfo.put("rackName", node.getRack());
-            if (racksInfoSet.contains(tmpRackInfo))
-            {
-                nodesList.add(node);
-                LOG.debug("Processing Node added to nodesList {}", node.getHostId());
-            }
-            else
-            {
-                LOG.debug("Skipping Node {}", node.getHostId());
-            }
-
-        }
-        return nodesList;
-    }
-
-    private List<Node> resolveHostAware(final CqlSession session, final List<InetSocketAddress> hostsInfo)
-    {
-        Set<InetSocketAddress> hostsInfoSet = new HashSet<>(hostsInfo);
-        List<Node> nodesList = new ArrayList<>();
-        Collection<Node> nodes = session.getMetadata().getNodes().values();
-        LOG.debug("Total nodes found for HostAware: {}", nodes.size());
-        for (Node node : nodes)
-        {
-            InetSocketAddress tmpAddress = (InetSocketAddress) node.getEndPoint().resolve();
-            if (hostsInfoSet.contains(tmpAddress))
-            {
-                nodesList.add(node);
-                LOG.debug("Processing Node added to nodesList {}", node.getHostId());
-            }
-            else
-            {
-                LOG.debug("Skipping Node {}", node.getHostId());
-            }
-
-        }
-        return nodesList;
-    }
-
-    private static ProgrammaticDriverConfigLoaderBuilder loaderBuilder(
-            final DistributedNativeBuilder builder
-    )
-    {
-        ProgrammaticDriverConfigLoaderBuilder loaderBuilder = DriverConfigLoader.programmaticBuilder()
-                .withStringList(DefaultDriverOption.METADATA_SCHEMA_REFRESHED_KEYSPACES,
-                        SCHEMA_REFRESHED_KEYSPACES);
-        if (builder.myIsMetricsEnabled)
-        {
-            loaderBuilder.withStringList(DefaultDriverOption.METRICS_SESSION_ENABLED, SESSION_METRICS);
-            loaderBuilder.withString(DefaultDriverOption.METRICS_FACTORY_CLASS, "MicrometerMetricsFactory");
-            loaderBuilder.withString(DefaultDriverOption.METRICS_ID_GENERATOR_CLASS, "TaggingMetricIdGenerator");
-        }
-        return loaderBuilder;
-    }
-
-    private static CqlSessionBuilder fromBuilder(final DistributedNativeBuilder builder)
-    {
-        CqlSessionBuilder sessionBuilder = CqlSession.builder()
-                .addContactPoints(resolveIfNeeded(builder.myInitialContactPoints))
-                .withLocalDatacenter(builder.myLocalDatacenter)
-                .withAuthProvider(builder.myAuthProvider)
-                .withSslEngineFactory(builder.mySslEngineFactory)
-                .withSchemaChangeListener(builder.mySchemaChangeListener);
-        for (NodeStateListener listener: builder.myNodeStateListeners)
-        {
-            sessionBuilder = sessionBuilder.addNodeStateListener(listener);
-        }
-        return sessionBuilder;
-    }
-
-    private static Collection<InetSocketAddress> resolveIfNeeded(final List<InetSocketAddress> initialContactPoints)
-    {
-        List<InetSocketAddress> resolvedContactPoints = new ArrayList<>();
-        for (InetSocketAddress address : initialContactPoints)
-        {
-            if (address.isUnresolved())
-            {
-                resolvedContactPoints.add(new InetSocketAddress(address.getHostString(), address.getPort()));
-            }
-            else
-            {
-                resolvedContactPoints.add(address);
-            }
-        }
-        return resolvedContactPoints;
-    }
-
-    /**
-     * Resolves nodes in the specified datacenters for testing purposes. This method delegates to
-     * {@link #resolveDatacenterNodes(CqlSession, List)}.
-     *
-     * @param session
-     *         the {@link CqlSession} used to connect to the cluster.
-     * @param datacenterNames
-     *         the list of datacenter names to resolve nodes for.
-     * @return a list of {@link Node} instances representing the resolved nodes.
-     */
-    @VisibleForTesting
-    public final List<Node> testResolveDatacenterNodes(final CqlSession session, final List<String> datacenterNames)
-    {
-        return resolveDatacenterNodes(session, datacenterNames);
-    }
-
-    /**
-     * Resolves nodes in the specified racks for testing purposes. This method delegates to
-     * {@link #resolveRackNodes(CqlSession, List)}.
-     *
-     * @param session
-     *         the {@link CqlSession} used to connect to the cluster.
-     * @param rackInfo
-     *         a list of maps representing rack information.
-     * @return a list of {@link Node} instances representing the resolved nodes.
-     */
-    @VisibleForTesting
-    public final List<Node> testResolveRackNodes(final CqlSession session, final List<Map<String, String>> rackInfo)
-    {
-        return resolveRackNodes(session, rackInfo);
-    }
-
-    /**
-     * Resolves nodes based on host awareness for testing purposes. This method delegates to
-     * {@link #resolveHostAware(CqlSession, List)}.
-     *
-     * @param session
-     *         the {@link CqlSession} used to connect to the cluster.
-     * @param hostsInfo
-     *         a list of {@link InetSocketAddress} representing host information.
-     * @return a list of {@link Node} instances representing the resolved nodes.
-     */
-    @VisibleForTesting
-    public final List<Node> testResolveHostAware(final CqlSession session, final List<InetSocketAddress> hostsInfo)
-    {
-        return resolveHostAware(session, hostsInfo);
     }
 }

--- a/connection.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/connection/impl/builders/HostNodeFilter.java
+++ b/connection.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/connection/impl/builders/HostNodeFilter.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2024 Telefonaktiebolaget LM Ericsson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ericsson.bss.cassandra.ecchronos.connection.impl.builders;
+
+import com.datastax.oss.driver.api.core.metadata.Node;
+
+import java.net.InetSocketAddress;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+public final class HostNodeFilter implements NodeFilter
+{
+    private final Set<InetSocketAddress> myHosts;
+
+    public HostNodeFilter(final List<InetSocketAddress> hosts)
+    {
+        myHosts = new HashSet<>(hosts);
+    }
+
+    @Override
+    public boolean isValid(final Node node)
+    {
+        InetSocketAddress address = (InetSocketAddress) node.getEndPoint().resolve();
+        return myHosts.contains(address);
+    }
+}

--- a/connection.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/connection/impl/builders/NodeFilter.java
+++ b/connection.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/connection/impl/builders/NodeFilter.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2024 Telefonaktiebolaget LM Ericsson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ericsson.bss.cassandra.ecchronos.connection.impl.builders;
+
+import com.datastax.oss.driver.api.core.CqlSession;
+import com.datastax.oss.driver.api.core.metadata.Node;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public interface NodeFilter
+{
+    Logger LOG = LoggerFactory.getLogger(NodeFilter.class);
+
+    /**
+     * Resolve the list of nodes matching this filter from the cluster metadata.
+     */
+    default List<Node> resolve(final CqlSession session)
+    {
+        List<Node> nodesList = new ArrayList<>();
+        for (Node node : session.getMetadata().getNodes().values())
+        {
+            if (isValid(node))
+            {
+                nodesList.add(node);
+                LOG.debug("Processing Node added to nodesList {}", node.getHostId());
+            }
+            else
+            {
+                LOG.debug("Skipping Node {}", node.getHostId());
+            }
+        }
+        return nodesList;
+    }
+
+    /**
+     * Check if a single node matches this filter.
+     */
+    boolean isValid(Node node);
+}

--- a/connection.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/connection/impl/builders/RackNodeFilter.java
+++ b/connection.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/connection/impl/builders/RackNodeFilter.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2024 Telefonaktiebolaget LM Ericsson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ericsson.bss.cassandra.ecchronos.connection.impl.builders;
+
+import com.datastax.oss.driver.api.core.metadata.Node;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public final class RackNodeFilter implements NodeFilter
+{
+    private final Set<Map<String, String>> myRackInfo;
+
+    public RackNodeFilter(final List<Map<String, String>> rackInfo)
+    {
+        myRackInfo = new HashSet<>(rackInfo);
+    }
+
+    @Override
+    public boolean isValid(final Node node)
+    {
+        Map<String, String> nodeRack = new HashMap<>();
+        nodeRack.put("datacenterName", node.getDatacenter());
+        nodeRack.put("rackName", node.getRack());
+        return myRackInfo.contains(nodeRack);
+    }
+}

--- a/connection.impl/src/test/java/com/ericsson/bss/cassandra/ecchronos/connection/impl/builders/TestNodeFilters.java
+++ b/connection.impl/src/test/java/com/ericsson/bss/cassandra/ecchronos/connection/impl/builders/TestNodeFilters.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2026 Telefonaktiebolaget LM Ericsson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ericsson.bss.cassandra.ecchronos.connection.impl.builders;
+
+import com.datastax.oss.driver.api.core.CqlSession;
+import com.datastax.oss.driver.api.core.metadata.Metadata;
+import com.datastax.oss.driver.api.core.metadata.Node;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.net.InetSocketAddress;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class TestNodeFilters
+{
+    @Mock
+    private CqlSession mockSession;
+    @Mock
+    private Metadata mockMetadata;
+    @Mock
+    private Node nodeA;
+    @Mock
+    private Node nodeB;
+
+    @Before
+    public void setup()
+    {
+        when(nodeA.getDatacenter()).thenReturn("dc1");
+        when(nodeA.getRack()).thenReturn("rack1");
+        when(nodeA.getEndPoint()).thenReturn(new ContactEndPoint("10.0.0.1", 9042));
+
+        when(nodeB.getDatacenter()).thenReturn("dc2");
+        when(nodeB.getRack()).thenReturn("rack2");
+        when(nodeB.getEndPoint()).thenReturn(new ContactEndPoint("10.0.0.2", 9042));
+
+        Map<UUID, Node> nodes = new HashMap<>();
+        nodes.put(UUID.randomUUID(), nodeA);
+        nodes.put(UUID.randomUUID(), nodeB);
+        when(mockMetadata.getNodes()).thenReturn(nodes);
+        when(mockSession.getMetadata()).thenReturn(mockMetadata);
+    }
+
+    @Test
+    public void testDatacenterFilterEmptyListMatchesNothing()
+    {
+        DatacenterNodeFilter filter = new DatacenterNodeFilter(Collections.emptyList());
+        assertThat(filter.resolve(mockSession)).isEmpty();
+        assertThat(filter.isValid(nodeA)).isFalse();
+    }
+
+    @Test
+    public void testDatacenterFilterMultipleDatacenters()
+    {
+        DatacenterNodeFilter filter = new DatacenterNodeFilter(List.of("dc1", "dc2"));
+        assertThat(filter.resolve(mockSession)).hasSize(2);
+        assertThat(filter.isValid(nodeA)).isTrue();
+        assertThat(filter.isValid(nodeB)).isTrue();
+    }
+
+    @Test
+    public void testRackFilterEmptyListMatchesNothing()
+    {
+        RackNodeFilter filter = new RackNodeFilter(Collections.emptyList());
+        assertThat(filter.resolve(mockSession)).isEmpty();
+        assertThat(filter.isValid(nodeA)).isFalse();
+    }
+
+    @Test
+    public void testRackFilterWrongRackInCorrectDc()
+    {
+        Map<String, String> rack = new HashMap<>();
+        rack.put("datacenterName", "dc1");
+        rack.put("rackName", "rack2");
+        RackNodeFilter filter = new RackNodeFilter(List.of(rack));
+        assertThat(filter.isValid(nodeA)).isFalse();
+        assertThat(filter.isValid(nodeB)).isFalse();
+    }
+
+    @Test
+    public void testHostFilterEmptyListMatchesNothing()
+    {
+        HostNodeFilter filter = new HostNodeFilter(Collections.emptyList());
+        assertThat(filter.resolve(mockSession)).isEmpty();
+        assertThat(filter.isValid(nodeA)).isFalse();
+    }
+
+    @Test
+    public void testHostFilterWrongPortDoesNotMatch()
+    {
+        HostNodeFilter filter = new HostNodeFilter(List.of(new InetSocketAddress("10.0.0.1", 7000)));
+        assertThat(filter.isValid(nodeA)).isFalse();
+    }
+
+    @Test
+    public void testHostFilterExactMatch()
+    {
+        HostNodeFilter filter = new HostNodeFilter(List.of(new InetSocketAddress("10.0.0.1", 9042)));
+        assertThat(filter.isValid(nodeA)).isTrue();
+        assertThat(filter.isValid(nodeB)).isFalse();
+    }
+}

--- a/connection.impl/src/test/java/com/ericsson/bss/cassandra/ecchronos/connection/impl/providers/TestDistributedNativeConnectionProviderImpl.java
+++ b/connection.impl/src/test/java/com/ericsson/bss/cassandra/ecchronos/connection/impl/providers/TestDistributedNativeConnectionProviderImpl.java
@@ -15,19 +15,18 @@
 package com.ericsson.bss.cassandra.ecchronos.connection.impl.providers;
 
 import com.ericsson.bss.cassandra.ecchronos.connection.impl.builders.ContactEndPoint;
-import com.ericsson.bss.cassandra.ecchronos.connection.impl.builders.DistributedNativeBuilder;
-import com.ericsson.bss.cassandra.ecchronos.utils.enums.connection.ConnectionType;
+import com.ericsson.bss.cassandra.ecchronos.connection.impl.builders.DatacenterNodeFilter;
+import com.ericsson.bss.cassandra.ecchronos.connection.impl.builders.HostNodeFilter;
+import com.ericsson.bss.cassandra.ecchronos.connection.impl.builders.RackNodeFilter;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
-
 
 import com.datastax.oss.driver.api.core.CqlSession;
 import com.datastax.oss.driver.api.core.metadata.Metadata;
@@ -72,14 +71,9 @@ public class TestDistributedNativeConnectionProviderImpl
 
     private final ContactEndPoint endPointNodeDC2Rack2 = new ContactEndPoint("127.0.0.4", 9042);
 
-    private final List<InetSocketAddress> contactPoints = new ArrayList<>();
-
     @Before
     public void setup()
     {
-        contactPoints.add(new InetSocketAddress("127.0.0.1", 9042));
-        contactPoints.add(new InetSocketAddress("127.0.0.2", 9042));
-
         when(mockNodeDC1Rack1.getDatacenter()).thenReturn("datacenter1");
         when(mockNodeDC1Rack2.getDatacenter()).thenReturn("datacenter1");
         when(mockNodeDC2Rack1.getDatacenter()).thenReturn("datacenter2");
@@ -112,14 +106,11 @@ public class TestDistributedNativeConnectionProviderImpl
     @Test
     public void testResolveDatacenterAware()
     {
-        List<String> datacentersInfo = new ArrayList<>();
-        datacentersInfo.add("datacenter1");
+        List<String> datacentersInfo = List.of("datacenter1");
 
-        DistributedNativeBuilder provider = DistributedNativeConnectionProviderImpl.builder()
-                .withInitialContactPoints(contactPoints)
-                .withDatacenterAware(datacentersInfo);
+        DatacenterNodeFilter filter = new DatacenterNodeFilter(datacentersInfo);
+        List<Node> realNodesList = filter.resolve(mySessionMock);
 
-        List<Node> realNodesList = provider.testResolveDatacenterNodes(mySessionMock, datacentersInfo);
         assertThat(realNodesList)
                 .extracting(Node::getDatacenter)
                 .containsOnly("datacenter1");
@@ -127,20 +118,16 @@ public class TestDistributedNativeConnectionProviderImpl
     }
 
     @Test
-    public void testResolveRackAware() throws SecurityException, IllegalArgumentException
+    public void testResolveRackAware()
     {
-        List<Map<String, String>> rackList = new ArrayList<>();
         Map<String, String> rackInfo = new HashMap<>();
         rackInfo.put("datacenterName", "datacenter1");
         rackInfo.put("rackName", "rack1");
-        rackList.add(rackInfo);
+        List<Map<String, String>> rackList = List.of(rackInfo);
 
-        DistributedNativeBuilder provider = DistributedNativeConnectionProviderImpl.builder()
-                .withInitialContactPoints(contactPoints)
-                .withAgentType(ConnectionType.rackAware)
-                .withRackAware(rackList);
+        RackNodeFilter filter = new RackNodeFilter(rackList);
+        List<Node> realNodesList = filter.resolve(mySessionMock);
 
-        List<Node> realNodesList = provider.testResolveRackNodes(mySessionMock, rackList);
         assertThat(realNodesList)
                 .extracting(Node::getRack)
                 .containsOnly("rack1");
@@ -150,15 +137,14 @@ public class TestDistributedNativeConnectionProviderImpl
     @Test
     public void testResolveHostAware()
     {
-        List<InetSocketAddress> hostList = new ArrayList<>();
-        hostList.add(new InetSocketAddress("127.0.0.1", 9042));
-        hostList.add(new InetSocketAddress("127.0.0.2", 9042));
-        hostList.add(new InetSocketAddress("127.0.0.3", 9042));
-        DistributedNativeBuilder provider = DistributedNativeConnectionProviderImpl.builder()
-                .withInitialContactPoints(contactPoints)
-                .withAgentType(ConnectionType.hostAware)
-                .withHostAware(hostList);
-        List<Node> realNodesList = provider.testResolveHostAware(mySessionMock, hostList);
+        List<InetSocketAddress> hostList = List.of(
+                new InetSocketAddress("127.0.0.1", 9042),
+                new InetSocketAddress("127.0.0.2", 9042),
+                new InetSocketAddress("127.0.0.3", 9042));
+
+        HostNodeFilter filter = new HostNodeFilter(hostList);
+        List<Node> realNodesList = filter.resolve(mySessionMock);
+
         assertEquals(3, realNodesList.size());
     }
 }


### PR DESCRIPTION
Extract node filtering into a strategy pattern:
- NodeFilter: interface with default resolve() and abstract isValid()
- DatacenterNodeFilter: filter by datacenter name
- RackNodeFilter: filter by datacenter + rack
- HostNodeFilter: filter by endpoint address

Extract session creation into CqlSessionFactory.

Remove @VisibleForTesting methods by testing filter classes directly. Add TestNodeFilters with edge case coverage.