### PR TITLE
ecctool run-repair now displays actual error message on failure

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Version 1.0.1 (Not yet Released)
 
+* ecctool run-repair now displays actual error message from REST API on failure - Issue #1603
 * Implement Lazy Repair State Updates in RepairStateImpl - Issue #1585
 * Bound SSL session cache to prevent unbounded SSLSessionImpl growth - Issue #1601
 * Fix HTTP Exchange Retention and Resource Leaks in JolokiaNotificationController - Issue #1583

--- a/ecchronos-binary/src/bin/ecctool.py
+++ b/ecchronos-binary/src/bin/ecctool.py
@@ -608,7 +608,12 @@ def run_repair(arguments):
     if result.is_successful():
         table_printer.print_repairs(result.data, columns=arguments.columns, output=arguments.output)
     else:
-        print("Repair Request Failed")
+        msg = "Repair Request Failed"
+        if result.message:
+            msg += ": " + result.message
+        if result.message and "disabled" in result.message:
+            msg += ". Use --forceRepairDisabled to force repair."
+        print(msg)
         sys.exit(1)
 
 

--- a/ecchronos-binary/src/pylib/ecchronoslib/rest.py
+++ b/ecchronos-binary/src/pylib/ecchronoslib/rest.py
@@ -98,8 +98,17 @@ class RestRequest(object):
             response.close()
             return RequestResult(status_code=response.getcode(), data=json_data)
         except HTTPError as e:
+            error_body = None
+            try:
+                error_body = e.read().decode("utf-8")
+                error_json = json.loads(error_body)
+                error_msg = error_json.get("message", error_body)
+            except (ValueError, UnicodeDecodeError, OSError):
+                error_msg = error_body
             return RequestResult(
-                status_code=e.code, message="Unable to retrieve resource {0}".format(request_url), exception=e
+                status_code=e.code,
+                message=error_msg or "Unable to retrieve resource {0}".format(request_url),
+                exception=e,
             )
         except URLError as e:
             return RequestResult(status_code=404, message="Unable to connect to {0}".format(request_url), exception=e)

--- a/ecchronos-binary/src/test/behave/ecc_step_library/common.py
+++ b/ecchronos-binary/src/test/behave/ecc_step_library/common.py
@@ -142,7 +142,8 @@ def step_validate_nodeid_error(context):
 
 @then("the output should contain a repair request failed message")
 def step_validate_repair_failed_error(context):
-    validate_nodeid_error(context.header, REPAIR_REQUEST_FAILED)
+    assert len(context.header) == 1, context.header
+    assert context.header[0].startswith(REPAIR_REQUEST_FAILED), context.header[0]
 
 
 @then("the output should contain a repair row for {keyspace}.{table} with type {repair_type}")


### PR DESCRIPTION
Preserve raw error body when JSON parsing fails in REST error handler, so ecctool displays the actual API error (e.g. 'Table ks.tb2 is disabled') instead of a generic message. Also narrows broad exception catch to (ValueError, UnicodeDecodeError, OSError) to fix pylint W0718.

Closes #1603 