### PR TITLE
Refactor RepairTask God Class into single-responsibility classes

### DIFF
--- a/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/RepairHangMonitor.java
+++ b/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/RepairHangMonitor.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2026 Telefonaktiebolaget LM Ericsson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ericsson.bss.cassandra.ecchronos.core.impl.repair;
+
+import com.ericsson.bss.cassandra.ecchronos.core.jmx.DistributedJmxProxy;
+import com.ericsson.bss.cassandra.ecchronos.core.jmx.DistributedJmxProxyFactory;
+import com.ericsson.bss.cassandra.ecchronos.core.table.TableReference;
+import com.ericsson.bss.cassandra.ecchronos.utils.exceptions.ScheduledJobException;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.UUID;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Monitors a running repair for hangs by periodically checking node status
+ * and repair activity. Terminates the repair if the node is down, the repair
+ * is no longer active, or the max wait time is exceeded.
+ */
+public class RepairHangMonitor
+{
+    private static final Logger LOG = LoggerFactory.getLogger(RepairHangMonitor.class);
+    private static final String NORMAL_STATUS = "NORMAL";
+    private static final int DEFAULT_HEALTH_CHECK_INTERVAL_MINUTES = 1;
+
+    private final ScheduledExecutorService myExecutor = Executors.newSingleThreadScheduledExecutor(
+            new ThreadFactoryBuilder().setNameFormat("HangPreventingTask-%d").build());
+    private final DistributedJmxProxyFactory myJmxProxyFactory;
+    private final UUID myNodeID;
+    private final TableReference myTableReference;
+    private final int myMaxWaitTimeInMinutes;
+    private final RepairNotificationHandler myNotificationHandler;
+    private final long myHealthCheckInterval;
+    private final TimeUnit myHealthCheckTimeUnit;
+
+    private volatile ScheduledFuture<?> myHangPreventFuture;
+
+    public RepairHangMonitor(final DistributedJmxProxyFactory jmxProxyFactory,
+            final UUID nodeID,
+            final TableReference tableReference,
+            final int maxWaitTimeInMinutes,
+            final RepairNotificationHandler notificationHandler)
+    {
+        this(jmxProxyFactory, nodeID, tableReference, maxWaitTimeInMinutes, notificationHandler,
+                DEFAULT_HEALTH_CHECK_INTERVAL_MINUTES, TimeUnit.MINUTES);
+    }
+
+    @VisibleForTesting
+    RepairHangMonitor(final DistributedJmxProxyFactory jmxProxyFactory,
+            final UUID nodeID,
+            final TableReference tableReference,
+            final int maxWaitTimeInMinutes,
+            final RepairNotificationHandler notificationHandler,
+            final long healthCheckInterval,
+            final TimeUnit healthCheckTimeUnit)
+    {
+        myJmxProxyFactory = jmxProxyFactory;
+        myNodeID = nodeID;
+        myTableReference = tableReference;
+        myMaxWaitTimeInMinutes = maxWaitTimeInMinutes;
+        myNotificationHandler = notificationHandler;
+        myHealthCheckInterval = healthCheckInterval;
+        myHealthCheckTimeUnit = healthCheckTimeUnit;
+    }
+
+    /**
+     * Reschedule the hang prevention check. Should be called whenever progress is made.
+     */
+    public void reschedule()
+    {
+        if (myHangPreventFuture != null)
+        {
+            myHangPreventFuture.cancel(false);
+        }
+        myHangPreventFuture = myExecutor.schedule(new HangPreventingTask(),
+                myHealthCheckInterval, myHealthCheckTimeUnit);
+    }
+
+    /**
+     * Cancel any pending checks.
+     */
+    public void cancel()
+    {
+        if (myHangPreventFuture != null)
+        {
+            myHangPreventFuture.cancel(false);
+        }
+    }
+
+    /**
+     * Shut down the executor.
+     */
+    public void shutdown()
+    {
+        myExecutor.shutdownNow();
+    }
+
+    private final class HangPreventingTask implements Runnable
+    {
+        private final long startTime = System.currentTimeMillis();
+
+        @Override
+        public void run()
+        {
+            int command = myNotificationHandler.getCommand();
+            try (DistributedJmxProxy proxy = myJmxProxyFactory.connect())
+            {
+                String nodeStatus = proxy.getNodeStatus(myNodeID);
+                if (!NORMAL_STATUS.equals(nodeStatus))
+                {
+                    LOG.error("Cassandra node {} is down, aborting repair task.", myNodeID);
+                    myNotificationHandler.setError(
+                            new ScheduledJobException("Cassandra node " + myNodeID + " is down"));
+                    proxy.forceTerminateAllRepairSessionsInSpecificNode(myNodeID);
+                    myNotificationHandler.countDown();
+                }
+                else if (!proxy.isRepairActive(myNodeID, command))
+                {
+                    LOG.warn("Repair-{} of {} is no longer active on node {}, notification may have been lost",
+                            command, myTableReference, myNodeID);
+                    myNotificationHandler.countDown();
+                }
+                else if (System.currentTimeMillis() - startTime
+                        >= TimeUnit.MINUTES.toMillis(myMaxWaitTimeInMinutes))
+                {
+                    LOG.error("Repair-{} of {} still active after {} minutes on node {}, forcing termination",
+                            command, myTableReference, myMaxWaitTimeInMinutes, myNodeID);
+                    proxy.forceTerminateAllRepairSessionsInSpecificNode(myNodeID);
+                    myNotificationHandler.countDown();
+                }
+                else
+                {
+                    LOG.debug("Repair-{} still in status {}. Will recheck in {} {}",
+                            command, nodeStatus, myHealthCheckInterval, myHealthCheckTimeUnit);
+                    myHangPreventFuture = myExecutor.schedule(this,
+                            myHealthCheckInterval, myHealthCheckTimeUnit);
+                }
+            }
+            catch (IOException e)
+            {
+                LOG.error("Unable to check node status or prevent hanging repair task for Repair-{} of {}",
+                        command, myTableReference, e);
+            }
+        }
+    }
+}

