### PR TITLE
Avoid Repeated Gauge Registration in TableRepairMetricsImpl

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Version 1.0.0 (Not yet Released)
 
+* Avoid Repeated Gauge Registration in TableRepairMetricsImpl - Issue #1584
 * Implement ReplicaSet Interning for VnodeRepairState Instances - Issue #1581
 * Implement Flyweight Caching for LongTokenRange Instances - Issue #1580
 * Deprecate JMX Port Discover to use port field in ecc.yml - Issue #1578

--- a/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/metrics/TableRepairMetricsImpl.java
+++ b/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/metrics/TableRepairMetricsImpl.java
@@ -24,6 +24,7 @@ import io.micrometer.core.instrument.Timer;
 import java.io.Closeable;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 
@@ -56,11 +57,25 @@ public final class TableRepairMetricsImpl implements TableRepairMetrics, TableRe
     static Clock clock = () -> System.currentTimeMillis(); // NOPMD
 
     private final Map<TableReference, TableGauges> myTableGauges = new ConcurrentHashMap<>();
+    private final Set<TableReference> myRegisteredTables = ConcurrentHashMap.newKeySet();
     private final MeterRegistry myMeterRegistry;
 
     private TableRepairMetricsImpl(final Builder builder)
     {
         myMeterRegistry = Preconditions.checkNotNull(builder.myMeterRegistry, "Meter registry cannot be null");
+        // Register node-level aggregate gauges once at construction time
+        Gauge.builder(NODE_REPAIRED_RATIO, myTableGauges,
+                        tableGauges -> tableGauges.values().stream()
+                                .mapToDouble(TableGauges::getRepairRatio).average().orElse(0))
+                .register(myMeterRegistry);
+        TimeGauge.builder(NODE_TIME_SINCE_LAST_REPAIRED, myTableGauges, TimeUnit.MILLISECONDS,
+                        tableGauges -> clock.timeNow() - tableGauges.values().stream()
+                                .mapToDouble(TableGauges::getLastRepairedAt).min().orElse(0))
+                .register(myMeterRegistry);
+        TimeGauge.builder(NODE_REMAINING_REPAIR_TIME, myTableGauges, TimeUnit.MILLISECONDS,
+                        tableGauges -> tableGauges.values().stream()
+                                .mapToDouble(TableGauges::getRemainingRepairTime).sum())
+                .register(myMeterRegistry);
     }
 
     @Override
@@ -69,24 +84,18 @@ public final class TableRepairMetricsImpl implements TableRepairMetrics, TableRe
                             final int notRepairedRanges)
     {
         createOrGetTableGauges(tableReference).repairRatio(repairedRanges, notRepairedRanges);
-        Gauge.builder(REPAIRED_RATIO, myTableGauges,
-                        (tableGauges) -> tableGauges.get(tableReference).getRepairRatio())
-                .tags(KEYSPACE_TAG, tableReference.getKeyspace(), TABLE_TAG, tableReference.getTable())
-                .register(myMeterRegistry);
-        Gauge.builder(NODE_REPAIRED_RATIO, myTableGauges,
-                        (tableGauges) -> tableGauges.values().stream().mapToDouble(TableGauges::getRepairRatio)
-                                .average().orElse(0))
-                .register(myMeterRegistry);
+        registerTableGaugesIfAbsent(tableReference);
     }
 
     @Override
     public Optional<Double> getRepairRatio(final TableReference tableReference)
     {
-        if (myTableGauges.get(tableReference) == null)
+        TableGauges gauges = myTableGauges.get(tableReference);
+        if (gauges == null)
         {
             return Optional.empty();
         }
-        return Optional.ofNullable(myTableGauges.get(tableReference).getRepairRatio());
+        return Optional.ofNullable(gauges.getRepairRatio());
     }
 
     @Override
