### PR TITLE
Set HttpClient keepalive timeout to 5s in jvm.options

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Version 1.0.1 (Not yet Released)
 
+* Set HttpClient keepalive timeout to 5s to prevent connection pool memory growth - Issue #1614
 * Add MaxMetaspaceSize and ReservedCodeCacheSize to jvm.options - Issue #1610
 * Fix native memory leak: replace per-task executor with shared pool in RepairHangMonitor - Issue #1611
 * Add -Xss512k to jvm.options to limit thread stack memory - Issue #1608

--- a/ecchronos-binary/src/resources/jvm.options
+++ b/ecchronos-binary/src/resources/jvm.options
@@ -63,3 +63,12 @@
 # Thread stack size. Default is 1MB which is excessive for ecChronos workloads.
 # Reducing to 512k halves per-thread memory overhead in high-thread-count scenarios.
 -Xss512k
+
+##############################
+# HTTP CLIENT POOL SETTINGS #
+##############################
+
+# Evict idle HTTP connections after 5 seconds. Default is 1200s (20 minutes)
+# which causes completed exchange objects to be retained on pooled connections,
+# leading to steady memory growth.
+-Djdk.httpclient.keepalive.timeout=5


### PR DESCRIPTION
Add -Djdk.httpclient.keepalive.timeout=5 to evict idle HTTP connections after 5 seconds. Default of 1200s causes completed exchange objects to be retained on pooled connections, leading to steady memory growth. Setting in jvm.options ensures it applies before any HttpClient is created.

Closes #1614 