### PR TITLE
Fix RepairStateSnapshot retention by in-flight repair tasks

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Version 1.0.1 (Not yet Released)
 
+* Fix RepairStateSnapshot retention by decoupling RepairGroup from snapshot object graph - Issue #1616
 * Set HttpClient keepalive timeout to 5s to prevent connection pool memory growth - Issue #1614
 * Add MaxMetaspaceSize and ReservedCodeCacheSize to jvm.options - Issue #1610
 * Fix native memory leak: replace per-task executor with shared pool in RepairHangMonitor - Issue #1611

--- a/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/RepairGroup.java
+++ b/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/RepairGroup.java
@@ -89,8 +89,8 @@ public class RepairGroup extends ScheduledTask
 
         myRepairConfiguration = Preconditions
                 .checkNotNull(builder.myRepairConfiguration, "Repair configuration must be set");
-        myReplicaRepairGroup = Preconditions
-                .checkNotNull(builder.myReplicaRepairGroup, "Replica repair group must be set");
+        myReplicaRepairGroup = copyReplicaRepairGroup(Preconditions
+                .checkNotNull(builder.myReplicaRepairGroup, "Replica repair group must be set"));
         myJmxProxyFactory = Preconditions
                 .checkNotNull(builder.myJmxProxyFactory, "Jmx proxy factory must be set");
         myTableRepairMetrics = Preconditions
@@ -265,6 +265,14 @@ public class RepairGroup extends ScheduledTask
             }
         }
         return allowedParticipants;
+    }
+
+    private static ReplicaRepairGroup copyReplicaRepairGroup(final ReplicaRepairGroup original)
+    {
+        return new ReplicaRepairGroup(
+                original.replicas() != null ? new HashSet<>(original.replicas()) : null,
+                original.vnodes() != null ? new ArrayList<>(original.vnodes()) : null,
+                original.lastCompletedAt());
     }
 
     /**


### PR DESCRIPTION
Create a defensive copy of ReplicaRepairGroup when constructing RepairGroup, breaking the reference chain from in-flight tasks back to the snapshot's ImmutableList. This allows old RepairStateSnapshot objects to be GC'd immediately when replaced, instead of being pinned until all repair tasks referencing their members complete.

Frees ~80MB of retained heap (VnodeRepairState + LongTokenRange).

Closes #1616 