@@ -94,15 +103,7 @@ public final class TableRepairMetricsImpl implements TableRepairMetrics, TableRe
                                final long lastRepairedAt)
     {
         createOrGetTableGauges(tableReference).lastRepairedAt(lastRepairedAt);
-        TimeGauge.builder(TIME_SINCE_LAST_REPAIRED, myTableGauges, TimeUnit.MILLISECONDS,
-                        (tableGauges) -> clock.timeNow() - tableGauges.get(tableReference).getLastRepairedAt())
-                .tags(KEYSPACE_TAG, tableReference.getKeyspace(), TABLE_TAG, tableReference.getTable())
-                .register(myMeterRegistry);
-        TimeGauge.builder(NODE_TIME_SINCE_LAST_REPAIRED, myTableGauges, TimeUnit.MILLISECONDS,
-                        (tableGauges) ->
-                                clock.timeNow() - tableGauges.values().stream()
-                                        .mapToDouble(TableGauges::getLastRepairedAt).min().orElse(0))
-                .register(myMeterRegistry);
+        registerTableGaugesIfAbsent(tableReference);
     }
 
     @Override
@@ -110,14 +111,7 @@ public final class TableRepairMetricsImpl implements TableRepairMetrics, TableRe
                                     final long remainingRepairTime)
     {
         createOrGetTableGauges(tableReference).remainingRepairTime(remainingRepairTime);
-        TimeGauge.builder(REMAINING_REPAIR_TIME, myTableGauges, TimeUnit.MILLISECONDS,
-                        (tableGauges) -> tableGauges.get(tableReference).getRemainingRepairTime())
-                .tags(KEYSPACE_TAG, tableReference.getKeyspace(), TABLE_TAG, tableReference.getTable())
-                .register(myMeterRegistry);
-        TimeGauge.builder(NODE_REMAINING_REPAIR_TIME, myTableGauges, TimeUnit.MILLISECONDS,
-                        (tableGauges) ->
-                                tableGauges.values().stream().mapToDouble(TableGauges::getRemainingRepairTime).sum())
-                .register(myMeterRegistry);
+        registerTableGaugesIfAbsent(tableReference);
     }
 
     @Override
@@ -144,6 +138,41 @@ public final class TableRepairMetricsImpl implements TableRepairMetrics, TableRe
         for (TableGauges tableGauges : myTableGauges.values())
         {
             tableGauges.close();
+        }
+    }
+
+    /**
+     * Registers per-table gauges only once per table to avoid redundant allocations.
+     * Gauge lambdas are null-safe and return fallback values if the table is removed.
+     */
+    private void registerTableGaugesIfAbsent(final TableReference tableReference)
+    {
+        if (myRegisteredTables.add(tableReference))
+        {
+            Gauge.builder(REPAIRED_RATIO, myTableGauges,
+                            tableGauges ->
+                            {
+                                TableGauges g = tableGauges.get(tableReference);
+                                return g != null ? g.getRepairRatio() : 0.0;
+                            })
+                    .tags(KEYSPACE_TAG, tableReference.getKeyspace(), TABLE_TAG, tableReference.getTable())
+                    .register(myMeterRegistry);
+            TimeGauge.builder(TIME_SINCE_LAST_REPAIRED, myTableGauges, TimeUnit.MILLISECONDS,
+                            tableGauges ->
+                            {
+                                TableGauges g = tableGauges.get(tableReference);
+                                return g != null ? clock.timeNow() - g.getLastRepairedAt() : 0.0;
+                            })
+                    .tags(KEYSPACE_TAG, tableReference.getKeyspace(), TABLE_TAG, tableReference.getTable())
+                    .register(myMeterRegistry);
+            TimeGauge.builder(REMAINING_REPAIR_TIME, myTableGauges, TimeUnit.MILLISECONDS,
+                            tableGauges ->
+                            {
+                                TableGauges g = tableGauges.get(tableReference);
+                                return g != null ? g.getRemainingRepairTime() : 0.0;
+                            })
+                    .tags(KEYSPACE_TAG, tableReference.getKeyspace(), TABLE_TAG, tableReference.getTable())
+                    .register(myMeterRegistry);
         }
     }
 

--- a/core/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/metrics/TestMetricInspector.java
+++ b/core/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/metrics/TestMetricInspector.java
@@ -79,7 +79,7 @@ public class TestMetricInspector
         Level logLevel = logsList.get(0).getLevel();
         assertEquals("Total repair failures in node till now is: 2", logMessage);
         assertEquals(Level.DEBUG, logLevel);
