### PR TITLE
Add -Xss512k to jvm.options to limit thread stack memory

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Version 1.0.1 (Not yet Released)
 
+* Add -Xss512k to jvm.options to limit thread stack memory - Issue #1608
 * ecctool run-repair now displays actual error message from REST API on failure - Issue #1603
 * Implement Lazy Repair State Updates in RepairStateImpl - Issue #1585
 * Bound SSL session cache to prevent unbounded SSLSessionImpl growth - Issue #1601

--- a/ecchronos-binary/src/resources/jvm.options
+++ b/ecchronos-binary/src/resources/jvm.options
@@ -43,3 +43,11 @@
 
 # Size of the heap for young generation.
 #-Xmn100M
+
+##################
+# STACK SETTINGS #
+##################
+
+# Thread stack size. Default is 1MB which is excessive for ecChronos workloads.
+# Reducing to 512k halves per-thread memory overhead in high-thread-count scenarios.
+-Xss512k


### PR DESCRIPTION
Reduces per-thread stack from 1MB default to 512k. Prevents container OOM kills in high-thread-count scenarios without affecting ecChronos workloads which have shallow call stacks.

Closes #1608 