### PR TITLE
Fix native memory leak: shut down RepairHangMonitor executor

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Version 1.0.1 (Not yet Released)
 
+* Fix native memory leak: replace per-task executor with shared pool in RepairHangMonitor - Issue #1611
 * Add -Xss512k to jvm.options to limit thread stack memory - Issue #1608
 * ecctool run-repair now displays actual error message from REST API on failure - Issue #1603
 * Implement Lazy Repair State Updates in RepairStateImpl - Issue #1585

--- a/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/RepairHangMonitor.java
+++ b/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/RepairHangMonitor.java
@@ -34,15 +34,22 @@ import java.util.concurrent.TimeUnit;
  * Monitors a running repair for hangs by periodically checking node status
  * and repair activity. Terminates the repair if the node is down, the repair
  * is no longer active, or the max wait time is exceeded.
+ *
+ * Uses a shared static executor to avoid per-task thread creation overhead
+ * and prevent native memory leaks from orphaned executor threads.
  */
 public class RepairHangMonitor
 {
     private static final Logger LOG = LoggerFactory.getLogger(RepairHangMonitor.class);
     private static final String NORMAL_STATUS = "NORMAL";
     private static final int DEFAULT_HEALTH_CHECK_INTERVAL_MINUTES = 1;
+    private static final int SHARED_POOL_SIZE = 2;
 
-    private final ScheduledExecutorService myExecutor = Executors.newSingleThreadScheduledExecutor(
-            new ThreadFactoryBuilder().setNameFormat("HangPreventingTask-%d").build());
+    private static final ScheduledExecutorService SHARED_EXECUTOR = Executors.newScheduledThreadPool(
+            SHARED_POOL_SIZE,
+            new ThreadFactoryBuilder().setNameFormat("HangPreventingTask-%d").setDaemon(true).build());
+
+    private final ScheduledExecutorService myExecutor;
     private final DistributedJmxProxyFactory myJmxProxyFactory;
     private final UUID myNodeID;
     private final TableReference myTableReference;
@@ -60,7 +67,7 @@ public class RepairHangMonitor
             final RepairNotificationHandler notificationHandler)
     {
         this(jmxProxyFactory, nodeID, tableReference, maxWaitTimeInMinutes, notificationHandler,
-                DEFAULT_HEALTH_CHECK_INTERVAL_MINUTES, TimeUnit.MINUTES);
+                DEFAULT_HEALTH_CHECK_INTERVAL_MINUTES, TimeUnit.MINUTES, SHARED_EXECUTOR);
     }
 
     @VisibleForTesting
@@ -72,6 +79,20 @@ public class RepairHangMonitor
             final long healthCheckInterval,
             final TimeUnit healthCheckTimeUnit)
     {
+        this(jmxProxyFactory, nodeID, tableReference, maxWaitTimeInMinutes, notificationHandler,
+                healthCheckInterval, healthCheckTimeUnit, SHARED_EXECUTOR);
+    }
+
+    @VisibleForTesting
+    RepairHangMonitor(final DistributedJmxProxyFactory jmxProxyFactory,
+            final UUID nodeID,
+            final TableReference tableReference,
+            final int maxWaitTimeInMinutes,
+            final RepairNotificationHandler notificationHandler,
+            final long healthCheckInterval,
+            final TimeUnit healthCheckTimeUnit,
+            final ScheduledExecutorService executor)
+    {
         myJmxProxyFactory = jmxProxyFactory;
         myNodeID = nodeID;
         myTableReference = tableReference;
@@ -79,6 +100,7 @@ public class RepairHangMonitor
         myNotificationHandler = notificationHandler;
         myHealthCheckInterval = healthCheckInterval;
         myHealthCheckTimeUnit = healthCheckTimeUnit;
+        myExecutor = executor;
     }
 
     /**
@@ -95,7 +117,7 @@ public class RepairHangMonitor
     }
 
     /**
-     * Cancel any pending checks.
+     * Cancel any pending checks. Since the executor is shared, only the future is cancelled.
      */
     public void cancel()
     {
@@ -103,14 +125,6 @@ public class RepairHangMonitor
         {
             myHangPreventFuture.cancel(false);
         }
-    }
-
-    /**
-     * Shut down the executor.
-     */
-    public void shutdown()
-    {
-        myExecutor.shutdownNow();
     }
 
     private final class HangPreventingTask implements Runnable

--- a/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/RepairTask.java
+++ b/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/RepairTask.java
@@ -244,7 +244,7 @@ public abstract class RepairTask
      */
     public void cleanup()
     {
-        myHangMonitor.shutdown();
+        myHangMonitor.cancel();
     }
 
     /**

--- a/core.impl/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/TestRepairHangMonitor.java
+++ b/core.impl/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/TestRepairHangMonitor.java
@@ -33,6 +33,8 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 import java.io.IOException;
 import java.util.UUID;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
 @RunWith(MockitoJUnitRunner.Silent.class)
@@ -56,19 +58,23 @@ public class TestRepairHangMonitor
 
     private RepairHangMonitor monitor;
 
+    private ScheduledExecutorService testExecutor;
+
     @Before
     public void setup() throws IOException
     {
         when(myJmxProxyFactory.connect()).thenReturn(myProxy);
         when(myNotificationHandler.getCommand()).thenReturn(COMMAND);
+        testExecutor = Executors.newSingleThreadScheduledExecutor();
         monitor = new RepairHangMonitor(myJmxProxyFactory, NODE_ID, myTableReference,
-                MAX_WAIT_MINUTES, myNotificationHandler, 1, TimeUnit.SECONDS);
+                MAX_WAIT_MINUTES, myNotificationHandler, 1, TimeUnit.SECONDS, testExecutor);
     }
 
     @After
     public void teardown()
     {
-        monitor.shutdown();
+        monitor.cancel();
+        testExecutor.shutdownNow();
     }
 
     @Test


### PR DESCRIPTION
Replace per-task ScheduledExecutorService with a shared static daemon
thread pool (size 2). Each RepairHangMonitor now only schedules/cancels
futures on the shared pool, eliminating per-task thread creation and
preventing native memory leaks from orphaned executor threads.

Previously each completed repair leaked one native thread (~80KB),
growing at ~5MB/hour (~120MB/day).

Closes #1611 