### PR TITLE
Implement ReplicaSet Interning for VnodeRepairState Instances

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Version 1.0.0 (Not yet Released)
 
+* Implement ReplicaSet Interning for VnodeRepairState Instances - Issue #1581
 * Implement Flyweight Caching for LongTokenRange Instances - Issue #1580
 * Deprecate JMX Port Discover to use port field in ecc.yml - Issue #1578
 * Refactor DistributedJmxBuilder to Reduce Cyclomatic Complexity - Issue #1573

--- a/application/src/main/java/com/ericsson/bss/cassandra/ecchronos/application/spring/ECChronos.java
+++ b/application/src/main/java/com/ericsson/bss/cassandra/ecchronos/application/spring/ECChronos.java
@@ -155,7 +155,8 @@ public class ECChronos implements Closeable
                 .withJmxConnectionProvider(jmxConnectionProvider)
                 .withNodeWorkerManager(myNodeWorkerManager)
                 .withScheduleManager(myECChronosInternals.getScheduleManager())
-                .withDistributedNativeConnectionProvider(nativeConnectionProvider));
+                .withDistributedNativeConnectionProvider(nativeConnectionProvider)
+                .withReplicaSetCache(repairStateFactoryImpl.getReplicaSetCache()));
 
         myRepairStatsProvider = new RepairStatsProviderImpl(
                 nativeConnectionProvider,

--- a/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/DefaultRepairConfigurationProvider.java
+++ b/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/DefaultRepairConfigurationProvider.java
@@ -17,6 +17,7 @@ package com.ericsson.bss.cassandra.ecchronos.core.impl.repair;
 import com.ericsson.bss.cassandra.ecchronos.connection.DistributedJmxConnectionProvider;
 import com.ericsson.bss.cassandra.ecchronos.connection.DistributedNativeConnectionProvider;
 import com.ericsson.bss.cassandra.ecchronos.core.impl.multithreads.NodeWorkerManager;
+import com.ericsson.bss.cassandra.ecchronos.core.impl.repair.vnode.ReplicaSetCache;
 import com.ericsson.bss.cassandra.ecchronos.core.repair.multithread.CloseEvent;
 import com.ericsson.bss.cassandra.ecchronos.core.repair.multithread.KeyspaceCreatedEvent;
 import com.ericsson.bss.cassandra.ecchronos.core.repair.multithread.SetupEvent;
@@ -74,7 +75,8 @@ public class DefaultRepairConfigurationProvider extends NodeStateListenerBase im
                 builder.myAgentNativeConnectionProvider,
                 builder.myNodeWorkerManager,
                 builder.myScheduleManager,
-                myService);
+                myService,
+                builder.myReplicaSetCache);
         setupConfiguration();
     }
 
@@ -93,7 +95,8 @@ public class DefaultRepairConfigurationProvider extends NodeStateListenerBase im
                 builder.myAgentNativeConnectionProvider,
                 builder.myNodeWorkerManager,
                 builder.myScheduleManager,
-                myService);
+                myService,
+                builder.myReplicaSetCache);
         setupConfiguration();
     }
 
@@ -361,6 +364,7 @@ public class DefaultRepairConfigurationProvider extends NodeStateListenerBase im
         private DistributedNativeConnectionProvider myAgentNativeConnectionProvider;
         private NodeWorkerManager myNodeWorkerManager;
         private ScheduleManager myScheduleManager;
+        private ReplicaSetCache myReplicaSetCache;
 
         /**
          * Build with session.
@@ -427,6 +431,17 @@ public class DefaultRepairConfigurationProvider extends NodeStateListenerBase im
         public Builder withScheduleManager(final ScheduleManager scheduleManager)
         {
             myScheduleManager = scheduleManager;
+            return this;
+        }
+
+        /**
+         * Build with ReplicaSetCache.
+         * @param replicaSetCache the replica set cache to clear on topology changes.
+         * @return Builder
+         */
+        public Builder withReplicaSetCache(final ReplicaSetCache replicaSetCache)
+        {
+            myReplicaSetCache = replicaSetCache;
             return this;
         }
 

--- a/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/NodeLifecycleHandler.java
+++ b/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/NodeLifecycleHandler.java
@@ -20,6 +20,7 @@ import com.ericsson.bss.cassandra.ecchronos.connection.DistributedNativeConnecti
 import com.ericsson.bss.cassandra.ecchronos.core.impl.multithreads.NodeWorkerManager;
 import com.ericsson.bss.cassandra.ecchronos.core.impl.refresh.NodeAddedAction;
 import com.ericsson.bss.cassandra.ecchronos.core.impl.refresh.NodeRemovedAction;
