### PR TITLE
Add MaxMetaspaceSize and ReservedCodeCacheSize to jvm.options

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Version 1.0.1 (Not yet Released)
 
+* Add MaxMetaspaceSize and ReservedCodeCacheSize to jvm.options - Issue #1610
 * ecctool run-repair now displays actual error message from REST API on failure - Issue #1603
 * Implement Lazy Repair State Updates in RepairStateImpl - Issue #1585
 * Bound SSL session cache to prevent unbounded SSLSessionImpl growth - Issue #1601

--- a/ecchronos-binary/src/resources/jvm.options
+++ b/ecchronos-binary/src/resources/jvm.options
@@ -43,3 +43,15 @@
 
 # Size of the heap for young generation.
 #-Xmn100M
+
+###########################
+# NATIVE MEMORY SETTINGS #
+###########################
+
+# Cap metaspace to prevent classloader leaks from consuming unbounded native memory.
+# ecChronos loads ~5K classes; 128m provides generous headroom.
+-XX:MaxMetaspaceSize=128m
+
+# Cap JIT code cache. Default is 240MB which is excessive for ecChronos.
+# 64m is sufficient for the application's hot method set.
+-XX:ReservedCodeCacheSize=64m


### PR DESCRIPTION
- Add -XX:MaxMetaspaceSize=128m to cap metaspace
- Add -XX:ReservedCodeCacheSize=64m to reduce code cache from 240MB

Saves ~176MB reserved memory and prevents container OOM kills from classloader leaks or oversized code cache.

Closes #1610 