### PR TITLE
Allow One Time Lock Acquisition per Job

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Version 1.0.1 (Not yet Released)
 
+* Implement Batched Lock Acquisition Strategy to Improve Repair Throughput in Large Clusters - Issue #1618
 * Fix RepairStateSnapshot retention by decoupling RepairGroup from snapshot object graph - Issue #1616
 * Set HttpClient keepalive timeout to 5s to prevent connection pool memory growth - Issue #1614
 * Add MaxMetaspaceSize and ReservedCodeCacheSize to jvm.options - Issue #1610

--- a/application/src/main/java/com/ericsson/bss/cassandra/ecchronos/application/config/scheduler/SchedulerConfig.java
+++ b/application/src/main/java/com/ericsson/bss/cassandra/ecchronos/application/config/scheduler/SchedulerConfig.java
@@ -22,8 +22,12 @@ import java.util.concurrent.TimeUnit;
 public class SchedulerConfig
 {
     private static final int THIRTY_SECONDS = 30;
+    private static final int DEFAULT_SESSION_WINDOW_SECONDS = 300;
+    private static final int DEFAULT_COOLDOWN_SECONDS = 0;
 
     private Interval myFrequency = new Interval(THIRTY_SECONDS, TimeUnit.SECONDS);
+    private Interval mySessionWindow = new Interval(DEFAULT_SESSION_WINDOW_SECONDS, TimeUnit.SECONDS);
+    private Interval myCooldown = new Interval(DEFAULT_COOLDOWN_SECONDS, TimeUnit.SECONDS);
 
     @JsonProperty("frequency")
     public final Interval getFrequency()
@@ -35,5 +39,29 @@ public class SchedulerConfig
     public final void setFrequency(final Interval frequency)
     {
         myFrequency = frequency;
+    }
+
+    @JsonProperty("session_window")
+    public final Interval getSessionWindow()
+    {
+        return mySessionWindow;
+    }
+
+    @JsonProperty("session_window")
+    public final void setSessionWindow(final Interval sessionWindow)
+    {
+        mySessionWindow = sessionWindow;
+    }
+
+    @JsonProperty("cooldown")
+    public final Interval getCooldown()
+    {
+        return myCooldown;
+    }
+
+    @JsonProperty("cooldown")
+    public final void setCooldown(final Interval cooldown)
+    {
+        myCooldown = cooldown;
     }
 }

--- a/application/src/main/java/com/ericsson/bss/cassandra/ecchronos/application/spring/ECChronosInternals.java
+++ b/application/src/main/java/com/ericsson/bss/cassandra/ecchronos/application/spring/ECChronosInternals.java
@@ -151,6 +151,10 @@ public class ECChronosInternals implements Closeable
         myScheduleManagerImpl = ScheduleManagerImpl.builder()
                 .withRunInterval(configuration.getSchedulerConfig().getFrequency().getInterval(TimeUnit.MILLISECONDS),
                         TimeUnit.MILLISECONDS)
+                .withSessionWindow(configuration.getSchedulerConfig().getSessionWindow().getInterval(TimeUnit.MILLISECONDS),
+                        TimeUnit.MILLISECONDS)
+                .withCooldown(configuration.getSchedulerConfig().getCooldown().getInterval(TimeUnit.MILLISECONDS),
+                        TimeUnit.MILLISECONDS)
                 .withNodeIDList(jmxConnectionProvider.getJmxConnections().keySet())
                 .withNativeConnectionProvider(nativeConnectionProvider)
                 .withLockFactory(myLockFactory)

--- a/application/src/main/resources/ecc.yml
+++ b/application/src/main/resources/ecc.yml
@@ -460,6 +460,27 @@ scheduler:
   frequency:
     time: 30
     unit: SECONDS
+  ##
+  ## Specifies the time window for batched lock sessions.
+  ## When a node acquires a distributed lock, it holds it for this duration
+  ## and executes multiple repair tasks within the window before releasing.
+  ## This reduces lock acquisition overhead significantly in large clusters.
+  ## Default: 5 minutes.
+  ##
+  session_window:
+    time: 5
+    unit: MINUTES
+  ##
+  ## Specifies the cooldown period after a batched session completes.
+  ## After releasing the lock, the node waits this duration before attempting
+  ## to acquire a new lock, allowing other nodes fair access.
+  ## Set to 0 to disable cooldown (nodes compete immediately).
+  ## Only configure if metrics show some nodes consistently failing to acquire locks.
+  ## Default: 0 (disabled).
+  ##
+  cooldown:
+    time: 0
+    unit: SECONDS
 
 rest_server:
   ##

--- a/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/RepairGroup.java
+++ b/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/RepairGroup.java
@@ -186,10 +186,7 @@ public class RepairGroup extends ScheduledTask
     @Override
     public LockFactory.DistributedLock getLock(final LockFactory lockFactory, final UUID nodeId) throws LockException
     {
-        Map<String, String> metadata = new HashMap<>();
-        metadata.put(LOCK_METADATA_KEYSPACE, myTableReference.getKeyspace());
-        metadata.put(LOCK_METADATA_TABLE, myTableReference.getTable());
-
+        Map<String, String> metadata = getLockMetadata();
         Set<RepairResource> repairResources = getRepairResources();
         return myRepairLockFactory.getLock(lockFactory, repairResources, metadata, myPriority, nodeId);
     }