+import com.ericsson.bss.cassandra.ecchronos.core.impl.repair.vnode.ReplicaSetCache;
 import com.ericsson.bss.cassandra.ecchronos.core.repair.scheduler.ScheduleManager;
 import com.ericsson.bss.cassandra.ecchronos.core.state.LongTokenRange;
 import com.ericsson.bss.cassandra.ecchronos.data.sync.EccNodesSync;
@@ -42,6 +43,7 @@ public class NodeLifecycleHandler
     private final NodeWorkerManager myWorkerManager;
     private final ScheduleManager myScheduleManager;
     private final ExecutorService myService;
+    private final ReplicaSetCache myReplicaSetCache;
 
     public NodeLifecycleHandler(final EccNodesSync eccNodesSync,
                                 final DistributedJmxConnectionProvider jmxConnectionProvider,
@@ -50,12 +52,25 @@ public class NodeLifecycleHandler
                                 final ScheduleManager scheduleManager,
                                 final ExecutorService service)
     {
+        this(eccNodesSync, jmxConnectionProvider, agentNativeConnectionProvider,
+                workerManager, scheduleManager, service, null);
+    }
+
+    public NodeLifecycleHandler(final EccNodesSync eccNodesSync,
+                                final DistributedJmxConnectionProvider jmxConnectionProvider,
+                                final DistributedNativeConnectionProvider agentNativeConnectionProvider,
+                                final NodeWorkerManager workerManager,
+                                final ScheduleManager scheduleManager,
+                                final ExecutorService service,
+                                final ReplicaSetCache replicaSetCache)
+    {
         myEccNodesSync = eccNodesSync;
         myJmxConnectionProvider = jmxConnectionProvider;
         myAgentNativeConnectionProvider = agentNativeConnectionProvider;
         myWorkerManager = workerManager;
         myScheduleManager = scheduleManager;
         myService = service;
+        myReplicaSetCache = replicaSetCache;
     }
 
     /**
@@ -103,6 +118,7 @@ public class NodeLifecycleHandler
         {
             LOG.info("Node added {}", node.getHostId());
             LongTokenRange.clearCache();
+            clearReplicaSetCache();
             NodeAddedAction callable = new NodeAddedAction(myEccNodesSync, myJmxConnectionProvider,
                     myAgentNativeConnectionProvider, node);
             myService.submit(callable);
@@ -130,6 +146,7 @@ public class NodeLifecycleHandler
         {
             LOG.info("Node removed {}", node.getHostId());
             LongTokenRange.clearCache();
+            clearReplicaSetCache();
             NodeRemovedAction callable = new NodeRemovedAction(myEccNodesSync, myJmxConnectionProvider,
                     myAgentNativeConnectionProvider, node);
             myService.submit(callable);
@@ -141,6 +158,14 @@ public class NodeLifecycleHandler
             {
                 myScheduleManager.removeScheduleFutureForNode(node.getHostId());
             }
+        }
+    }
+
+    private void clearReplicaSetCache()
+    {
+        if (myReplicaSetCache != null)
+        {
+            myReplicaSetCache.clear();
         }
     }
 }

--- a/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/state/RepairStateFactoryImpl.java
+++ b/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/state/RepairStateFactoryImpl.java
@@ -17,6 +17,7 @@ package com.ericsson.bss.cassandra.ecchronos.core.impl.repair.state;
 import com.datastax.oss.driver.api.core.metadata.Node;
 import com.ericsson.bss.cassandra.ecchronos.core.impl.repair.vnode.VnodeRepairGroupFactory;
 import com.ericsson.bss.cassandra.ecchronos.core.impl.repair.vnode.VnodeRepairStateFactoryImpl;
+import com.ericsson.bss.cassandra.ecchronos.core.impl.repair.vnode.ReplicaSetCache;
 import com.ericsson.bss.cassandra.ecchronos.core.repair.config.RepairConfiguration;
 
 import com.ericsson.bss.cassandra.ecchronos.core.state.HostStates;
@@ -37,16 +38,28 @@ public final class RepairStateFactoryImpl implements RepairStateFactory
 
     private final VnodeRepairStateFactoryImpl myVnodeRepairStateFactory;
     private final VnodeRepairStateFactoryImpl mySubRangeRepairStateFactory;
+    private final ReplicaSetCache myReplicaSetCache;
 
     private RepairStateFactoryImpl(final Builder builder)
     {
         myHostStates = builder.myHostStates;
         myTableRepairMetrics = builder.myTableRepairMetrics;
+        myReplicaSetCache = new ReplicaSetCache();
 
         myVnodeRepairStateFactory = new VnodeRepairStateFactoryImpl(builder.myReplicationState,
-                builder.myRepairHistoryProvider, false);
+                builder.myRepairHistoryProvider, false, myReplicaSetCache);
         mySubRangeRepairStateFactory = new VnodeRepairStateFactoryImpl(builder.myReplicationState,
-                builder.myRepairHistoryProvider, true);
+                builder.myRepairHistoryProvider, true, myReplicaSetCache);
+    }
+
+    /**
+     * Get the shared replica set cache.
+     *
+     * @return The ReplicaSetCache instance.
+     */
+    public ReplicaSetCache getReplicaSetCache()
+    {
+        return myReplicaSetCache;
     }
 
     @Override