--- a/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/RepairNotificationHandler.java
+++ b/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/RepairNotificationHandler.java
@@ -1,0 +1,235 @@
+/*
+ * Copyright 2026 Telefonaktiebolaget LM Ericsson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ericsson.bss.cassandra.ecchronos.core.impl.repair;
+
+import com.ericsson.bss.cassandra.ecchronos.core.state.LongTokenRange;
+import com.ericsson.bss.cassandra.ecchronos.utils.enums.repair.RepairStatus;
+import com.ericsson.bss.cassandra.ecchronos.utils.exceptions.ScheduledJobException;
+import com.google.common.annotations.VisibleForTesting;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.management.Notification;
+import javax.management.NotificationListener;
+import javax.management.remote.JMXConnectionNotification;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Handles JMX notifications during a repair task, parsing progress messages
+ * and signaling completion or failure.
+ */
+public final class RepairNotificationHandler implements NotificationListener
+{
+    private static final Logger LOG = LoggerFactory.getLogger(RepairNotificationHandler.class);
+    private static final Pattern RANGE_PATTERN = Pattern.compile("\\((-?[0-9]+),(-?[0-9]+)\\]");
+
+    private final CountDownLatch myLatch = new CountDownLatch(1);
+    private final List<Notification> myPendingNotifications = Collections.synchronizedList(new ArrayList<>());
+    private final RangeFinishedCallback myRangeCallback;
+    private final HangPreventionCallback myHangPreventionCallback;
+
+    private volatile ScheduledJobException myLastError;
+    private volatile boolean hasLostNotification = false;
+    private volatile int myCommand;
+    private volatile boolean myCommandReady = false;
+
+    /**
+     * Callback invoked when a token range finishes repair.
+     */
+    @FunctionalInterface
+    public interface RangeFinishedCallback
+    {
+        void onRangeFinished(LongTokenRange range, RepairStatus status);
+    }
+
+    /**
+     * Callback invoked when hang prevention should be rescheduled.
+     */
+    @FunctionalInterface
+    public interface HangPreventionCallback
+    {
+        void rescheduleHangPrevention();
+    }
+
+    public RepairNotificationHandler(final RangeFinishedCallback rangeCallback,
+            final HangPreventionCallback hangPreventionCallback)
+    {
+        myRangeCallback = rangeCallback;
+        myHangPreventionCallback = hangPreventionCallback;
+    }
+
+    /**
+     * Prepare for a new repair command. Must be called before repairAsync.
+     */
+    public void prepareForCommand()
+    {
+        myCommandReady = false;
+        myPendingNotifications.clear();
+    }
+
+    /**
+     * Set the command ID once repairAsync returns. Processes any pending notifications.
+     *
+     * @param command the repair command ID
+     */
+    public void setCommand(final int command)
+    {
+        myCommand = command;
+        myCommandReady = true;
+        if (!myPendingNotifications.isEmpty())
+        {
+            LOG.debug("Processing {} pending notifications", myPendingNotifications.size());
+            for (Notification pending : new ArrayList<>(myPendingNotifications))
+            {
+                handleNotification(pending, null);
+            }
+            myPendingNotifications.clear();
+        }
+    }
+
+    /**
+     * Wait for the repair to complete.
+     *
+     * @throws InterruptedException if the thread is interrupted while waiting
+     */
+    public void await() throws InterruptedException
+    {
+        myLatch.await();
+    }
+
+    /**
+     * @return the last error encountered, or null if none
+     */
+    public ScheduledJobException getLastError()
+    {
+        return myLastError;
+    }
+
+    /**
+     * @return true if a JMX notification was lost
+     */
+    public boolean hasLostNotification()
+    {
+        return hasLostNotification;
+    }
+
+    /**
+     * @return the repair command ID
+     */
+    public int getCommand()
+    {
+        return myCommand;
+    }
+
+    /**
+     * Signal completion (e.g., from hang monitor).
+     */
+    public void countDown()
+    {
+        myLatch.countDown();
+    }
+
+    /**
+     * Set an error (e.g., from hang monitor).
+     *
+     * @param error the error to record
+     */
+    public void setError(final ScheduledJobException error)
+    {
+        myLastError = error;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public void handleNotification(final Notification notification, final Object handback)
+    {
+        LOG.debug("Notification {}", notification.toString());
+        switch (notification.getType())
+        {
+        case "progress":
+            myHangPreventionCallback.rescheduleHangPrevention();
+            String tag = (String) notification.getSource();
+            if (!myCommandReady)
+            {
+                LOG.debug("Notification arrived before command ID is ready, storing as pending: {}", tag);
+                myPendingNotifications.add(notification);
+                break;
+            }
+            if (tag.equals("repair:" + myCommand))
+            {
+                Map<String, Integer> progress = (Map<String, Integer>) notification.getUserData();
+                String message = notification.getMessage();
+                RepairTask.ProgressEventType type = RepairTask.ProgressEventType.values()[progress.get("type")];
+                LOG.debug("Notification Type {}", type.toString());
+                progress(type, message);
+            }
+            break;
+
+        case JMXConnectionNotification.NOTIFS_LOST:
+            hasLostNotification = true;
+            break;
+
+        case JMXConnectionNotification.FAILED:
+        case JMXConnectionNotification.CLOSED:
+            String errorMessage = String.format("Unable to repair, error: %s", notification.getType());
+            LOG.error(errorMessage);
+            myLastError = new ScheduledJobException(errorMessage);
+            myLatch.countDown();
+            break;
+        default:
+            LOG.debug("Unknown JMXConnectionNotification type: {}", notification.getType());
+            break;
+        }
+    }
+
+    @VisibleForTesting
+    void progress(final RepairTask.ProgressEventType type, final String message)
+    {
+        if (type == RepairTask.ProgressEventType.PROGRESS || type == RepairTask.ProgressEventType.ERROR)
+        {
+            if (message.contains("finished") || message.contains("failed"))
+            {
+                LOG.debug("Progress message received: {}", message);
+                RepairStatus repairStatus = RepairStatus.SUCCESS;
+                if (message.contains("failed"))
+                {
+                    repairStatus = RepairStatus.FAILED;
+                }
+                Matcher rangeMatcher = RANGE_PATTERN.matcher(message);
+                while (rangeMatcher.find())
+                {
+                    long start = Long.parseLong(rangeMatcher.group(1));
+                    long end = Long.parseLong(rangeMatcher.group(2));
+                    myRangeCallback.onRangeFinished(new LongTokenRange(start, end), repairStatus);
+                }
+            }
+            else
+            {
+                LOG.warn("Unknown progress message received: {}", message);
+            }
+        }
+        if (type == RepairTask.ProgressEventType.COMPLETE)
+        {
+            LOG.debug("Progress message set to complete, latch counted down: {}", message);
+            myLatch.countDown();
+        }
+    }
+}

--- a/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/RepairRangeTracker.java
+++ b/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/RepairRangeTracker.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2026 Telefonaktiebolaget LM Ericsson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ericsson.bss.cassandra.ecchronos.core.impl.repair;
+
+import com.ericsson.bss.cassandra.ecchronos.core.state.LongTokenRange;
+import com.ericsson.bss.cassandra.ecchronos.utils.enums.repair.RepairStatus;
+
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Tracks the outcome of individual token ranges during a repair task.
+ */
+public class RepairRangeTracker
+{
+    private final Set<LongTokenRange> myFailedRanges = ConcurrentHashMap.newKeySet();
+    private final Set<LongTokenRange> mySuccessfulRanges = ConcurrentHashMap.newKeySet();
+
+    /**
+     * Record the result of a repaired range.
+     *
+     * @param range the token range that was repaired
+     * @param repairStatus the outcome of the repair for this range
+     */
+    public void onRangeFinished(final LongTokenRange range, final RepairStatus repairStatus)
+    {
+        if (repairStatus.equals(RepairStatus.FAILED))
+        {
+            myFailedRanges.add(range);
+        }
+        else
+        {
+            mySuccessfulRanges.add(range);
+        }
+    }
+
+    /**
+     * @return the set of token ranges that failed during repair
+     */
+    public Set<LongTokenRange> getFailedRanges()
+    {
+        return myFailedRanges;
+    }
+
+    /**
+     * @return the set of token ranges that succeeded during repair
+     */
+    public Set<LongTokenRange> getSuccessfulRanges()
+    {
+        return mySuccessfulRanges;
+    }
+
+    /**
+     * @return true if any ranges have failed
+     */
+    public boolean hasFailedRanges()
+    {
+        return !myFailedRanges.isEmpty();
+    }
+}

--- a/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/RepairTask.java
+++ b/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/RepairTask.java
@@ -24,55 +24,32 @@ import com.ericsson.bss.cassandra.ecchronos.utils.enums.repair.RepairStatus;
 import com.ericsson.bss.cassandra.ecchronos.utils.exceptions.ScheduledJobException;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
-import com.google.common.util.concurrent.ThreadFactoryBuilder;
-import java.util.UUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.management.Notification;
-import javax.management.NotificationListener;
-import javax.management.remote.JMXConnectionNotification;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ScheduledFuture;
+import java.util.UUID;
 import java.util.concurrent.TimeUnit;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 /**
- * Abstract Class used to represent repair tasks.
+ * Abstract class used to represent repair tasks. Orchestrates repair execution
+ * by delegating to {@link RepairRangeTracker}, {@link RepairNotificationHandler},
+ * and {@link RepairHangMonitor}.
  */
-public abstract class RepairTask implements NotificationListener // NOPMD Possible God Class
+public abstract class RepairTask
 {
     private static final Logger LOG = LoggerFactory.getLogger(RepairTask.class);
-    private static final Pattern RANGE_PATTERN = Pattern.compile("\\((-?[0-9]+),(-?[0-9]+)\\]");
-    private static final int HEALTH_CHECK_INTERVAL_MINUTES = 1;
-    private final int maxWaitTimeInMinutes;
 
     private final UUID nodeID;
-    private final ScheduledExecutorService myExecutor = Executors.newSingleThreadScheduledExecutor(
-            new ThreadFactoryBuilder().setNameFormat("HangPreventingTask-%d").build());
-    private final CountDownLatch myLatch = new CountDownLatch(1);
     private final DistributedJmxProxyFactory myJmxProxyFactory;
     private final TableReference myTableReference;
     private final TableRepairMetrics myTableRepairMetrics;
     private final RepairConfiguration myRepairConfiguration;
-    private volatile ScheduledFuture<?> myHangPreventFuture;
-    private volatile ScheduledJobException myLastError;
-    private volatile boolean hasLostNotification = false;
-    private volatile int myCommand;
-    private volatile boolean myCommandReady = false;
-    private final List<Notification> myPendingNotifications = Collections.synchronizedList(new ArrayList<>());
-    private final Set<LongTokenRange> myFailedRanges = ConcurrentHashMap.newKeySet();
-    private final Set<LongTokenRange> mySuccessfulRanges = ConcurrentHashMap.newKeySet();
+
+    private final RepairRangeTracker myRangeTracker = new RepairRangeTracker();
+    private final RepairNotificationHandler myNotificationHandler;
+    private final RepairHangMonitor myHangMonitor;
 
     /**
      * Constructs a RepairTask for the specified node and table with the given repair configuration and metrics.
@@ -98,7 +75,14 @@ public abstract class RepairTask implements NotificationListener // NOPMD Possib
         myTableReference = Preconditions.checkNotNull(tableReference, "Table reference must be set");
         myRepairConfiguration = Preconditions.checkNotNull(repairConfiguration, "Repair configuration must be set");
         myTableRepairMetrics = tableRepairMetrics;
-        maxWaitTimeInMinutes = maxWaitTime;
+
+        myNotificationHandler = new RepairNotificationHandler(
+                this::onRangeFinished,
+                this::rescheduleHangPrevention
+        );
+        myHangMonitor = new RepairHangMonitor(
+                myJmxProxyFactory, nodeID, myTableReference, maxWaitTime, myNotificationHandler
+        );
     }
 
     /**
@@ -116,7 +100,7 @@ public abstract class RepairTask implements NotificationListener // NOPMD Possib
         onExecute();
         try (DistributedJmxProxy proxy = myJmxProxyFactory.connect())
         {
-            rescheduleHangPrevention();
+            myHangMonitor.reschedule();
             repair(proxy);
             onFinish(RepairStatus.SUCCESS);
         }
@@ -128,10 +112,7 @@ public abstract class RepairTask implements NotificationListener // NOPMD Possib
         }
         finally
         {
-            if (myHangPreventFuture != null)
-            {
-                myHangPreventFuture.cancel(false);
-            }
+            myHangMonitor.cancel();
             end = System.nanoTime();
             total = end - start;
             myTableRepairMetrics.repairSession(myTableReference, total, TimeUnit.NANOSECONDS, successful);
@@ -146,69 +127,65 @@ public abstract class RepairTask implements NotificationListener // NOPMD Possib
     {
         // NOOP
     }
-    @SuppressWarnings({"PMD.CyclomaticComplexity", "PMD.CognitiveComplexity"})
+
     private void repair(final DistributedJmxProxy proxy) throws ScheduledJobException
     {
         LOG.debug("repair starting for table {} on node {}", myTableReference, nodeID);
-        if (proxy.addStorageServiceListener(nodeID, this))
+        if (!proxy.addStorageServiceListener(nodeID, myNotificationHandler))
         {
-            try
-            {
-                myCommandReady = false;
-                myPendingNotifications.clear();
-                myCommand = proxy.repairAsync(nodeID, myTableReference.getKeyspace(), getOptions());
-                myCommandReady = true;
-                if (myCommand > 0)
-                {
-                    // Process any notifications that arrived before myCommand was set
-                    if (!myPendingNotifications.isEmpty())
-                    {
-                        LOG.debug("Processing {} pending notifications for table {} on node {}",
-                                myPendingNotifications.size(), myTableReference, nodeID);
-                        for (Notification pending : new ArrayList<>(myPendingNotifications))
-                        {
-                            handleNotification(pending, null);
-                        }
-                        myPendingNotifications.clear();
-                    }
-                    try
-                    {
-                        LOG.debug("waiting for latch for table {} on node {}", myTableReference, nodeID);
-                        myLatch.await();
-                        LOG.debug("finished waiting for latch for table {} on node {}", myTableReference, nodeID);
-                        verifyRepair(proxy);
-                        if (myLastError != null)
-                        {
-                            throw myLastError;
-                        }
-                        if (hasLostNotification)
-                        {
-                            String msg = String.format("Repair-%d of %s had lost notifications", myCommand, myTableReference);
-                            LOG.warn(msg);
-                            throw new ScheduledJobException(msg);
-                        }
-                        LOG.debug("{} completed successfully on node {}", this, nodeID);
-                    }
-                    catch (InterruptedException e)
-                    {
-                        String msg = this + " was interrupted";
-                        LOG.warn(msg, e);
-                        Thread.currentThread().interrupt();
-                        throw new ScheduledJobException(msg, e);
-                    }
-                }
-            }
-            finally
-            {
-                proxy.removeStorageServiceListener(nodeID, this);
-            }
-        }
-        else
-        {
-            String msg = String.format("Repair of %s has no jmx connection", myCommand, myTableReference);
+            String msg = String.format("Repair of %s has no jmx connection", myTableReference);
             LOG.warn(msg);
             throw new ScheduledJobException(msg);
         }
+        try
+        {
+            myNotificationHandler.prepareForCommand();
+            int command = proxy.repairAsync(nodeID, myTableReference.getKeyspace(), getOptions());
+            if (command > 0)
+            {
+                myNotificationHandler.setCommand(command);
+                awaitAndVerifyRepair(proxy, command);
+            }
+        }
+        finally
+        {
+            proxy.removeStorageServiceListener(nodeID, myNotificationHandler);
+        }
+    }
+
+    private void awaitAndVerifyRepair(final DistributedJmxProxy proxy, final int command)
+            throws ScheduledJobException
+    {
+        try
+        {
+            LOG.debug("waiting for latch for table {} on node {}", myTableReference, nodeID);
+            myNotificationHandler.await();
+            LOG.debug("finished waiting for latch for table {} on node {}", myTableReference, nodeID);
+            verifyRepair(proxy);
+            if (myNotificationHandler.getLastError() != null)
+            {
+                throw myNotificationHandler.getLastError();
+            }
+            if (myNotificationHandler.hasLostNotification())
+            {
+                String msg = String.format("Repair-%d of %s had lost notifications", command, myTableReference);
+                LOG.warn(msg);
+                throw new ScheduledJobException(msg);
+            }
+            LOG.debug("{} completed successfully on node {}", this, nodeID);
+        }
+        catch (InterruptedException e)
+        {
+            String msg = this + " was interrupted";
+            LOG.warn(msg, e);
+            Thread.currentThread().interrupt();
+            throw new ScheduledJobException(msg, e);
+        }
+    }
+
+    private void rescheduleHangPrevention()
+    {
+        myHangMonitor.reschedule();
     }
 
     /**
@@ -228,10 +205,10 @@ public abstract class RepairTask implements NotificationListener // NOPMD Possib
      */
     protected void verifyRepair(final DistributedJmxProxy proxy) throws ScheduledJobException
     {
-        if (!myFailedRanges.isEmpty())
+        if (myRangeTracker.hasFailedRanges())
         {
             proxy.forceTerminateAllRepairSessions();
-            throw new ScheduledJobException("Repair has failed ranges '" + myFailedRanges + "'");
+            throw new ScheduledJobException("Repair has failed ranges '" + myRangeTracker.getFailedRanges() + "'");
         }
     }
 
@@ -267,134 +244,19 @@ public abstract class RepairTask implements NotificationListener // NOPMD Possib
      */
     public void cleanup()
     {
-        myExecutor.shutdownNow();
+        myHangMonitor.shutdown();
     }
 
     /**
-     * Notification handler.
-     *
-     * @param notification
-     *         The notification.
-     * @param handback
-     *         The handback.
-     */
-    @SuppressWarnings("unchecked")
-    @Override
-    public void handleNotification(final Notification notification, final Object handback)
-    {
-        LOG.debug("Notification {}", notification.toString());
-        switch (notification.getType())
-        {
-        case "progress":
-            rescheduleHangPrevention();
-            String tag = (String) notification.getSource();
-            if (!myCommandReady)
-            {
-                LOG.debug("Notification arrived before command ID is ready, storing as pending: {}", tag);
-                myPendingNotifications.add(notification);
-                break;
-            }
-            if (tag.equals("repair:" + myCommand))
-            {
-                Map<String, Integer> progress = (Map<String, Integer>) notification.getUserData();
-
-                String message = notification.getMessage();
-                ProgressEventType type = ProgressEventType.values()[progress.get("type")];
-                LOG.debug("Notification Type {}", type.toString());
-
-                this.progress(type, message);
-            }
-            break;
-
-        case JMXConnectionNotification.NOTIFS_LOST:
-            hasLostNotification = true;
-            break;
-
-        case JMXConnectionNotification.FAILED:
-        case JMXConnectionNotification.CLOSED:
-            String errorMessage = String.format("Unable to repair %s, error: %s", myTableReference, notification.getType());
-            LOG.error(errorMessage);
-            myLastError = new ScheduledJobException(errorMessage);
-            myLatch.countDown();
-            break;
-        default:
-            LOG.debug("Unknown JMXConnectionNotification type: {}", notification.getType());
-            break;
-        }
-    }
-
-    private void rescheduleHangPrevention()
-    {
-        if (myHangPreventFuture != null)
-        {
-            myHangPreventFuture.cancel(false);
-        }
-        // Schedule the first check to happen after 1 minute
-        myHangPreventFuture = myExecutor.schedule(new HangPreventingTask(), HEALTH_CHECK_INTERVAL_MINUTES,
-                TimeUnit.MINUTES);
-    }
-
-    /**
-     * Update progress.
-     *
-     * @param type
-     *         Progress event type.
-     * @param message
-     *         The message.
-     */
-    @VisibleForTesting
-    void progress(final ProgressEventType type, final String message)
-    {
-        if (type == ProgressEventType.PROGRESS || type == ProgressEventType.ERROR)
-        {
-            if (message.contains("finished") || message.contains("failed"))
-            {
-                LOG.debug("Progress message received: {}", message);
-                RepairStatus repairStatus = RepairStatus.SUCCESS;
-                if (message.contains("failed"))
-                {
-                    repairStatus = RepairStatus.FAILED;
-                }
-                Matcher rangeMatcher = RANGE_PATTERN.matcher(message);
-                while (rangeMatcher.find())
-                {
-                    long start = Long.parseLong(rangeMatcher.group(1));
-                    long end = Long.parseLong(rangeMatcher.group(2));
-
-                    LongTokenRange completedRange = new LongTokenRange(start, end);
-                    onRangeFinished(completedRange, repairStatus);
-                }
-            }
-            else
-            {
-                LOG.warn("{} - Unknown progress message received: {}", this, message);
-            }
-        }
-        if (type == ProgressEventType.COMPLETE)
-        {
-            LOG.debug("Progress message set to complete latch counted down: {}", message);
-            myLatch.countDown();
-            LOG.debug("Latch count now set to: {}", myLatch.getCount());
-        }
-    }
-
-    /**
-     * Method called once a range is finished successfully. In case of multiple ranges being repaired this will be
-     * called once per range. If this method is overriden make sure to call the super method.
+     * Method called once a range is finished. In case of multiple ranges being repaired this will be
+     * called once per range. If this method is overridden make sure to call the super method.
      *
      * @param range The range
      * @param repairStatus The status of the range
      */
     protected void onRangeFinished(final LongTokenRange range, final RepairStatus repairStatus)
     {
-        if (repairStatus.equals(RepairStatus.FAILED))
-        {
-            myFailedRanges.add(range);
-        }
-        else
-        {
-            mySuccessfulRanges.add(range);
-        }
+        myRangeTracker.onRangeFinished(range, repairStatus);
     }
 
     /**
@@ -439,73 +301,21 @@ public abstract class RepairTask implements NotificationListener // NOPMD Possib
         NOTIFICATION
     }
 
-    private final class HangPreventingTask implements Runnable
-    {
-        private static final String NORMAL_STATUS = "NORMAL";
-        private final long startTime = System.currentTimeMillis();
-
-        @Override
-        public void run()
-        {
-            try (DistributedJmxProxy proxy = myJmxProxyFactory.connect())
-            {
-                String nodeStatus = proxy.getNodeStatus(nodeID);
-                if (!NORMAL_STATUS.equals(nodeStatus))
-                {
-                    // Node state is not normal, terminate the repair directly
-                    LOG.error("Cassandra node {} is down, aborting repair task.", nodeID);
-                    myLastError = new ScheduledJobException("Cassandra node " + nodeID + " is down");
-                    proxy.forceTerminateAllRepairSessionsInSpecificNode(nodeID);
-                    myLatch.countDown();
-                }
-                else if (!proxy.isRepairActive(nodeID, myCommand))
-                {
-                    // No repair is active, assume notification was lost
-                    LOG.warn("Repair-{} of {} is no longer active on node {}, notification may have been lost",
-                            myCommand, myTableReference, nodeID);
-                    myLatch.countDown();
-                }
-                else if (System.currentTimeMillis() - startTime >= TimeUnit.MINUTES.toMillis(maxWaitTimeInMinutes))
-                {
-                    // Repair takes too long, force termination of sessions
-                    LOG.error("Repair-{} of {} still active after {} minutes on node {}, forcing termination",
-                            myCommand, myTableReference, maxWaitTimeInMinutes, nodeID);
-                    proxy.forceTerminateAllRepairSessionsInSpecificNode(nodeID);
-                    myLatch.countDown();
-                }
-                else
-                {
-                    LOG.debug("Repair-{} still in status {}. Will recheck in {} minutes",
-                            myCommand, nodeStatus, HEALTH_CHECK_INTERVAL_MINUTES);
-                    myHangPreventFuture = myExecutor.schedule(this,
-                            HEALTH_CHECK_INTERVAL_MINUTES, TimeUnit.MINUTES);
-                }
-            }
-            catch (IOException e)
-            {
-                LOG.error("Unable to check node status or prevent hanging repair task for Repair-{} of {}",
-                        myCommand, myTableReference, e);
-            }
-        }
-    }
-
     /**
      * Returns the set of token ranges that have failed during the repair task.
-     *
-     * <p>This method is primarily intended for testing purposes.</p>
      *
      * @return a set of {@link LongTokenRange} representing the failed token ranges.
      */
     @VisibleForTesting
     protected final Set<LongTokenRange> getFailedRanges()
     {
-        return myFailedRanges;
+        return myRangeTracker.getFailedRanges();
     }
 
     @VisibleForTesting
     protected final Set<LongTokenRange> getSuccessfulRanges()
     {
-        return mySuccessfulRanges;
+        return myRangeTracker.getSuccessfulRanges();
     }
 
     /**

--- a/core.impl/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/TestRepairHangMonitor.java
+++ b/core.impl/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/TestRepairHangMonitor.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2026 Telefonaktiebolaget LM Ericsson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ericsson.bss.cassandra.ecchronos.core.impl.repair;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.ericsson.bss.cassandra.ecchronos.core.jmx.DistributedJmxProxy;
+import com.ericsson.bss.cassandra.ecchronos.core.jmx.DistributedJmxProxyFactory;
+import com.ericsson.bss.cassandra.ecchronos.core.table.TableReference;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.io.IOException;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+@RunWith(MockitoJUnitRunner.Silent.class)
+public class TestRepairHangMonitor
+{
+    private static final UUID NODE_ID = UUID.randomUUID();
+    private static final int COMMAND = 42;
+    private static final int MAX_WAIT_MINUTES = 10;
+
+    @Mock
+    private DistributedJmxProxyFactory myJmxProxyFactory;
+
+    @Mock
+    private DistributedJmxProxy myProxy;
+
+    @Mock
+    private TableReference myTableReference;
+
+    @Mock
+    private RepairNotificationHandler myNotificationHandler;
+
+    private RepairHangMonitor monitor;
+
+    @Before
+    public void setup() throws IOException
+    {
+        when(myJmxProxyFactory.connect()).thenReturn(myProxy);
+        when(myNotificationHandler.getCommand()).thenReturn(COMMAND);
+        monitor = new RepairHangMonitor(myJmxProxyFactory, NODE_ID, myTableReference,
+                MAX_WAIT_MINUTES, myNotificationHandler, 1, TimeUnit.SECONDS);
+    }
+
+    @After
+    public void teardown()
+    {
+        monitor.shutdown();
+    }
+
+    @Test
+    public void testNodeDownTerminatesRepair()
+    {
+        when(myProxy.getNodeStatus(NODE_ID)).thenReturn("DOWN");
+
+        monitor.reschedule();
+
+        await().atMost(5, TimeUnit.SECONDS).untilAsserted(() -> {
+            verify(myProxy, atLeastOnce()).forceTerminateAllRepairSessionsInSpecificNode(eq(NODE_ID));
+            verify(myNotificationHandler, atLeastOnce()).countDown();
+        });
+    }
+
+    @Test
+    public void testRepairNoLongerActiveCountsDown()
+    {
+        when(myProxy.getNodeStatus(NODE_ID)).thenReturn("NORMAL");
+        when(myProxy.isRepairActive(NODE_ID, COMMAND)).thenReturn(false);
+
+        monitor.reschedule();
+
+        await().atMost(5, TimeUnit.SECONDS).untilAsserted(() -> {
+            verify(myNotificationHandler, atLeastOnce()).countDown();
+        });
+    }
+
+    @Test
+    public void testNormalNodeWithActiveRepairReschedules()
+    {
+        when(myProxy.getNodeStatus(NODE_ID)).thenReturn("NORMAL");
+        when(myProxy.isRepairActive(NODE_ID, COMMAND)).thenReturn(true);
+
+        monitor.reschedule();
+
+        // The monitor should check and reschedule - verify it at least checked
+        await().atMost(5, TimeUnit.SECONDS).untilAsserted(() -> {
+            verify(myProxy, atLeastOnce()).getNodeStatus(NODE_ID);
+            verify(myProxy, atLeastOnce()).isRepairActive(NODE_ID, COMMAND);
+        });
+    }
+}

--- a/core.impl/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/TestRepairNotificationHandler.java
+++ b/core.impl/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/TestRepairNotificationHandler.java
@@ -1,0 +1,212 @@
+/*
+ * Copyright 2026 Telefonaktiebolaget LM Ericsson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ericsson.bss.cassandra.ecchronos.core.impl.repair;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import com.ericsson.bss.cassandra.ecchronos.core.state.LongTokenRange;
+import com.ericsson.bss.cassandra.ecchronos.utils.enums.repair.RepairStatus;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import javax.management.Notification;
+import javax.management.remote.JMXConnectionNotification;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+@RunWith(MockitoJUnitRunner.Silent.class)
+public class TestRepairNotificationHandler
+{
+    private static final int COMMAND = 42;
+
+    @Mock
+    private RepairNotificationHandler.HangPreventionCallback myHangPreventionCallback;
+
+    private final List<RangeResult> myRangeResults = new ArrayList<>();
+    private RepairNotificationHandler handler;
+
+    @Before
+    public void setup()
+    {
+        handler = new RepairNotificationHandler(
+                (range, status) -> myRangeResults.add(new RangeResult(range, status)),
+                myHangPreventionCallback
+        );
+        handler.prepareForCommand();
+        handler.setCommand(COMMAND);
+    }
+
+    @Test
+    public void testProgressNotificationParsesFinishedRange()
+    {
+        Notification notification = createProgressNotification(
+                "repair:" + COMMAND,
+                "Repair session 1 on range (1,100] for keyspace finished",
+                RepairTask.ProgressEventType.PROGRESS.ordinal());
+
+        handler.handleNotification(notification, null);
+
+        assertThat(myRangeResults).hasSize(1);
+        assertThat(myRangeResults.get(0).range).isEqualTo(new LongTokenRange(1, 100));
+        assertThat(myRangeResults.get(0).status).isEqualTo(RepairStatus.SUCCESS);
+    }
+
+    @Test
+    public void testProgressNotificationParsesFailedRange()
+    {
+        Notification notification = createProgressNotification(
+                "repair:" + COMMAND,
+                "Repair session 1 on range (-100,200] for keyspace failed",
+                RepairTask.ProgressEventType.PROGRESS.ordinal());
+
+        handler.handleNotification(notification, null);
+
+        assertThat(myRangeResults).hasSize(1);
+        assertThat(myRangeResults.get(0).range).isEqualTo(new LongTokenRange(-100, 200));
+        assertThat(myRangeResults.get(0).status).isEqualTo(RepairStatus.FAILED);
+    }
+
+    @Test
+    public void testCompleteEventCountsDownLatch() throws InterruptedException
+    {
+        Notification notification = createProgressNotification(
+                "repair:" + COMMAND,
+                "Repair completed successfully",
+                RepairTask.ProgressEventType.COMPLETE.ordinal());
+
+        handler.handleNotification(notification, null);
+
+        // await should return immediately since latch was counted down
+        CountDownLatch verifyLatch = new CountDownLatch(1);
+        Thread t = new Thread(() -> {
+            try
+            {
+                handler.await();
+                verifyLatch.countDown();
+            }
+            catch (InterruptedException e)
+            {
+                Thread.currentThread().interrupt();
+            }
+        });
+        t.start();
+        assertThat(verifyLatch.await(1, TimeUnit.SECONDS)).isTrue();
+    }
+
+    @Test
+    public void testConnectionClosedSetsError()
+    {
+        Notification notification = new Notification(
+                JMXConnectionNotification.CLOSED, "source", 1L);
+
+        handler.handleNotification(notification, null);
+
+        assertThat(handler.getLastError()).isNotNull();
+    }
+
+    @Test
+    public void testLostNotificationFlagSet()
+    {
+        Notification notification = new Notification(
+                JMXConnectionNotification.NOTIFS_LOST, "source", 1L);
+
+        handler.handleNotification(notification, null);
+
+        assertThat(handler.hasLostNotification()).isTrue();
+    }
+
+    @Test
+    public void testPendingNotificationsProcessedAfterCommandSet()
+    {
+        // Create a fresh handler without setting command
+        RepairNotificationHandler freshHandler = new RepairNotificationHandler(
+                (range, status) -> myRangeResults.add(new RangeResult(range, status)),
+                myHangPreventionCallback
+        );
+        freshHandler.prepareForCommand();
+
+        // Send notification before command is ready
+        Notification notification = createProgressNotification(
+                "repair:" + COMMAND,
+                "Repair session 1 on range (50,150] for keyspace finished",
+                RepairTask.ProgressEventType.PROGRESS.ordinal());
+        freshHandler.handleNotification(notification, null);
+
+        // Not processed yet
+        assertThat(myRangeResults).isEmpty();
+
+        // Now set command - pending should be processed
+        freshHandler.setCommand(COMMAND);
+
+        assertThat(myRangeResults).hasSize(1);
+        assertThat(myRangeResults.get(0).range).isEqualTo(new LongTokenRange(50, 150));
+    }
+
+    @Test
+    public void testProgressReschedulesHangPrevention()
+    {
+        Notification notification = createProgressNotification(
+                "repair:" + COMMAND,
+                "Repair session 1 on range (1,100] for keyspace finished",
+                RepairTask.ProgressEventType.PROGRESS.ordinal());
+
+        handler.handleNotification(notification, null);
+
+        verify(myHangPreventionCallback).rescheduleHangPrevention();
+    }
+
+    @Test
+    public void testNotificationForDifferentCommandIgnored()
+    {
+        Notification notification = createProgressNotification(
+                "repair:999",
+                "Repair session 1 on range (1,100] for keyspace finished",
+                RepairTask.ProgressEventType.PROGRESS.ordinal());
+
+        handler.handleNotification(notification, null);
+
+        assertThat(myRangeResults).isEmpty();
+    }
+
+    private Notification createProgressNotification(String source, String message, int type)
+    {
+        Notification notification = new Notification("progress", source, 1L, message);
+        Map<String, Integer> userData = new HashMap<>();
+        userData.put("type", type);
+        notification.setUserData(userData);
+        return notification;
+    }
+
+    private static class RangeResult
+    {
+        final LongTokenRange range;
+        final RepairStatus status;
+
+        RangeResult(LongTokenRange range, RepairStatus status)
+        {
+            this.range = range;
+            this.status = status;
+        }
+    }
+}

--- a/core.impl/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/TestRepairRangeTracker.java
+++ b/core.impl/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/TestRepairRangeTracker.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2026 Telefonaktiebolaget LM Ericsson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ericsson.bss.cassandra.ecchronos.core.impl.repair;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.ericsson.bss.cassandra.ecchronos.core.state.LongTokenRange;
+import com.ericsson.bss.cassandra.ecchronos.utils.enums.repair.RepairStatus;
+import org.junit.Test;
+
+public class TestRepairRangeTracker
+{
+    private final RepairRangeTracker tracker = new RepairRangeTracker();
+
+    @Test
+    public void testHasFailedRangesReturnsFalseWhenEmpty()
+    {
+        assertThat(tracker.hasFailedRanges()).isFalse();
+        assertThat(tracker.getFailedRanges()).isEmpty();
+        assertThat(tracker.getSuccessfulRanges()).isEmpty();
+    }
+
+    @Test
+    public void testSuccessfulRangeTracked()
+    {
+        LongTokenRange range = new LongTokenRange(1, 100);
+        tracker.onRangeFinished(range, RepairStatus.SUCCESS);
+
+        assertThat(tracker.getSuccessfulRanges()).containsExactly(range);
+        assertThat(tracker.hasFailedRanges()).isFalse();
+    }
+
+    @Test
+    public void testFailedRangeTracked()
+    {
+        LongTokenRange range = new LongTokenRange(1, 100);
+        tracker.onRangeFinished(range, RepairStatus.FAILED);
+
+        assertThat(tracker.getFailedRanges()).containsExactly(range);
+        assertThat(tracker.hasFailedRanges()).isTrue();
+    }
+
+    @Test
+    public void testMixedRangesTrackedCorrectly()
+    {
+        LongTokenRange successRange = new LongTokenRange(1, 100);
+        LongTokenRange failedRange = new LongTokenRange(101, 200);
+
+        tracker.onRangeFinished(successRange, RepairStatus.SUCCESS);
+        tracker.onRangeFinished(failedRange, RepairStatus.FAILED);
+
+        assertThat(tracker.getSuccessfulRanges()).containsExactly(successRange);
+        assertThat(tracker.getFailedRanges()).containsExactly(failedRange);
+        assertThat(tracker.hasFailedRanges()).isTrue();
+    }
+}


### PR DESCRIPTION
Extract RepairRangeTracker, RepairNotificationHandler, and RepairHangMonitor from RepairTask to reduce complexity and improve testability.

- RepairRangeTracker: tracks failed/successful token ranges
- RepairNotificationHandler: handles JMX notifications and progress parsing
- RepairHangMonitor: scheduled health checks to detect hung repairs
- RepairTask: slimmed-down orchestrator delegating to the above

Added unit tests for all three extracted classes.