-        assertEquals(1, count);
+        assertEquals(4, count);
     }
 
     @Test
@@ -110,7 +110,7 @@ public class TestMetricInspector
         Level logLevel = logsList.get(0).getLevel();
         assertEquals("Total repair failures in node till now is: 2", logMessage);
         assertEquals(Level.DEBUG, logLevel);
-        assertEquals(1, count);
+        assertEquals(4, count);
         assertEquals(2, myMetricInspector.getTotalRecordFailures());
         myMetricInspector.stopInspection();
     }

--- a/core/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/metrics/TestTableRepairMetricsImpl.java
+++ b/core/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/metrics/TestTableRepairMetricsImpl.java
@@ -531,4 +531,54 @@ public class TestTableRepairMetricsImpl
         assertThat(nodeFailedRepairSessions.max(TimeUnit.MILLISECONDS)).isEqualTo(failedRepairTimeTable1);
         assertThat(nodeFailedRepairSessions.mean(TimeUnit.MILLISECONDS)).isEqualTo(expectedNodeMeanFailedTime);
     }
+
+    @Test
+    public void testGaugeRegisteredOnlyOncePerTable()
+    {
+        TableReference tableReference = tableReference(TEST_KEYSPACE, TEST_TABLE1);
+
+        myTableRepairMetricsImpl.repairState(tableReference, 1, 0);
+        myTableRepairMetricsImpl.repairState(tableReference, 1, 1);
+        myTableRepairMetricsImpl.repairState(tableReference, 0, 1);
+
+        // Should still have exactly one gauge for this table
+        long gaugeCount = myMeterRegistry.getMeters().stream()
+                .filter(m -> m.getId().getName().equals(TableRepairMetricsImpl.REPAIRED_RATIO))
+                .filter(m -> TEST_TABLE1.equals(m.getId().getTag("table")))
+                .count();
+        assertThat(gaugeCount).isEqualTo(1);
+    }
+
+    @Test
+    public void testMetricValuesUpdateAfterSingleRegistration()
+    {
+        TableReference tableReference = tableReference(TEST_KEYSPACE, TEST_TABLE1);
+
+        myTableRepairMetricsImpl.repairState(tableReference, 1, 0);
+        Gauge gauge = myMeterRegistry.find(TableRepairMetricsImpl.REPAIRED_RATIO)
+                .tags("keyspace", TEST_KEYSPACE, "table", TEST_TABLE1)
+                .gauge();
+        assertThat(gauge).isNotNull();
+        assertThat(gauge.value()).isEqualTo(1.0);
+
+        // Update value — gauge should reflect new value without re-registration
+        myTableRepairMetricsImpl.repairState(tableReference, 1, 1);
+        assertThat(gauge.value()).isEqualTo(0.5);
+    }
+
+    @Test
+    public void testNodeGaugesRegisteredAtConstruction()
+    {
+        // NODE_* gauges should exist even before any table metrics are reported
+        Gauge nodeRatio = myMeterRegistry.find(TableRepairMetricsImpl.NODE_REPAIRED_RATIO).gauge();
+        assertThat(nodeRatio).isNotNull();
+        assertThat(nodeRatio.value()).isEqualTo(0.0);
+
+        Gauge nodeTime = myMeterRegistry.find(TableRepairMetricsImpl.NODE_TIME_SINCE_LAST_REPAIRED).gauge();
+        assertThat(nodeTime).isNotNull();
+
+        Gauge nodeRemaining = myMeterRegistry.find(TableRepairMetricsImpl.NODE_REMAINING_REPAIR_TIME).gauge();
+        assertThat(nodeRemaining).isNotNull();
+        assertThat(nodeRemaining.value()).isEqualTo(0.0);
+    }
 }


### PR DESCRIPTION
Closes #1584

- Register per-table gauges only once using ConcurrentHashMap.newKeySet()
- Move NODE_* aggregate gauges to constructor (registered once)
- Make gauge lambdas null-safe with fallback to 0.0
- Update TestMetricInspector expected log counts to reflect NODE_* gauges now existing at construction time