--- a/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/vnode/ReplicaSetCache.java
+++ b/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/vnode/ReplicaSetCache.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2026 Telefonaktiebolaget LM Ericsson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ericsson.bss.cassandra.ecchronos.core.impl.repair.vnode;
+
+import com.ericsson.bss.cassandra.ecchronos.core.metadata.DriverNode;
+import com.google.common.collect.ImmutableSet;
+
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Interns {@link ImmutableSet} instances of {@link DriverNode} so that identical replica
+ * combinations share the same object reference across the application lifecycle.
+ * <p>
+ * In a typical cluster with RF=3 and 6 nodes, there are at most 20 unique replica set
+ * combinations. This cache ensures those ~20 sets are reused across the thousands of
+ * {@code VnodeRepairState} instances that reference them.
+ * <p>
+ * The cache should be cleared on topology changes to avoid retaining obsolete combinations.
+ */
+public class ReplicaSetCache
+{
+    private final ConcurrentHashMap<ImmutableSet<DriverNode>, ImmutableSet<DriverNode>> myCache
+            = new ConcurrentHashMap<>();
+
+    /**
+     * Returns a cached instance equal to the given replica set.
+     *
+     * @param replicas The replica set to intern.
+     * @return A shared instance equal to the input.
+     */
+    public ImmutableSet<DriverNode> intern(final ImmutableSet<DriverNode> replicas)
+    {
+        return myCache.computeIfAbsent(replicas, k -> k);
+    }
+
+    /**
+     * Clears the cache. Should be called on topology changes.
+     */
+    public void clear()
+    {
+        myCache.clear();
+    }
+
+    /**
+     * Returns the current number of cached replica sets.
+     *
+     * @return The cache size.
+     */
+    public int size()
+    {
+        return myCache.size();
+    }
+}

--- a/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/vnode/VnodeRepairStateFactoryImpl.java
+++ b/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/vnode/VnodeRepairStateFactoryImpl.java
@@ -49,15 +49,36 @@ public class VnodeRepairStateFactoryImpl implements VnodeRepairStateFactory
     private final ReplicationState myReplicationState;
     private final RepairHistoryProvider myRepairHistoryProvider;
     private final boolean useSubRanges;