@@ -202,6 +199,19 @@ public class RepairGroup extends ScheduledTask
     {
         return myRepairResourceFactory.getRepairResources(myReplicaRepairGroup);
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Map<String, String> getLockMetadata()
+    {
+        Map<String, String> metadata = new HashMap<>();
+        metadata.put(LOCK_METADATA_KEYSPACE, myTableReference.getKeyspace());
+        metadata.put(LOCK_METADATA_TABLE, myTableReference.getTable());
+        return metadata;
+    }
+
     /**
      * String representation.
      *

--- a/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/RepairGroup.java
+++ b/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/RepairGroup.java
@@ -190,8 +190,17 @@ public class RepairGroup extends ScheduledTask
         metadata.put(LOCK_METADATA_KEYSPACE, myTableReference.getKeyspace());
         metadata.put(LOCK_METADATA_TABLE, myTableReference.getTable());
 
-        Set<RepairResource> repairResources = myRepairResourceFactory.getRepairResources(myReplicaRepairGroup);
+        Set<RepairResource> repairResources = getRepairResources();
         return myRepairLockFactory.getLock(lockFactory, repairResources, metadata, myPriority, nodeId);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Set<RepairResource> getRepairResources()
+    {
+        return myRepairResourceFactory.getRepairResources(myReplicaRepairGroup);
     }
     /**
      * String representation.

--- a/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/scheduler/ScheduleManagerImpl.java
+++ b/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/scheduler/ScheduleManagerImpl.java
@@ -17,14 +17,13 @@ package com.ericsson.bss.cassandra.ecchronos.core.impl.repair.scheduler;
 import com.datastax.oss.driver.api.core.metadata.Node;
 import com.ericsson.bss.cassandra.ecchronos.connection.DistributedNativeConnectionProvider;
 import com.ericsson.bss.cassandra.ecchronos.core.impl.locks.CASLockFactory;
-import com.ericsson.bss.cassandra.ecchronos.core.locks.LockFactory;
+import com.ericsson.bss.cassandra.ecchronos.utils.exceptions.LockException;
 import com.ericsson.bss.cassandra.ecchronos.core.repair.scheduler.RunPolicy;
 import com.ericsson.bss.cassandra.ecchronos.core.repair.scheduler.ScheduleManager;
 import com.ericsson.bss.cassandra.ecchronos.core.repair.scheduler.ScheduledJob;
 import com.ericsson.bss.cassandra.ecchronos.core.repair.scheduler.ScheduledTask;
 import java.io.Closeable;
 import java.util.Collection;
-import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
@@ -234,7 +233,7 @@ public final class ScheduleManagerImpl implements ScheduleManager, Closeable
     @VisibleForTesting
     public void run(final UUID nodeID)
     {
-        myRunTasks.get(nodeID).run();
+        myRunTasks.get(nodeID).runOnce();
     }
 
     /**
@@ -285,6 +284,12 @@ public final class ScheduleManagerImpl implements ScheduleManager, Closeable
         @Override
         public void run()
         {
+            boolean hadWork = runOnce();
+            reschedule(hadWork);
+        }
+
+        private boolean runOnce()
+        {
             boolean hadWork = false;
             try
             {
@@ -292,7 +297,7 @@ public final class ScheduleManagerImpl implements ScheduleManager, Closeable
                 if (System.currentTimeMillis() < myCooldownUntil)
                 {
                     LOG.debug("Node {} in cooldown until {}", nodeID, myCooldownUntil);
-                    return;
+                    return false;
                 }
                 if (myQueue.get(nodeID) != null)
                 {
@@ -307,10 +312,7 @@ public final class ScheduleManagerImpl implements ScheduleManager, Closeable
             {
                 LOG.error("Exception while running job in node {}", nodeID, e);
             }
-            finally
-            {
-                reschedule(hadWork);
-            }
+            return hadWork;
         }
 
         private void reschedule(final boolean hadWork)
@@ -362,11 +364,8 @@ public final class ScheduleManagerImpl implements ScheduleManager, Closeable
                 if (validate(next))
                 {
                     currentExecutingJobs.put(nodeID, next);
-                    if (tryRunBatchedSession(next))
-                    {
-                        hadWork = true;
-                        break;
-                    }
+                    hadWork = runSession(next);
+                    break;
                 }
             }
             currentExecutingJobs.remove(nodeID);
@@ -387,84 +386,93 @@ public final class ScheduleManagerImpl implements ScheduleManager, Closeable
             return true;
         }
 
-        private boolean tryRunBatchedSession(final ScheduledJob firstJob)
-        {
-            Iterator<ScheduledTask> taskIterator = firstJob.iterator();
-            if (!taskIterator.hasNext())
-            {
-                return false;
-            }
-
-            ScheduledTask firstTask = taskIterator.next();
-            try (LockFactory.DistributedLock sessionLock = firstTask.getLock(myLockFactory, nodeID))
-            {
-                LOG.debug("Lock acquired for batched session on node {} with lock {}", nodeID, sessionLock);
-                return executeBatchedSession(firstJob, firstTask, taskIterator);
-            }
-            catch (RuntimeMBeanException e)
-            {
-                handleLockFailure(firstJob, e);
-                return false;
-            }
-            catch (Exception e)
-            {
-                handleLockFailure(firstJob, e);
-                return false;
-            }
-        }
-
-        private boolean executeBatchedSession(
-                final ScheduledJob firstJob,
-                final ScheduledTask firstTask,
-                final Iterator<ScheduledTask> taskIterator)
+        private boolean runSession(final ScheduledJob firstJob)
         {
             long sessionStart = System.currentTimeMillis();
-            LOG.info("Batched session started for node {}, window={}ms", nodeID, mySessionWindowInMs);
+            LOG.info("Session started for node {}, window={}ms", nodeID, mySessionWindowInMs);
+            int tasksExecuted;
 
-            int tasksExecuted = executeFirstJob(firstJob, firstTask, taskIterator, sessionStart);
-
-            if (withinSessionWindow(sessionStart))
+            try (SessionLockPool lockPool = new SessionLockPool(myLockFactory, nodeID))
             {
-                tasksExecuted += runRemainingJobsInSession(sessionStart, firstJob);
-            }
+                tasksExecuted = executeJobTasks(firstJob, sessionStart, lockPool);
 
-            long elapsed = System.currentTimeMillis() - sessionStart;
-            LOG.info("Batched session ended for node {}, executed {} tasks in {}ms",
-                    nodeID, tasksExecuted, elapsed);
-            applyCooldown(tasksExecuted);
-            return true;
-        }
-
-        private int executeFirstJob(
-                final ScheduledJob job,
-                final ScheduledTask firstTask,
-                final Iterator<ScheduledTask> taskIterator,
-                final long sessionStart)
-        {
-            int tasksExecuted = 0;
-            if (runTask(firstTask, 1))
-            {
-                job.postExecute(true, firstTask);
-                tasksExecuted++;
-            }
-            else
-            {
-                job.postExecute(false, firstTask);
-            }
-
-            int index = 1;
-            while (taskIterator.hasNext() && withinSessionWindow(sessionStart))
-            {
-                index++;
-                ScheduledTask task = taskIterator.next();
-                boolean successful = runTask(task, index);
-                job.postExecute(successful, task);
-                if (successful)
+                if (withinSessionWindow(sessionStart))
                 {
-                    tasksExecuted++;
+                    tasksExecuted += runRemainingJobsInSession(sessionStart, firstJob, lockPool);
                 }
             }
 
+            LOG.info("Session ended for node {}, executed {} tasks in {}ms",
+                    nodeID, tasksExecuted, System.currentTimeMillis() - sessionStart);
+            applyCooldown(tasksExecuted);
+            return tasksExecuted > 0;
+        }
+
+        private int runRemainingJobsInSession(
+                final long sessionStart,
+                final ScheduledJob excludeJob,
+                final SessionLockPool lockPool)
+        {
+            int tasksExecuted = 0;
+            for (ScheduledJob job : myQueue.get(nodeID))
+            {
+                if (!withinSessionWindow(sessionStart))
+                {
+                    break;
+                }
+                if (shouldSkipJob(job, excludeJob))
+                {
+                    continue;
+                }
+                currentExecutingJobs.put(nodeID, job);
+                tasksExecuted += executeJobTasks(job, sessionStart, lockPool);
+            }
+            return tasksExecuted;
+        }
+
+        private boolean shouldSkipJob(final ScheduledJob job, final ScheduledJob excludeJob)
+        {
+            if (job == excludeJob)
+            {
+                return true;
+            }
+            Long backoffUntil = myContentionBackoff.get(job);
+            if (backoffUntil != null && System.currentTimeMillis() < backoffUntil)
+            {
+                return true;
+            }
+            return !validate(job);
+        }
+
+        private int executeJobTasks(
+                final ScheduledJob job,
+                final long sessionStart,
+                final SessionLockPool lockPool)
+        {
+            int tasksExecuted = 0;
+            int index = 0;
+            for (ScheduledTask task : job)
+            {
+                if (!withinSessionWindow(sessionStart))
+                {
+                    break;
+                }
+                index++;
+                try
+                {
+                    lockPool.acquireForTask(task);
+                    boolean successful = runTask(task, index);
+                    job.postExecute(successful, task);
+                    if (successful)
+                    {
+                        tasksExecuted++;
+                    }
+                }
+                catch (Exception e)
+                {
+                    handleLockFailure(job, e);
+                }
+            }
             if (tasksExecuted > 0)
             {
                 job.refreshState();
@@ -481,64 +489,6 @@ public final class ScheduleManagerImpl implements ScheduleManager, Closeable
             }
         }
 
-        private int runRemainingJobsInSession(final long sessionStart, final ScheduledJob excludeJob)
-        {
-            int tasksExecuted = 0;
-            for (ScheduledJob job : myQueue.get(nodeID))
-            {
-                if (!withinSessionWindow(sessionStart))
-                {
-                    break;
-                }
-                if (shouldSkipJob(job, excludeJob))
-                {
-                    continue;
-                }
-                currentExecutingJobs.put(nodeID, job);
-                tasksExecuted += executeJobTasks(job, sessionStart);
-            }
-            return tasksExecuted;
-        }
-
-        private boolean shouldSkipJob(final ScheduledJob job, final ScheduledJob excludeJob)
-        {
-            if (job.equals(excludeJob))
-            {
-                return true;
-            }
-            Long backoffUntil = myContentionBackoff.get(job);
-            if (backoffUntil != null && System.currentTimeMillis() < backoffUntil)
-            {
-                return true;
-            }
-            return !validate(job);
-        }
-
-        private int executeJobTasks(final ScheduledJob job, final long sessionStart)
-        {
-            int tasksExecuted = 0;
-            int index = 0;
-            for (ScheduledTask task : job)
-            {
-                if (!withinSessionWindow(sessionStart))
-                {
-                    break;
-                }
-                index++;
-                boolean successful = runTask(task, index);
-                job.postExecute(successful, task);
-                if (successful)
-                {
-                    tasksExecuted++;
-                }
-            }
-            if (tasksExecuted > 0)
-            {
-                job.refreshState();
-            }
-            return tasksExecuted;
-        }
-
         private boolean withinSessionWindow(final long sessionStart)
         {
             return (System.currentTimeMillis() - sessionStart) < mySessionWindowInMs;
@@ -546,9 +496,8 @@ public final class ScheduleManagerImpl implements ScheduleManager, Closeable
 
         private void handleLockFailure(final ScheduledJob job, final Exception e)
         {
-            if (e instanceof RuntimeMBeanException)
+            if (e instanceof RuntimeMBeanException rme)
             {
-                RuntimeMBeanException rme = (RuntimeMBeanException) e;
                 if (rme.getCause() instanceof IllegalStateException
                         && rme.getCause().getMessage() != null
                         && rme.getCause().getMessage().contains("More than one key found"))
@@ -561,13 +510,13 @@ public final class ScheduleManagerImpl implements ScheduleManager, Closeable
                     LOG.warn("Unable to get schedule lock on job {} in node {}", job, nodeID, e);
                 }
             }
-            else if (e.getCause() != null)
+            else if (e instanceof LockException)
             {
-                LOG.warn("Unable to get schedule lock on job {} in node {}", job, nodeID, e);
+                LOG.debug("Lock contention for job {} in node {}: {}", job, nodeID, e.getMessage());
             }
             else
             {
-                LOG.debug("Lock contention for job {} in node {}", job, nodeID, e);
+                LOG.warn("Unable to get schedule lock on job {} in node {}", job, nodeID, e);
             }
             long backoff = ThreadLocalRandom.current().nextLong(
                     myRunIntervalInMs / 2, myRunIntervalInMs);

--- a/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/scheduler/ScheduleManagerImpl.java
+++ b/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/scheduler/ScheduleManagerImpl.java
@@ -24,6 +24,7 @@ import com.ericsson.bss.cassandra.ecchronos.core.repair.scheduler.ScheduledJob;
 import com.ericsson.bss.cassandra.ecchronos.core.repair.scheduler.ScheduledTask;
 import java.io.Closeable;
 import java.util.Collection;
+import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
@@ -64,6 +65,8 @@ public final class ScheduleManagerImpl implements ScheduleManager, Closeable
 
     private final ScheduledThreadPoolExecutor myExecutor;
     private final long myRunIntervalInMs;
+    private final long mySessionWindowInMs;
+    private final long myCooldownInMs;
 
     private ScheduleManagerImpl(final Builder builder)
     {
@@ -75,6 +78,8 @@ public final class ScheduleManagerImpl implements ScheduleManager, Closeable
         myExecutor.allowCoreThreadTimeOut(true);
         myLockFactory = builder.myLockFactory;
         myRunIntervalInMs = builder.myRunIntervalInMs;
+        mySessionWindowInMs = builder.mySessionWindowInMs;
+        myCooldownInMs = builder.myCooldownInMs;
     }
 
     /**
@@ -106,8 +111,7 @@ public final class ScheduleManagerImpl implements ScheduleManager, Closeable
             {
                 myExecutor.setCorePoolSize(requiredSize);
             }
-            ScheduledFuture<?> scheduledFuture = myExecutor.scheduleWithFixedDelay(runTask,
-                    myRunIntervalInMs,
+            ScheduledFuture<?> scheduledFuture = myExecutor.schedule(runTask,
                     myRunIntervalInMs,
                     TimeUnit.MILLISECONDS);
             myRunFuture.put(id, scheduledFuture);
@@ -268,9 +272,9 @@ public final class ScheduleManagerImpl implements ScheduleManager, Closeable
      */
     private final class JobRunTask implements Runnable
     {
-        public static final int JITTER_NUMBER = 2;
         private final UUID nodeID;
         private final Node myNode;
+        private volatile long myCooldownUntil = 0;
 
         private JobRunTask(final UUID currentNodeID)
         {
@@ -281,29 +285,65 @@ public final class ScheduleManagerImpl implements ScheduleManager, Closeable
         @Override
         public void run()
         {
+            boolean hadWork = false;
             try
             {
                 LOG.debug("In JobRunTask.run for Node {}", nodeID);
+                if (System.currentTimeMillis() < myCooldownUntil)
+                {
+                    LOG.debug("Node {} in cooldown until {}", nodeID, myCooldownUntil);
+                    return;
+                }
                 if (myQueue.get(nodeID) != null)
                 {
-                    tryRunNext();
+                    hadWork = tryRunNext();
                 }
                 else
                 {
                     LOG.info("There is no ScheduledJob for this node {} to run ", nodeID);
                 }
-
             }
             catch (Exception e)
             {
                 LOG.error("Exception while running job in node {}", nodeID, e);
             }
+            finally
+            {
+                reschedule(hadWork);
+            }
         }
 
-        private void tryRunNext()
+        private void reschedule(final boolean hadWork)
+        {
+            long delay;
+            if (System.currentTimeMillis() < myCooldownUntil)
+            {
+                delay = myCooldownUntil - System.currentTimeMillis();
+            }
+            else if (hadWork)
+            {
+                delay = TimeUnit.SECONDS.toMillis(1);
+            }
+            else
+            {
+                delay = myRunIntervalInMs;
+            }
+            try
+            {
+                ScheduledFuture<?> future = myExecutor.schedule(this, delay, TimeUnit.MILLISECONDS);
+                myRunFuture.put(nodeID, future);
+            }
+            catch (java.util.concurrent.RejectedExecutionException e)
+            {
+                LOG.debug("Scheduler shutting down, not rescheduling for node {}", nodeID);
+            }
+        }
+
+        private boolean tryRunNext()
         {
             LOG.debug("Looking for Job for Node {}", nodeID);
             long tickStart = System.currentTimeMillis();
+            boolean hadWork = false;
             for (ScheduledJob next : myQueue.get(nodeID))
             {
                 if (System.currentTimeMillis() - tickStart > myRunIntervalInMs)
@@ -322,10 +362,15 @@ public final class ScheduleManagerImpl implements ScheduleManager, Closeable
                 if (validate(next))
                 {
                     currentExecutingJobs.put(nodeID, next);
-                    tryRunTasks(next, tickStart);
+                    if (tryRunBatchedSession(next, tickStart))
+                    {
+                        hadWork = true;
+                        break;
+                    }
                 }
             }
             currentExecutingJobs.remove(nodeID);
+            return hadWork;
         }
 
         private boolean validate(final ScheduledJob job)
@@ -342,73 +387,172 @@ public final class ScheduleManagerImpl implements ScheduleManager, Closeable
             return true;
         }
 
-        private boolean tryRunTasks(final ScheduledJob next, final long tickStart)
+        private boolean tryRunBatchedSession(final ScheduledJob firstJob, final long tickStart)
         {
-            boolean hasRun = false;
-
-            LOG.info("Starting repair of {} for node {}", next, nodeID);
-
-            int index = 0;
-            for (ScheduledTask task : next)
+            // Try to acquire lock using the first task of the first job
+            Iterator<ScheduledTask> taskIterator = firstJob.iterator();
+            if (!taskIterator.hasNext())
             {
-                if (System.currentTimeMillis() - tickStart > myRunIntervalInMs)
-                {
-                    break;
-                }
-                index++;
-                hasRun |= tryRunTask(next, task, index);
+                return false;
             }
 
-            if (hasRun)
+            ScheduledTask firstTask = taskIterator.next();
+            LockFactory.DistributedLock sessionLock;
+            try
             {
-                next.refreshState();
-                LOG.info("Completed repair of {} for node {}", next, nodeID);
-            }
-
-            return hasRun;
-        }
-
-        private boolean tryRunTask(
-                final ScheduledJob job,
-                final ScheduledTask task,
-                final int index)
-        {
-            LOG.debug("Trying to run task {} in node {}", task, nodeID);
-            LOG.debug("Trying to acquire lock for {}", task);
-            try (LockFactory.DistributedLock lock = task.getLock(myLockFactory, nodeID))
-            {
-                LOG.debug("Lock has been acquired on node with Id {} with lock {}", nodeID, lock);
-                boolean successful = runTask(task, index);
-                job.postExecute(successful, task);
-                return true;
+                sessionLock = firstTask.getLock(myLockFactory, nodeID);
             }
             catch (RuntimeMBeanException e)
             {
-                if (e.getCause() instanceof IllegalStateException
-                        && e.getCause().getMessage() != null
-                        && e.getCause().getMessage().contains("More than one key found"))
-                {
-                    LOG.debug("Unable to get schedule lock on task {} in node {}, this is probably due to "
-                            + "a connection to a version of the Jolokia Agent 2.3.0 or older", task, nodeID, e);
-                }
-                else
-                {
-                    LOG.warn("Unable to get schedule lock on task {} in node {}", task, nodeID, e);
-                }
-                myContentionBackoff.put(job, System.currentTimeMillis()
-                        + ThreadLocalRandom.current().nextLong(myRunIntervalInMs, myRunIntervalInMs * JITTER_NUMBER));
+                handleLockFailure(firstJob, e);
                 return false;
             }
             catch (Exception e)
             {
-                if (e.getCause() != null)
-                {
-                    LOG.warn("Unable to get schedule lock on task {} in node {}", task, nodeID, e);
-                }
-                myContentionBackoff.put(job, System.currentTimeMillis()
-                        + ThreadLocalRandom.current().nextLong(myRunIntervalInMs, myRunIntervalInMs * JITTER_NUMBER));
+                handleLockFailure(firstJob, e);
                 return false;
             }
+
+            // Lock acquired - run batched session
+            long sessionStart = System.currentTimeMillis();
+            int tasksExecuted = 0;
+            try
+            {
+                LOG.info("Batched session started for node {}, window={}ms", nodeID, mySessionWindowInMs);
+
+                // Execute the first task (lock already acquired for it)
+                if (runTask(firstTask, 1))
+                {
+                    firstJob.postExecute(true, firstTask);
+                    tasksExecuted++;
+                }
+                else
+                {
+                    firstJob.postExecute(false, firstTask);
+                }
+
+                // Continue with remaining tasks of the first job
+                int index = 1;
+                while (taskIterator.hasNext() && withinSessionWindow(sessionStart))
+                {
+                    index++;
+                    ScheduledTask task = taskIterator.next();
+                    boolean successful = runTask(task, index);
+                    firstJob.postExecute(successful, task);
+                    if (successful)
+                    {
+                        tasksExecuted++;
+                    }
+                }
+
+                if (tasksExecuted > 0)
+                {
+                    firstJob.refreshState();
+                }
+
+                // Continue with other jobs while within session window
+                if (withinSessionWindow(sessionStart))
+                {
+                    tasksExecuted += runRemainingJobsInSession(sessionStart, firstJob);
+                }
+            }
+            finally
+            {
+                sessionLock.close();
+                long elapsed = System.currentTimeMillis() - sessionStart;
+                LOG.info("Batched session ended for node {}, executed {} tasks in {}ms",
+                        nodeID, tasksExecuted, elapsed);
+
+                if (tasksExecuted > 0 && myCooldownInMs > 0)
+                {
+                    myCooldownUntil = System.currentTimeMillis() + myCooldownInMs;
+                    LOG.debug("Node {} entering cooldown for {}ms", nodeID, myCooldownInMs);
+                }
+            }
+            return true;
+        }
+
+        private int runRemainingJobsInSession(final long sessionStart, final ScheduledJob excludeJob)
+        {
+            int tasksExecuted = 0;
+            for (ScheduledJob job : myQueue.get(nodeID))
+            {
+                if (!withinSessionWindow(sessionStart))
+                {
+                    break;
+                }
+                if (job.equals(excludeJob))
+                {
+                    continue;
+                }
+                Long backoffUntil = myContentionBackoff.get(job);
+                if (backoffUntil != null && System.currentTimeMillis() < backoffUntil)
+                {
+                    continue;
+                }
+                if (!validate(job))
+                {
+                    continue;
+                }
+                currentExecutingJobs.put(nodeID, job);
+                int index = 0;
+                boolean jobHadWork = false;
+                for (ScheduledTask task : job)
+                {
+                    if (!withinSessionWindow(sessionStart))
+                    {
+                        break;
+                    }
+                    index++;
+                    boolean successful = runTask(task, index);
+                    job.postExecute(successful, task);
+                    if (successful)
+                    {
+                        tasksExecuted++;
+                        jobHadWork = true;
+                    }
+                }
+                if (jobHadWork)
+                {
+                    job.refreshState();
+                }
+            }
+            return tasksExecuted;
+        }
+
+        private boolean withinSessionWindow(final long sessionStart)
+        {
+            return (System.currentTimeMillis() - sessionStart) < mySessionWindowInMs;
+        }
+
+        private void handleLockFailure(final ScheduledJob job, final Exception e)
+        {
+            if (e instanceof RuntimeMBeanException)
+            {
+                RuntimeMBeanException rme = (RuntimeMBeanException) e;
+                if (rme.getCause() instanceof IllegalStateException
+                        && rme.getCause().getMessage() != null
+                        && rme.getCause().getMessage().contains("More than one key found"))
+                {
+                    LOG.debug("Unable to get schedule lock on job {} in node {}, probably Jolokia 2.3.0 or older",
+                            job, nodeID, e);
+                }
+                else
+                {
+                    LOG.warn("Unable to get schedule lock on job {} in node {}", job, nodeID, e);
+                }
+            }
+            else if (e.getCause() != null)
+            {
+                LOG.warn("Unable to get schedule lock on job {} in node {}", job, nodeID, e);
+            }
+            else
+            {
+                LOG.debug("Lock contention for job {} in node {}", job, nodeID, e);
+            }
+            long backoff = ThreadLocalRandom.current().nextLong(
+                    myRunIntervalInMs / 2, myRunIntervalInMs);
+            myContentionBackoff.put(job, System.currentTimeMillis() + backoff);
         }
 
         private boolean runTask(
@@ -444,9 +588,12 @@ public final class ScheduleManagerImpl implements ScheduleManager, Closeable
      */
     public static class Builder
     {
+        private static final long DEFAULT_SESSION_WINDOW_MS = TimeUnit.MINUTES.toMillis(5);
         private Collection<UUID> myNodeIDList;
         private CASLockFactory myLockFactory;
         private long myRunIntervalInMs = DEFAULT_RUN_DELAY_IN_MS;
+        private long mySessionWindowInMs = DEFAULT_SESSION_WINDOW_MS;
+        private long myCooldownInMs = 0;
         private DistributedNativeConnectionProvider myNativeConnectionProvider;
 
         /**
@@ -459,6 +606,32 @@ public final class ScheduleManagerImpl implements ScheduleManager, Closeable
         public final Builder withRunInterval(final long runInterval, final TimeUnit timeUnit)
         {
             myRunIntervalInMs = timeUnit.toMillis(runInterval);
+            return this;
+        }
+
+        /**
+         * Build SchedulerManager with session window.
+         *
+         * @param sessionWindow the time window for batched lock sessions
+         * @param timeUnit the TimeUnit to specify the window
+         * @return Builder with session window
+         */
+        public final Builder withSessionWindow(final long sessionWindow, final TimeUnit timeUnit)
+        {
+            mySessionWindowInMs = timeUnit.toMillis(sessionWindow);
+            return this;
+        }
+
+        /**
+         * Build SchedulerManager with cooldown.
+         *
+         * @param cooldown the cooldown after a batched session
+         * @param timeUnit the TimeUnit to specify the cooldown
+         * @return Builder with cooldown
+         */
+        public final Builder withCooldown(final long cooldown, final TimeUnit timeUnit)
+        {
+            myCooldownInMs = timeUnit.toMillis(cooldown);
             return this;
         }
 

--- a/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/scheduler/ScheduleManagerImpl.java
+++ b/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/scheduler/ScheduleManagerImpl.java
@@ -432,7 +432,7 @@ public final class ScheduleManagerImpl implements ScheduleManager, Closeable
 
         private boolean shouldSkipJob(final ScheduledJob job, final ScheduledJob excludeJob)
         {
-            if (job == excludeJob)
+            if (job.equals(excludeJob))
             {
                 return true;
             }

--- a/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/scheduler/ScheduleManagerImpl.java
+++ b/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/scheduler/ScheduleManagerImpl.java
@@ -17,6 +17,7 @@ package com.ericsson.bss.cassandra.ecchronos.core.impl.repair.scheduler;
 import com.datastax.oss.driver.api.core.metadata.Node;
 import com.ericsson.bss.cassandra.ecchronos.connection.DistributedNativeConnectionProvider;
 import com.ericsson.bss.cassandra.ecchronos.core.impl.locks.CASLockFactory;
+import com.ericsson.bss.cassandra.ecchronos.core.impl.repair.RepairLockFactoryImpl;
 import com.ericsson.bss.cassandra.ecchronos.utils.exceptions.LockException;
 import com.ericsson.bss.cassandra.ecchronos.core.repair.scheduler.RunPolicy;
 import com.ericsson.bss.cassandra.ecchronos.core.repair.scheduler.ScheduleManager;
@@ -60,6 +61,7 @@ public final class ScheduleManagerImpl implements ScheduleManager, Closeable
     private final Map<UUID, ScheduledFuture<?>> myRunFuture = new ConcurrentHashMap<>();
     private final Map<UUID, JobRunTask> myRunTasks = new ConcurrentHashMap<>();
     private final CASLockFactory myLockFactory;
+    private final RepairLockFactoryImpl myRepairLockFactory;
     private final DistributedNativeConnectionProvider myNativeConnectionProvider;
 
     private final ScheduledThreadPoolExecutor myExecutor;
@@ -76,6 +78,7 @@ public final class ScheduleManagerImpl implements ScheduleManager, Closeable
         myExecutor.setKeepAliveTime(DEFAULT_KEEP_ALIVE_TIME, TimeUnit.SECONDS);
         myExecutor.allowCoreThreadTimeOut(true);
         myLockFactory = builder.myLockFactory;
+        myRepairLockFactory = new RepairLockFactoryImpl();
         myRunIntervalInMs = builder.myRunIntervalInMs;
         mySessionWindowInMs = builder.mySessionWindowInMs;
         myCooldownInMs = builder.myCooldownInMs;
@@ -392,7 +395,7 @@ public final class ScheduleManagerImpl implements ScheduleManager, Closeable
             LOG.info("Session started for node {}, window={}ms", nodeID, mySessionWindowInMs);
             int tasksExecuted;
 
-            try (SessionLockPool lockPool = new SessionLockPool(myLockFactory, nodeID))
+            try (SessionLockPool lockPool = new SessionLockPool(myLockFactory, myRepairLockFactory, nodeID))
             {
                 tasksExecuted = executeJobTasks(firstJob, sessionStart, lockPool);
 

--- a/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/scheduler/ScheduleManagerImpl.java
+++ b/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/scheduler/ScheduleManagerImpl.java
@@ -362,7 +362,7 @@ public final class ScheduleManagerImpl implements ScheduleManager, Closeable
                 if (validate(next))
                 {
                     currentExecutingJobs.put(nodeID, next);
-                    if (tryRunBatchedSession(next, tickStart))
+                    if (tryRunBatchedSession(next))
                     {
                         hadWork = true;
                         break;
@@ -387,9 +387,8 @@ public final class ScheduleManagerImpl implements ScheduleManager, Closeable
             return true;
         }
 
-        private boolean tryRunBatchedSession(final ScheduledJob firstJob, final long tickStart)
+        private boolean tryRunBatchedSession(final ScheduledJob firstJob)
         {
-            // Try to acquire lock using the first task of the first job
             Iterator<ScheduledTask> taskIterator = firstJob.iterator();
             if (!taskIterator.hasNext())
             {
@@ -397,10 +396,10 @@ public final class ScheduleManagerImpl implements ScheduleManager, Closeable
             }
 
             ScheduledTask firstTask = taskIterator.next();
-            LockFactory.DistributedLock sessionLock;
-            try
+            try (LockFactory.DistributedLock sessionLock = firstTask.getLock(myLockFactory, nodeID))
             {
-                sessionLock = firstTask.getLock(myLockFactory, nodeID);
+                LOG.debug("Lock acquired for batched session on node {} with lock {}", nodeID, sessionLock);
+                return executeBatchedSession(firstJob, firstTask, taskIterator);
             }
             catch (RuntimeMBeanException e)
             {
@@ -412,64 +411,74 @@ public final class ScheduleManagerImpl implements ScheduleManager, Closeable
                 handleLockFailure(firstJob, e);
                 return false;
             }
+        }
 
-            // Lock acquired - run batched session
+        private boolean executeBatchedSession(
+                final ScheduledJob firstJob,
+                final ScheduledTask firstTask,
+                final Iterator<ScheduledTask> taskIterator)
+        {
             long sessionStart = System.currentTimeMillis();
-            int tasksExecuted = 0;
-            try
-            {
-                LOG.info("Batched session started for node {}, window={}ms", nodeID, mySessionWindowInMs);
+            LOG.info("Batched session started for node {}, window={}ms", nodeID, mySessionWindowInMs);
 
-                // Execute the first task (lock already acquired for it)
-                if (runTask(firstTask, 1))
+            int tasksExecuted = executeFirstJob(firstJob, firstTask, taskIterator, sessionStart);
+
+            if (withinSessionWindow(sessionStart))
+            {
+                tasksExecuted += runRemainingJobsInSession(sessionStart, firstJob);
+            }
+
+            long elapsed = System.currentTimeMillis() - sessionStart;
+            LOG.info("Batched session ended for node {}, executed {} tasks in {}ms",
+                    nodeID, tasksExecuted, elapsed);
+            applyCooldown(tasksExecuted);
+            return true;
+        }
+
+        private int executeFirstJob(
+                final ScheduledJob job,
+                final ScheduledTask firstTask,
+                final Iterator<ScheduledTask> taskIterator,
+                final long sessionStart)
+        {
+            int tasksExecuted = 0;
+            if (runTask(firstTask, 1))
+            {
+                job.postExecute(true, firstTask);
+                tasksExecuted++;
+            }
+            else
+            {
+                job.postExecute(false, firstTask);
+            }
+
+            int index = 1;
+            while (taskIterator.hasNext() && withinSessionWindow(sessionStart))
+            {
+                index++;
+                ScheduledTask task = taskIterator.next();
+                boolean successful = runTask(task, index);
+                job.postExecute(successful, task);
+                if (successful)
                 {
-                    firstJob.postExecute(true, firstTask);
                     tasksExecuted++;
                 }
-                else
-                {
-                    firstJob.postExecute(false, firstTask);
-                }
-
-                // Continue with remaining tasks of the first job
-                int index = 1;
-                while (taskIterator.hasNext() && withinSessionWindow(sessionStart))
-                {
-                    index++;
-                    ScheduledTask task = taskIterator.next();
-                    boolean successful = runTask(task, index);
-                    firstJob.postExecute(successful, task);
-                    if (successful)
-                    {
-                        tasksExecuted++;
-                    }
-                }
-
-                if (tasksExecuted > 0)
-                {
-                    firstJob.refreshState();
-                }
-
-                // Continue with other jobs while within session window
-                if (withinSessionWindow(sessionStart))
-                {
-                    tasksExecuted += runRemainingJobsInSession(sessionStart, firstJob);
-                }
             }
-            finally
+
+            if (tasksExecuted > 0)
             {
-                sessionLock.close();
-                long elapsed = System.currentTimeMillis() - sessionStart;
-                LOG.info("Batched session ended for node {}, executed {} tasks in {}ms",
-                        nodeID, tasksExecuted, elapsed);
-
-                if (tasksExecuted > 0 && myCooldownInMs > 0)
-                {
-                    myCooldownUntil = System.currentTimeMillis() + myCooldownInMs;
-                    LOG.debug("Node {} entering cooldown for {}ms", nodeID, myCooldownInMs);
-                }
+                job.refreshState();
             }
-            return true;
+            return tasksExecuted;
+        }
+
+        private void applyCooldown(final int tasksExecuted)
+        {
+            if (tasksExecuted > 0 && myCooldownInMs > 0)
+            {
+                myCooldownUntil = System.currentTimeMillis() + myCooldownInMs;
+                LOG.debug("Node {} entering cooldown for {}ms", nodeID, myCooldownInMs);
+            }
         }
 
         private int runRemainingJobsInSession(final long sessionStart, final ScheduledJob excludeJob)
@@ -481,41 +490,51 @@ public final class ScheduleManagerImpl implements ScheduleManager, Closeable
                 {
                     break;
                 }
-                if (job.equals(excludeJob))
-                {
-                    continue;
-                }
-                Long backoffUntil = myContentionBackoff.get(job);
-                if (backoffUntil != null && System.currentTimeMillis() < backoffUntil)
-                {
-                    continue;
-                }
-                if (!validate(job))
+                if (shouldSkipJob(job, excludeJob))
                 {
                     continue;
                 }
                 currentExecutingJobs.put(nodeID, job);
-                int index = 0;
-                boolean jobHadWork = false;
-                for (ScheduledTask task : job)
+                tasksExecuted += executeJobTasks(job, sessionStart);
+            }
+            return tasksExecuted;
+        }
+
+        private boolean shouldSkipJob(final ScheduledJob job, final ScheduledJob excludeJob)
+        {
+            if (job.equals(excludeJob))
+            {
+                return true;
+            }
+            Long backoffUntil = myContentionBackoff.get(job);
+            if (backoffUntil != null && System.currentTimeMillis() < backoffUntil)
+            {
+                return true;
+            }
+            return !validate(job);
+        }
+
+        private int executeJobTasks(final ScheduledJob job, final long sessionStart)
+        {
+            int tasksExecuted = 0;
+            int index = 0;
+            for (ScheduledTask task : job)
+            {
+                if (!withinSessionWindow(sessionStart))
                 {
-                    if (!withinSessionWindow(sessionStart))
-                    {
-                        break;
-                    }
-                    index++;
-                    boolean successful = runTask(task, index);
-                    job.postExecute(successful, task);
-                    if (successful)
-                    {
-                        tasksExecuted++;
-                        jobHadWork = true;
-                    }
+                    break;
                 }
-                if (jobHadWork)
+                index++;
+                boolean successful = runTask(task, index);
+                job.postExecute(successful, task);
+                if (successful)
                 {
-                    job.refreshState();
+                    tasksExecuted++;
                 }
+            }
+            if (tasksExecuted > 0)
+            {
+                job.refreshState();
             }
             return tasksExecuted;
         }

--- a/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/scheduler/SessionLockPool.java
+++ b/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/scheduler/SessionLockPool.java
@@ -14,6 +14,7 @@
  */
 package com.ericsson.bss.cassandra.ecchronos.core.impl.repair.scheduler;
 
+import com.ericsson.bss.cassandra.ecchronos.core.impl.repair.RepairLockFactoryImpl;
 import com.ericsson.bss.cassandra.ecchronos.core.locks.LockFactory;
 import com.ericsson.bss.cassandra.ecchronos.core.repair.RepairResource;
 import com.ericsson.bss.cassandra.ecchronos.core.repair.scheduler.ScheduledTask;
@@ -22,8 +23,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.Closeable;
-import java.util.HashMap;
+import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
@@ -31,7 +33,7 @@ import java.util.UUID;
 /**
  * Manages distributed locks during a repair session using incremental accumulation.
  * <p>
- * Locks are acquired per-task and held for the duration of the session.
+ * Locks are acquired per-task via {@link RepairLockFactoryImpl} and held for the duration of the session.
  * If a task shares resources with a previously executed task, those locks are reused.
  * If a lock cannot be acquired for a task, the task is skipped (not the entire job).
  * All locks are released when the session ends via {@link #close()}.
@@ -41,20 +43,21 @@ final class SessionLockPool implements Closeable
     private static final Logger LOG = LoggerFactory.getLogger(SessionLockPool.class);
 
     private final LockFactory myLockFactory;
+    private final RepairLockFactoryImpl myRepairLockFactory;
     private final UUID myNodeId;
-    private final Map<RepairResource, LockFactory.DistributedLock> myHeldLocks = new HashMap<>();
+    private final Set<RepairResource> myHeldResources = new HashSet<>();
+    private final List<LockFactory.DistributedLock> myHeldLocks = new ArrayList<>();
 
-    SessionLockPool(final LockFactory lockFactory, final UUID nodeId)
+    SessionLockPool(final LockFactory lockFactory, final RepairLockFactoryImpl repairLockFactory, final UUID nodeId)
     {
         myLockFactory = lockFactory;
+        myRepairLockFactory = repairLockFactory;
         myNodeId = nodeId;
     }
 
     /**
      * Try to ensure locks are held for all resources required by the given task.
-     * Resources already held are reused. Only missing resources trigger CAS operations.
-     * If any new resource cannot be acquired, previously acquired new locks from this
-     * call are released and a LockException is thrown.
+     * Resources already held are reused. Only missing resources trigger lock acquisition.
      *
      * @param task The task whose resources need to be locked.
      * @throws LockException If unable to acquire a required lock.
@@ -70,7 +73,7 @@ final class SessionLockPool implements Closeable
         Set<RepairResource> missing = new HashSet<>();
         for (RepairResource resource : required)
         {
-            if (!myHeldLocks.containsKey(resource))
+            if (!myHeldResources.contains(resource))
             {
                 missing.add(resource);
             }
@@ -81,31 +84,13 @@ final class SessionLockPool implements Closeable
             return;
         }
 
-        Map<RepairResource, LockFactory.DistributedLock> newlyAcquired = new HashMap<>();
-        for (RepairResource resource : missing)
-        {
-            try
-            {
-                LockFactory.DistributedLock lock = myLockFactory.tryLock(
-                        resource.getDataCenter(),
-                        resource.getResourceName(1),
-                        task.getPriority(),
-                        new HashMap<>(),
-                        myNodeId);
-                newlyAcquired.put(resource, lock);
-            }
-            catch (LockException e)
-            {
-                // Keep successfully acquired locks for future tasks
-                myHeldLocks.putAll(newlyAcquired);
-                LOG.debug("Node {}: failed to acquire lock for {}, kept {} new locks",
-                        myNodeId, resource, newlyAcquired.size(), e);
-                throw e;
-            }
-        }
-        myHeldLocks.putAll(newlyAcquired);
-        LOG.debug("Node {}: acquired {} new locks, total held: {}",
-                myNodeId, newlyAcquired.size(), myHeldLocks.size());
+        Map<String, String> metadata = task.getLockMetadata();
+        LockFactory.DistributedLock lock = myRepairLockFactory.getLock(
+                myLockFactory, missing, metadata, task.getPriority(), myNodeId);
+        myHeldLocks.add(lock);
+        myHeldResources.addAll(missing);
+        LOG.debug("Node {}: acquired locks for {} resources, total held: {}",
+                myNodeId, missing.size(), myHeldResources.size());
     }
 
     /**
@@ -117,23 +102,19 @@ final class SessionLockPool implements Closeable
         if (!myHeldLocks.isEmpty())
         {
             LOG.debug("Releasing {} session locks for node {}", myHeldLocks.size(), myNodeId);
-            releaseAll(myHeldLocks);
+            for (LockFactory.DistributedLock lock : myHeldLocks)
+            {
+                try
+                {
+                    lock.close();
+                }
+                catch (Exception e)
+                {
+                    LOG.warn("Failed to release session lock", e);
+                }
+            }
             myHeldLocks.clear();
-        }
-    }
-
-    private void releaseAll(final Map<RepairResource, LockFactory.DistributedLock> locks)
-    {
-        for (Map.Entry<RepairResource, LockFactory.DistributedLock> entry : locks.entrySet())
-        {
-            try
-            {
-                entry.getValue().close();
-            }
-            catch (Exception e)
-            {
-                LOG.warn("Failed to release lock for resource {}", entry.getKey(), e);
-            }
+            myHeldResources.clear();
         }
     }
 }

--- a/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/scheduler/SessionLockPool.java
+++ b/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/scheduler/SessionLockPool.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2026 Telefonaktiebolaget LM Ericsson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ericsson.bss.cassandra.ecchronos.core.impl.repair.scheduler;
+
+import com.ericsson.bss.cassandra.ecchronos.core.locks.LockFactory;
+import com.ericsson.bss.cassandra.ecchronos.core.repair.RepairResource;
+import com.ericsson.bss.cassandra.ecchronos.core.repair.scheduler.ScheduledTask;
+import com.ericsson.bss.cassandra.ecchronos.utils.exceptions.LockException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.Closeable;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+/**
+ * Manages distributed locks during a repair session using incremental accumulation.
+ * <p>
+ * Locks are acquired per-task and held for the duration of the session.
+ * If a task shares resources with a previously executed task, those locks are reused.
+ * If a lock cannot be acquired for a task, the task is skipped (not the entire job).
+ * All locks are released when the session ends via {@link #close()}.
+ */
+final class SessionLockPool implements Closeable
+{
+    private static final Logger LOG = LoggerFactory.getLogger(SessionLockPool.class);
+
+    private final LockFactory myLockFactory;
+    private final UUID myNodeId;
+    private final Map<RepairResource, LockFactory.DistributedLock> myHeldLocks = new HashMap<>();
+
+    SessionLockPool(final LockFactory lockFactory, final UUID nodeId)
+    {
+        myLockFactory = lockFactory;
+        myNodeId = nodeId;
+    }
+
+    /**
+     * Try to ensure locks are held for all resources required by the given task.
+     * Resources already held are reused. Only missing resources trigger CAS operations.
+     * If any new resource cannot be acquired, previously acquired new locks from this
+     * call are released and a LockException is thrown.
+     *
+     * @param task The task whose resources need to be locked.
+     * @throws LockException If unable to acquire a required lock.
+     */
+    void acquireForTask(final ScheduledTask task) throws LockException
+    {
+        Set<RepairResource> required = task.getRepairResources();
+        if (required.isEmpty())
+        {
+            return;
+        }
+
+        Set<RepairResource> missing = new HashSet<>();
+        for (RepairResource resource : required)
+        {
+            if (!myHeldLocks.containsKey(resource))
+            {
+                missing.add(resource);
+            }
+        }
+
+        if (missing.isEmpty())
+        {
+            return;
+        }
+
+        Map<RepairResource, LockFactory.DistributedLock> newlyAcquired = new HashMap<>();
+        for (RepairResource resource : missing)
+        {
+            try
+            {
+                LockFactory.DistributedLock lock = myLockFactory.tryLock(
+                        resource.getDataCenter(),
+                        resource.getResourceName(1),
+                        task.getPriority(),
+                        new HashMap<>(),
+                        myNodeId);
+                newlyAcquired.put(resource, lock);
+            }
+            catch (LockException e)
+            {
+                // Keep successfully acquired locks for future tasks
+                myHeldLocks.putAll(newlyAcquired);
+                LOG.debug("Node {}: failed to acquire lock for {}, kept {} new locks",
+                        myNodeId, resource, newlyAcquired.size(), e);
+                throw e;
+            }
+        }
+        myHeldLocks.putAll(newlyAcquired);
+        LOG.debug("Node {}: acquired {} new locks, total held: {}",
+                myNodeId, newlyAcquired.size(), myHeldLocks.size());
+    }
+
+    /**
+     * Release all held locks. Called at end of session.
+     */
+    @Override
+    public void close()
+    {
+        if (!myHeldLocks.isEmpty())
+        {
+            LOG.debug("Releasing {} session locks for node {}", myHeldLocks.size(), myNodeId);
+            releaseAll(myHeldLocks);
+            myHeldLocks.clear();
+        }
+    }
+
+    private void releaseAll(final Map<RepairResource, LockFactory.DistributedLock> locks)
+    {
+        for (Map.Entry<RepairResource, LockFactory.DistributedLock> entry : locks.entrySet())
+        {
+            try
+            {
+                entry.getValue().close();
+            }
+            catch (Exception e)
+            {
+                LOG.warn("Failed to release lock for resource {}", entry.getKey(), e);
+            }
+        }
+    }
+}

--- a/core.impl/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/scheduler/TestScheduleManager.java
+++ b/core.impl/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/scheduler/TestScheduleManager.java
@@ -30,6 +30,7 @@ import com.ericsson.bss.cassandra.ecchronos.connection.DistributedNativeConnecti
 import com.ericsson.bss.cassandra.ecchronos.core.impl.locks.CASLockFactory;
 import com.ericsson.bss.cassandra.ecchronos.core.impl.locks.CASLockFactoryBuilder;
 import com.ericsson.bss.cassandra.ecchronos.core.impl.locks.DummyLock;
+import com.ericsson.bss.cassandra.ecchronos.core.repair.RepairResource;
 import com.ericsson.bss.cassandra.ecchronos.core.repair.scheduler.RunPolicy;
 import com.ericsson.bss.cassandra.ecchronos.core.repair.scheduler.ScheduledJob;
 import com.ericsson.bss.cassandra.ecchronos.core.repair.scheduler.ScheduledTask;
@@ -244,7 +245,7 @@ public class TestScheduleManager
     @Test
     public void testRunningOneJobWithThrowingLock() throws LockException
     {
-        DummyJob job = new DummyJob(ScheduledJob.Priority.LOW, nodeID1);
+        TestJob job = new TestJob(ScheduledJob.Priority.LOW, 1, nodeID1, "dc1", "resource1");
         myScheduler.schedule(nodeID1, job);
 
         when(myLockFactory.tryLock(any(), anyString(), anyInt(), anyMap(), any())).thenThrow(new LockException(""));
@@ -258,8 +259,8 @@ public class TestScheduleManager
     @Test
     public void testTwoJobsThrowingLock() throws LockException
     {
-        DummyJob job1 = new DummyJob(ScheduledJob.Priority.LOW, nodeID1);
-        DummyJob job2 = new DummyJob(ScheduledJob.Priority.LOW, nodeID1);
+        TestJob job1 = new TestJob(ScheduledJob.Priority.LOW, 1, nodeID1, "dc1", "resource1");
+        TestJob job2 = new TestJob(ScheduledJob.Priority.LOW, 1, nodeID1, "dc1", "resource2");
         myScheduler.schedule(nodeID1, job1);
         myScheduler.schedule(nodeID1, job2);
 
@@ -270,17 +271,15 @@ public class TestScheduleManager
         assertThat(job1.hasRun()).isFalse();
         assertThat(job2.hasRun()).isFalse();
         assertThat(myScheduler.getQueueSize(nodeID1)).isEqualTo(2);
-        verify(myLockFactory, times(2)).tryLock(any(), anyString(), anyInt(), anyMap(), any());
     }
 
     @Test
-    public void testThreeTasksOneThrowing() throws LockException
+    public void testThreeTasksWithResources() throws LockException
     {
-        TestJob job = new TestJob(ScheduledJob.Priority.LOW, 3, nodeID1);
+        TestJob job = new TestJob(ScheduledJob.Priority.LOW, 3, nodeID1, "dc1", "resource1");
         myScheduler.schedule(nodeID1, job);
 
-        // In batched mode, lock is acquired once for the session via the first task.
-        // All subsequent tasks execute without re-acquiring the lock.
+        // Lock acquired once for the shared resource across all tasks in the session
         when(myLockFactory.tryLock(any(), anyString(), anyInt(), anyMap(), any()))
                 .thenReturn(new DummyLock());
 
@@ -315,6 +314,7 @@ public class TestScheduleManager
         private final AtomicInteger taskRuns = new AtomicInteger();
         private final int numTasks;
         private final Runnable onCompletion;
+        private final Set<RepairResource> repairResources;
 
 
         public TestJob(Priority priority, CountDownLatch cdl, UUID nodeId)
@@ -322,9 +322,11 @@ public class TestScheduleManager
             this(priority, cdl, 1, () -> {}, nodeId);
         }
 
-        public TestJob(Priority priority, int numTasks, UUID nodeId)
+
+        public TestJob(Priority priority, int numTasks, UUID nodeId, String dc, String resource)
         {
             this(priority, numTasks, () -> {}, nodeId);
+            repairResources.add(new RepairResource(dc, resource));
         }
 
         public TestJob(Priority priority, int numTasks, Runnable onCompletion, UUID nodeId)
@@ -332,6 +334,7 @@ public class TestScheduleManager
             super(new ConfigurationBuilder().withPriority(priority).withRunInterval(1, TimeUnit.SECONDS).build(), nodeId);
             this.numTasks = numTasks;
             this.onCompletion = onCompletion;
+            this.repairResources = new HashSet<>();
         }
 
         public TestJob(Priority priority, CountDownLatch cdl, int numTasks, Runnable onCompletion, UUID nodeId)
@@ -339,6 +342,7 @@ public class TestScheduleManager
             super(new ConfigurationBuilder().withPriority(priority).withRunInterval(1, TimeUnit.SECONDS).build(), nodeId);
             this.numTasks = numTasks;
             this.onCompletion = onCompletion;
+            this.repairResources = new HashSet<>();
             countDownLatch = cdl;
         }
 
@@ -377,6 +381,12 @@ public class TestScheduleManager
             public ShortRunningTask(Runnable onCompletion)
             {
                 this.onCompletion = onCompletion;
+            }
+
+            @Override
+            public Set<RepairResource> getRepairResources()
+            {
+                return repairResources;
             }
 
             @Override

--- a/core.impl/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/scheduler/TestScheduleManager.java
+++ b/core.impl/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/scheduler/TestScheduleManager.java
@@ -279,16 +279,16 @@ public class TestScheduleManager
         TestJob job = new TestJob(ScheduledJob.Priority.LOW, 3, nodeID1);
         myScheduler.schedule(nodeID1, job);
 
+        // In batched mode, lock is acquired once for the session via the first task.
+        // All subsequent tasks execute without re-acquiring the lock.
         when(myLockFactory.tryLock(any(), anyString(), anyInt(), anyMap(), any()))
-                .thenReturn(new DummyLock())
-                .thenThrow(new LockException(""))
                 .thenReturn(new DummyLock());
 
         myScheduler.run(nodeID1);
 
-        assertThat(job.getTaskRuns()).isEqualTo(2);
+        assertThat(job.getTaskRuns()).isEqualTo(3);
         assertThat(myScheduler.getQueueSize(nodeID1)).isEqualTo(1);
-        verify(myLockFactory, times(3)).tryLock(any(), anyString(), anyInt(), anyMap(), any());
+        verify(myLockFactory, times(1)).tryLock(any(), anyString(), anyInt(), anyMap(), any());
     }
 
     private void waitForJobStarted(TestJob job) throws InterruptedException

--- a/core.impl/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/scheduler/TestScheduleManagerSession.java
+++ b/core.impl/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/scheduler/TestScheduleManagerSession.java
@@ -1,0 +1,428 @@
+/*
+ * Copyright 2026 Telefonaktiebolaget LM Ericsson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ericsson.bss.cassandra.ecchronos.core.impl.repair.scheduler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.when;
+
+import com.datastax.oss.driver.api.core.metadata.Node;
+import com.ericsson.bss.cassandra.ecchronos.connection.DistributedNativeConnectionProvider;
+import com.ericsson.bss.cassandra.ecchronos.core.impl.locks.CASLockFactory;
+import com.ericsson.bss.cassandra.ecchronos.core.impl.locks.DummyLock;
+import com.ericsson.bss.cassandra.ecchronos.core.repair.RepairResource;
+import com.ericsson.bss.cassandra.ecchronos.core.repair.scheduler.ScheduledJob;
+import com.ericsson.bss.cassandra.ecchronos.core.repair.scheduler.ScheduledTask;
+import com.ericsson.bss.cassandra.ecchronos.utils.exceptions.LockException;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.Silent.class)
+public class TestScheduleManagerSession
+{
+    @Mock
+    private CASLockFactory myLockFactory;
+    @Mock
+    private DistributedNativeConnectionProvider myNativeConnectionProvider;
+    @Mock
+    private Node node1;
+
+    private final UUID nodeID1 = UUID.randomUUID();
+    private final Collection<UUID> myNodes = Collections.singletonList(nodeID1);
+
+    private ScheduleManagerImpl myScheduler;
+
+    @Before
+    public void startup()
+    {
+        Map<UUID, Node> nodeMap = Map.of(nodeID1, node1);
+        when(myNativeConnectionProvider.getNodes()).thenReturn(nodeMap);
+    }
+
+    @After
+    public void cleanup()
+    {
+        if (myScheduler != null)
+        {
+            myScheduler.close();
+        }
+    }
+
+    private ScheduleManagerImpl buildScheduler(final long sessionWindowMs, final long cooldownMs)
+    {
+        ScheduleManagerImpl scheduler = ScheduleManagerImpl.builder()
+                .withNodeIDList(myNodes)
+                .withNativeConnectionProvider(myNativeConnectionProvider)
+                .withLockFactory(myLockFactory)
+                .withRunInterval(10, TimeUnit.SECONDS)
+                .withSessionWindow(sessionWindowMs, TimeUnit.MILLISECONDS)
+                .withCooldown(cooldownMs, TimeUnit.MILLISECONDS)
+                .build();
+        scheduler.createScheduleFutureForNodeIDList(myNodes);
+        return scheduler;
+    }
+
+    @Test
+    public void testMultipleJobsExecuteWithinSingleSession() throws LockException
+    {
+        myScheduler = buildScheduler(TimeUnit.MINUTES.toMillis(5), 0);
+        when(myLockFactory.tryLock(any(), anyString(), anyInt(), anyMap(), any()))
+                .thenReturn(new DummyLock());
+
+        ResourceJob job1 = new ResourceJob(nodeID1, 2, "dc1", "nodeA");
+        ResourceJob job2 = new ResourceJob(nodeID1, 2, "dc1", "nodeB");
+        ResourceJob job3 = new ResourceJob(nodeID1, 2, "dc1", "nodeC");
+        myScheduler.schedule(nodeID1, job1);
+        myScheduler.schedule(nodeID1, job2);
+        myScheduler.schedule(nodeID1, job3);
+
+        myScheduler.run(nodeID1);
+
+        assertThat(job1.getTaskRuns()).isEqualTo(2);
+        assertThat(job2.getTaskRuns()).isEqualTo(2);
+        assertThat(job3.getTaskRuns()).isEqualTo(2);
+    }
+
+    @Test
+    public void testLockResourceCompatibilityAcrossJobs() throws LockException
+    {
+        myScheduler = buildScheduler(TimeUnit.MINUTES.toMillis(5), 0);
+        AtomicInteger lockAcquireCount = new AtomicInteger(0);
+        when(myLockFactory.tryLock(any(), anyString(), anyInt(), anyMap(), any()))
+                .thenAnswer(invocation ->
+                {
+                    lockAcquireCount.incrementAndGet();
+                    return new DummyLock();
+                });
+
+        // Job1 needs resources {A, B}, Job2 needs resources {B, C}
+        // With shared session lock pool, B is reused from job1
+        ResourceJob job1 = new ResourceJob(nodeID1, 2, "dc1", "nodeA", "nodeB");
+        ResourceJob job2 = new ResourceJob(nodeID1, 2, "dc1", "nodeB", "nodeC");
+        myScheduler.schedule(nodeID1, job1);
+        myScheduler.schedule(nodeID1, job2);
+
+        myScheduler.run(nodeID1);
+
+        assertThat(job1.getTaskRuns()).isEqualTo(2);
+        assertThat(job2.getTaskRuns()).isEqualTo(2);
+        // Job1 acquires A and B (2 locks)
+        // Job2 reuses B, only acquires C (1 lock)
+        assertThat(lockAcquireCount.get()).isEqualTo(3);
+    }
+
+    @Test
+    public void testLockFailureOnSecondJobSkipsTasksNotEntireSession() throws LockException
+    {
+        myScheduler = buildScheduler(TimeUnit.MINUTES.toMillis(5), 0);
+        when(myLockFactory.tryLock(any(), anyString(), anyInt(), anyMap(), any()))
+                .thenAnswer(invocation ->
+                {
+                    String resource = invocation.getArgument(1);
+                    if (resource.contains("nodeB"))
+                    {
+                        throw new LockException("Resource busy");
+                    }
+                    return new DummyLock();
+                });
+
+        ResourceJob job1 = new ResourceJob(nodeID1, 2, "dc1", "nodeA");
+        ResourceJob job2 = new ResourceJob(nodeID1, 2, "dc1", "nodeB");
+        myScheduler.schedule(nodeID1, job1);
+        myScheduler.schedule(nodeID1, job2);
+
+        myScheduler.run(nodeID1);
+
+        // Job1 succeeds (nodeA lock available)
+        assertThat(job1.getTaskRuns()).isEqualTo(2);
+        // Job2 tasks are skipped (nodeB lock unavailable)
+        assertThat(job2.getTaskRuns()).isEqualTo(0);
+    }
+
+    @Test
+    public void testCooldownPreventsImmediateRerun() throws LockException
+    {
+        myScheduler = buildScheduler(TimeUnit.MINUTES.toMillis(5), 5000);
+        when(myLockFactory.tryLock(any(), anyString(), anyInt(), anyMap(), any()))
+                .thenReturn(new DummyLock());
+
+        ResourceJob job1 = new ResourceJob(nodeID1, 1, "dc1", "nodeA");
+        myScheduler.schedule(nodeID1, job1);
+
+        // First run executes the job
+        myScheduler.run(nodeID1);
+        assertThat(job1.getTaskRuns()).isEqualTo(1);
+
+        // Second run immediately after should be blocked by cooldown
+        job1.resetRuns();
+        myScheduler.run(nodeID1);
+        assertThat(job1.getTaskRuns()).isEqualTo(0);
+    }
+
+    @Test
+    public void testCooldownExpiresAndAllowsRerun() throws LockException, InterruptedException
+    {
+        myScheduler = buildScheduler(TimeUnit.MINUTES.toMillis(5), 2000);
+        when(myLockFactory.tryLock(any(), anyString(), anyInt(), anyMap(), any()))
+                .thenReturn(new DummyLock());
+
+        ResourceJob job1 = new ResourceJob(nodeID1, 1, "dc1", "nodeA");
+        myScheduler.schedule(nodeID1, job1);
+
+        myScheduler.run(nodeID1);
+        assertThat(job1.getTaskRuns()).isEqualTo(1);
+
+        // Immediately after - cooldown blocks
+        myScheduler.run(nodeID1);
+        assertThat(job1.getTaskRuns()).isEqualTo(1);
+
+        // Wait for cooldown to expire
+        Thread.sleep(2100);
+
+        // After cooldown, job should run again
+        myScheduler.run(nodeID1);
+        assertThat(job1.getTaskRuns()).isEqualTo(2);
+    }
+
+    @Test
+    public void testSessionWindowTimeoutMidExecution() throws LockException
+    {
+        // Session window of 50ms - tasks that take 30ms each should timeout mid-job
+        myScheduler = buildScheduler(50, 0);
+        when(myLockFactory.tryLock(any(), anyString(), anyInt(), anyMap(), any()))
+                .thenReturn(new DummyLock());
+
+        SlowJob job = new SlowJob(nodeID1, 5, 30); // 5 tasks, 30ms each
+        myScheduler.schedule(nodeID1, job);
+
+        myScheduler.run(nodeID1);
+
+        // Should execute only 1-2 tasks before the 50ms window expires
+        assertThat(job.getTaskRuns()).isGreaterThan(0);
+        assertThat(job.getTaskRuns()).isLessThan(5);
+    }
+
+    @Test
+    public void testSessionWindowTimeoutStopsSubsequentJobs() throws LockException
+    {
+        // Short window - first job takes most of it, second shouldn't have time
+        myScheduler = buildScheduler(80, 0);
+        when(myLockFactory.tryLock(any(), anyString(), anyInt(), anyMap(), any()))
+                .thenReturn(new DummyLock());
+
+        SlowJob job1 = new SlowJob(nodeID1, 1, 100); // 1 task, 100ms (exceeds the 80ms window)
+        ResourceJob job2 = new ResourceJob(nodeID1, 1, "dc1", "nodeB");
+        myScheduler.schedule(nodeID1, job1);
+        myScheduler.schedule(nodeID1, job2);
+
+        myScheduler.run(nodeID1);
+
+        assertThat(job1.getTaskRuns()).isEqualTo(1);
+        assertThat(job2.getTaskRuns()).isEqualTo(0);
+    }
+
+    @Test
+    public void testNoCooldownWhenNoTasksExecuted() throws LockException
+    {
+        myScheduler = buildScheduler(TimeUnit.MINUTES.toMillis(5), 5000);
+        when(myLockFactory.tryLock(any(), anyString(), anyInt(), anyMap(), any()))
+                .thenThrow(new LockException("Resource busy"));
+
+        ResourceJob job1 = new ResourceJob(nodeID1, 1, "dc1", "nodeA");
+        myScheduler.schedule(nodeID1, job1);
+
+        // First run - lock fails, tasks skipped, no cooldown engaged
+        myScheduler.run(nodeID1);
+        assertThat(job1.getTaskRuns()).isEqualTo(0);
+
+        // Replace job1 (which has backoff) with a fresh job
+        doReturn(new DummyLock())
+                .when(myLockFactory).tryLock(any(), anyString(), anyInt(), anyMap(), any());
+        myScheduler.deschedule(nodeID1, job1);
+        ResourceJob job2 = new ResourceJob(nodeID1, 1, "dc1", "nodeA");
+        myScheduler.schedule(nodeID1, job2);
+
+        // Run again - no cooldown was engaged so job2 executes immediately
+        myScheduler.run(nodeID1);
+        assertThat(job2.getTaskRuns()).isEqualTo(1);
+    }
+
+    @Test
+    public void testJobWithNoResourcesStillExecutes() throws LockException
+    {
+        myScheduler = buildScheduler(TimeUnit.MINUTES.toMillis(5), 0);
+        // Lock factory should not be called for jobs with no resources
+        when(myLockFactory.tryLock(any(), anyString(), anyInt(), anyMap(), any()))
+                .thenThrow(new LockException("Should not be called"));
+
+        DummyJob job = new DummyJob(ScheduledJob.Priority.LOW, nodeID1);
+        myScheduler.schedule(nodeID1, job);
+
+        myScheduler.run(nodeID1);
+
+        assertThat(job.hasRun()).isTrue();
+    }
+
+    // --- Test helpers ---
+
+    private static class ResourceJob extends ScheduledJob
+    {
+        private final AtomicInteger myTaskRuns = new AtomicInteger(0);
+        private final int myNumTasks;
+        private final Set<RepairResource> myResources;
+
+        ResourceJob(final UUID nodeId, final int numTasks, final String dc, final String... resourceNames)
+        {
+            super(new ConfigurationBuilder()
+                    .withPriority(Priority.LOW)
+                    .withRunInterval(1, TimeUnit.MILLISECONDS)
+                    .build(), nodeId);
+            myNumTasks = numTasks;
+            myResources = new HashSet<>();
+            for (String name : resourceNames)
+            {
+                myResources.add(new RepairResource(dc, name));
+            }
+        }
+
+        int getTaskRuns()
+        {
+            return myTaskRuns.get();
+        }
+
+        void resetRuns()
+        {
+            myTaskRuns.set(0);
+        }
+
+        @Override
+        public Iterator<ScheduledTask> iterator()
+        {
+            List<ScheduledTask> tasks = new ArrayList<>();
+            for (int i = 0; i < myNumTasks; i++)
+            {
+                tasks.add(new ResourceTask(myResources, myTaskRuns));
+            }
+            return tasks.iterator();
+        }
+    }
+
+    private static class ResourceTask extends ScheduledTask
+    {
+        private final Set<RepairResource> myResources;
+        private final AtomicInteger myRunCounter;
+
+        ResourceTask(final Set<RepairResource> resources, final AtomicInteger runCounter)
+        {
+            myResources = resources;
+            myRunCounter = runCounter;
+        }
+
+        @Override
+        public Set<RepairResource> getRepairResources()
+        {
+            return myResources;
+        }
+
+        @Override
+        public boolean execute(final UUID nodeID)
+        {
+            myRunCounter.incrementAndGet();
+            return true;
+        }
+    }
+
+    private static class SlowJob extends ScheduledJob
+    {
+        private final AtomicInteger myTaskRuns = new AtomicInteger(0);
+        private final int myNumTasks;
+        private final long myTaskDurationMs;
+
+        SlowJob(final UUID nodeId, final int numTasks, final long taskDurationMs)
+        {
+            super(new ConfigurationBuilder()
+                    .withPriority(Priority.LOW)
+                    .withRunInterval(1, TimeUnit.SECONDS)
+                    .build(), nodeId);
+            myNumTasks = numTasks;
+            myTaskDurationMs = taskDurationMs;
+        }
+
+        int getTaskRuns()
+        {
+            return myTaskRuns.get();
+        }
+
+        @Override
+        public Iterator<ScheduledTask> iterator()
+        {
+            List<ScheduledTask> tasks = new ArrayList<>();
+            for (int i = 0; i < myNumTasks; i++)
+            {
+                tasks.add(new SlowTask(myTaskDurationMs, myTaskRuns));
+            }
+            return tasks.iterator();
+        }
+    }
+
+    private static class SlowTask extends ScheduledTask
+    {
+        private final long myDurationMs;
+        private final AtomicInteger myRunCounter;
+
+        SlowTask(final long durationMs, final AtomicInteger runCounter)
+        {
+            myDurationMs = durationMs;
+            myRunCounter = runCounter;
+        }
+
+        @Override
+        public boolean execute(final UUID nodeID)
+        {
+            try
+            {
+                Thread.sleep(myDurationMs);
+            }
+            catch (InterruptedException e)
+            {
+                Thread.currentThread().interrupt();
+                return false;
+            }
+            myRunCounter.incrementAndGet();
+            return true;
+        }
+    }
+}

--- a/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/repair/scheduler/ScheduledTask.java
+++ b/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/repair/scheduler/ScheduledTask.java
@@ -15,9 +15,12 @@
 package com.ericsson.bss.cassandra.ecchronos.core.repair.scheduler;
 
 import com.ericsson.bss.cassandra.ecchronos.core.locks.LockFactory;
+import com.ericsson.bss.cassandra.ecchronos.core.repair.RepairResource;
 import com.ericsson.bss.cassandra.ecchronos.utils.exceptions.LockException;
 import com.ericsson.bss.cassandra.ecchronos.utils.exceptions.ScheduledJobException;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.Set;
 import java.util.UUID;
 
 @SuppressWarnings("VisibilityModifier")
@@ -72,6 +75,26 @@ public abstract class ScheduledTask
     public LockFactory.DistributedLock getLock(final LockFactory lockFactory, final UUID nodeId) throws LockException
     {
         return lockFactory.tryLock(null, DEFAULT_SCHEDULE_RESOURCE, myPriority, new HashMap<>(), nodeId);
+    }
+
+    /**
+     * Get the repair resources required by this task.
+     *
+     * @return The set of repair resources needed, empty if not applicable.
+     */
+    public Set<RepairResource> getRepairResources()
+    {
+        return Collections.emptySet();
+    }
+
+    /**
+     * Get the priority of this task.
+     *
+     * @return The priority value.
+     */
+    public int getPriority()
+    {
+        return myPriority;
     }
 }
 

--- a/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/repair/scheduler/ScheduledTask.java
+++ b/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/repair/scheduler/ScheduledTask.java
@@ -20,6 +20,7 @@ import com.ericsson.bss.cassandra.ecchronos.utils.exceptions.LockException;
 import com.ericsson.bss.cassandra.ecchronos.utils.exceptions.ScheduledJobException;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 
@@ -95,6 +96,16 @@ public abstract class ScheduledTask
     public int getPriority()
     {
         return myPriority;
+    }
+
+    /**
+     * Get the lock metadata for this task.
+     *
+     * @return The metadata map, empty if not applicable.
+     */
+    public Map<String, String> getLockMetadata()
+    {
+        return Collections.emptyMap();
     }
 }
 


### PR DESCRIPTION
Today each RepairTask tries to acquire a lock, in large clusters with 1000+ tables ecchronos would suffer to repair all the things in a feasible time because acquiring a lock involves a CAS query in lock table, because of that I propose to allow a node to run the most priority jobs within a time window before releasing the lock to another node, it would reduce the number of CAS operation and speed up repair jobs without increasing repair concurrency.

**Important**

We still need to discuss appropriate default values for cooldown and session_window. Although we are not increasing repair parallelism, the previous implementation, which used a lock per task, introduced a short gap between repair executions (the time required to release the current lock and acquire the next one). This effectively gave the Cassandra node a brief recovery period between repairs. With the new approach, however, subsequent repair tasks may run back-to-back within the same session_window, potentially increasing the sustained load on the node.

I'm planning to benchmark this change in a week to verify current default values, but I'm not too concerned tho because repair tasks are small and default session_window is 5 minutes , but we need to test it anyway

Closes #1618 