### PR TITLE
Bound SSL session cache to prevent unbounded SSLSessionImpl growth

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Version 1.0.0 (Not yet Released)
 
+* Bound SSL session cache to prevent unbounded SSLSessionImpl growth - Issue #1601
 * Fix HTTP Exchange Retention and Resource Leaks in JolokiaNotificationController - Issue #1583
 * Reduce Memory Footprint of VnodeRepairState - Issue #1586
 * Avoid Repeated Gauge Registration in TableRepairMetricsImpl - Issue #1584

--- a/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/jmx/JolokiaNotificationController.java
+++ b/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/jmx/JolokiaNotificationController.java
@@ -58,6 +58,8 @@ public class JolokiaNotificationController implements Closeable
     private static final int SHUTDOWN_TIMEOUT_SECONDS = 1;
     private static final int HTTP_TIMEOUT_SECONDS = 5;
     private static final int HTTP_REQUEST_TIMEOUT_SECONDS = 10;
+    private static final int SSL_SESSION_CACHE_SIZE = 50;
+    private static final int SSL_SESSION_TIMEOUT_SECONDS = 3600;
     private static final int MAX_RETRIES = 3;
     private static final long INITIAL_RETRY_DELAY_IN_MS = 500;
     private static final int MAX_CONSECUTIVE_FAILURES = 5;
@@ -114,6 +116,8 @@ public class JolokiaNotificationController implements Closeable
             SSLContext sslContext = myCertificateHandler.getSSLContext();
             if (sslContext != null)
             {
+                sslContext.getClientSessionContext().setSessionCacheSize(SSL_SESSION_CACHE_SIZE);
+                sslContext.getClientSessionContext().setSessionTimeout(SSL_SESSION_TIMEOUT_SECONDS);
                 builder.sslContext(sslContext);
             }
         }


### PR DESCRIPTION
Closes #1601

- Configure SSLSessionContext with cache size of 50 and 1-hour timeout on the shared HttpClient's SSLContext to prevent TLS session accumulation over time