+    private final ReplicaSetCache myReplicaSetCache;
 
     public VnodeRepairStateFactoryImpl(
             final ReplicationState replicationState,
             final RepairHistoryProvider repairHistoryProvider,
             final boolean toUseSubRanges)
     {
+        this(replicationState, repairHistoryProvider, toUseSubRanges, new ReplicaSetCache());
+    }
+
+    public VnodeRepairStateFactoryImpl(
+            final ReplicationState replicationState,
+            final RepairHistoryProvider repairHistoryProvider,
+            final boolean toUseSubRanges,
+            final ReplicaSetCache replicaSetCache)
+    {
         myReplicationState = replicationState;
         myRepairHistoryProvider = repairHistoryProvider;
         this.useSubRanges = toUseSubRanges;
+        myReplicaSetCache = replicaSetCache;
+    }
+
+    /**
+     * Get the replica set cache used by this factory.
+     *
+     * @return The ReplicaSetCache instance.
+     */
+    public ReplicaSetCache getReplicaSetCache()
+    {
+        return myReplicaSetCache;
     }
 
     /**
@@ -131,7 +152,7 @@ public class VnodeRepairStateFactoryImpl implements VnodeRepairStateFactory
         for (Map.Entry<LongTokenRange, ImmutableSet<DriverNode>> entry : tokenRangeToReplicaMap.entrySet())
         {
             LongTokenRange longTokenRange = entry.getKey();
-            ImmutableSet<DriverNode> replicas = entry.getValue();
+            ImmutableSet<DriverNode> replicas = myReplicaSetCache.intern(entry.getValue());
             vnodeRepairStatesBase.add(new VnodeRepairState(longTokenRange, replicas, lastRepairedAt));
         }
 
@@ -154,7 +175,8 @@ public class VnodeRepairStateFactoryImpl implements VnodeRepairStateFactory
         {
             RepairEntry repairEntry = repairEntryIterator.next();
             LongTokenRange longTokenRange = repairEntry.getRange();
-            ImmutableSet<DriverNode> replicas = getReplicasForRange(longTokenRange, tokenRangeToReplicaMap);
+            ImmutableSet<DriverNode> rawReplicas = getReplicasForRange(longTokenRange, tokenRangeToReplicaMap);
+            ImmutableSet<DriverNode> replicas = rawReplicas != null ? myReplicaSetCache.intern(rawReplicas) : null;
 
             VnodeRepairState vnodeRepairState = new VnodeRepairState(longTokenRange,
                     replicas, repairEntry.getStartedAt(), repairEntry.getFinishedAt());

--- a/core.impl/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/TestNodeLifecycleHandler.java
+++ b/core.impl/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/TestNodeLifecycleHandler.java
@@ -18,9 +18,11 @@ import com.datastax.oss.driver.api.core.metadata.Node;
 import com.ericsson.bss.cassandra.ecchronos.connection.DistributedJmxConnectionProvider;
 import com.ericsson.bss.cassandra.ecchronos.connection.DistributedNativeConnectionProvider;
 import com.ericsson.bss.cassandra.ecchronos.core.impl.multithreads.NodeWorkerManager;
+import com.ericsson.bss.cassandra.ecchronos.core.impl.repair.vnode.ReplicaSetCache;
 import com.ericsson.bss.cassandra.ecchronos.core.repair.scheduler.ScheduleManager;
 import com.ericsson.bss.cassandra.ecchronos.core.state.LongTokenRange;
 import com.ericsson.bss.cassandra.ecchronos.data.sync.EccNodesSync;
+import com.google.common.collect.ImmutableSet;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -166,5 +168,37 @@ public class TestNodeLifecycleHandler
         handler.onRemove(mockNode);
 
         assertThat(LongTokenRange.cacheSize()).isEqualTo(0);
+    }
+
+    @Test
+    public void testOnAddClearsReplicaSetCache()
+    {
+        when(mockNativeProvider.confirmNodeValid(mockNode)).thenReturn(true);
+        ReplicaSetCache cache = new ReplicaSetCache();
+        cache.intern(ImmutableSet.of());
+        assertThat(cache.size()).isEqualTo(1);
+
+        NodeLifecycleHandler handlerWithCache = new NodeLifecycleHandler(mockEccNodesSync, mockJmxProvider,
+                mockNativeProvider, mockWorkerManager, mockScheduleManager, mockExecutor, cache);
+
+        handlerWithCache.onAdd(mockNode);
+
+        assertThat(cache.size()).isEqualTo(0);
+    }
+
+    @Test
+    public void testOnRemoveClearsReplicaSetCache()
+    {
+        when(mockNativeProvider.confirmNodeValid(mockNode)).thenReturn(true);
+        ReplicaSetCache cache = new ReplicaSetCache();
+        cache.intern(ImmutableSet.of());
+        assertThat(cache.size()).isEqualTo(1);
+
+        NodeLifecycleHandler handlerWithCache = new NodeLifecycleHandler(mockEccNodesSync, mockJmxProvider,
+                mockNativeProvider, mockWorkerManager, mockScheduleManager, mockExecutor, cache);
+
+        handlerWithCache.onRemove(mockNode);
+
+        assertThat(cache.size()).isEqualTo(0);
     }
 }

--- a/core.impl/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/vnode/TestReplicaSetCache.java
+++ b/core.impl/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/vnode/TestReplicaSetCache.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2026 Telefonaktiebolaget LM Ericsson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ericsson.bss.cassandra.ecchronos.core.impl.repair.vnode;
+
+import com.ericsson.bss.cassandra.ecchronos.core.metadata.DriverNode;
+import com.google.common.collect.ImmutableSet;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(MockitoJUnitRunner.class)
+public class TestReplicaSetCache
+{
+    @Mock
+    private DriverNode mockNode1;
+    @Mock
+    private DriverNode mockNode2;
+    @Mock
+    private DriverNode mockNode3;
+
+    private ReplicaSetCache cache;
+
+    @Before
+    public void setup()
+    {
+        cache = new ReplicaSetCache();
+    }
+
+    @Test
+    public void testInternReturnsSameInstance()
+    {
+        ImmutableSet<DriverNode> set1 = ImmutableSet.of(mockNode1, mockNode2);
+        ImmutableSet<DriverNode> set2 = ImmutableSet.of(mockNode1, mockNode2);
+
+        ImmutableSet<DriverNode> interned1 = cache.intern(set1);
+        ImmutableSet<DriverNode> interned2 = cache.intern(set2);
+
+        assertThat(interned1).isSameAs(interned2);
+    }
+
+    @Test
+    public void testDifferentSetsReturnDifferentInstances()
+    {
+        ImmutableSet<DriverNode> set1 = ImmutableSet.of(mockNode1, mockNode2);
+        ImmutableSet<DriverNode> set2 = ImmutableSet.of(mockNode1, mockNode3);
+
+        ImmutableSet<DriverNode> interned1 = cache.intern(set1);
+        ImmutableSet<DriverNode> interned2 = cache.intern(set2);
+
+        assertThat(interned1).isNotSameAs(interned2);
+    }
+
+    @Test
+    public void testCacheSizeMatchesUniqueEntries()
+    {
+        ImmutableSet<DriverNode> set1 = ImmutableSet.of(mockNode1, mockNode2);
+        ImmutableSet<DriverNode> set2 = ImmutableSet.of(mockNode2, mockNode3);
+
+        cache.intern(set1);
+        cache.intern(set1);
+        cache.intern(set2);
+        cache.intern(set2);
+
+        assertThat(cache.size()).isEqualTo(2);
+    }
+
+    @Test
+    public void testClearRemovesAllEntries()
+    {
+        cache.intern(ImmutableSet.of(mockNode1));
+        cache.intern(ImmutableSet.of(mockNode2));
+        assertThat(cache.size()).isEqualTo(2);
+
+        cache.clear();
+
+        assertThat(cache.size()).isEqualTo(0);
+    }
+
+    @Test
+    public void testClearAllowsNewInstancesAfterwards()
+    {
+        ImmutableSet<DriverNode> set = ImmutableSet.of(mockNode1, mockNode2);
+        ImmutableSet<DriverNode> first = cache.intern(set);
+
+        cache.clear();
+
+        ImmutableSet<DriverNode> second = cache.intern(ImmutableSet.of(mockNode1, mockNode2));
+        assertThat(second).isEqualTo(first);
+        assertThat(second).isNotSameAs(first);
+    }
+
+    @Test
+    public void testThreadSafety() throws Exception
+    {
+        int threadCount = 10;
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(1);
+        List<Future<ImmutableSet<DriverNode>>> futures = new ArrayList<>();
+
+        for (int i = 0; i < threadCount; i++)
+        {
+            futures.add(executor.submit(() ->
+            {
+                latch.await();
+                return cache.intern(ImmutableSet.of(mockNode1, mockNode2, mockNode3));
+            }));
+        }
+
+        latch.countDown();
+
+        ImmutableSet<DriverNode> expected = null;
+        for (Future<ImmutableSet<DriverNode>> future : futures)
+        {
+            ImmutableSet<DriverNode> result = future.get();
+            if (expected == null)
+            {
+                expected = result;
+            }
+            assertThat(result).isSameAs(expected);
+        }
+
+        assertThat(cache.size()).isEqualTo(1);
+        executor.shutdown();
+    }
+}


### PR DESCRIPTION
Closes #1581

- Add ReplicaSetCache using ConcurrentHashMap for interning ImmutableSet<DriverNode> instances
- Inject ReplicaSetCache into VnodeRepairStateFactoryImpl
- Clear cache on topology changes in NodeLifecycleHandler
- Wire shared cache through RepairStateFactoryImpl and DefaultRepairConfigurationProvider into the application
- Add unit tests for ReplicaSetCache and cache clearing