### PR TITLE
Fix SSLSessionImpl accumulation in JVM default SSLContext

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Version 1.0.1 (Not yet Released)
 
+* Fix SSLSessionImpl accumulation: apply cache bounds to JVM default SSLContext and cache instance - Issue #1620
 * Fix RepairStateSnapshot retention by decoupling RepairGroup from snapshot object graph - Issue #1616
 * Set HttpClient keepalive timeout to 5s to prevent connection pool memory growth - Issue #1614
 * Add MaxMetaspaceSize and ReservedCodeCacheSize to jvm.options - Issue #1610

--- a/application/src/main/java/com/ericsson/bss/cassandra/ecchronos/application/config/security/ReloadingCertificateHandler.java
+++ b/application/src/main/java/com/ericsson/bss/cassandra/ecchronos/application/config/security/ReloadingCertificateHandler.java
@@ -116,6 +116,12 @@ public class ReloadingCertificateHandler implements CertificateHandler
     {
     }
 
+    private static final int SSL_SESSION_CACHE_SIZE = 50;
+    private static final int SSL_SESSION_TIMEOUT_SECONDS = 3600;
+
+    private volatile SSLContext myCachedSSLContext;
+    private volatile Context myCachedSSLContextSource;
+
     @Override
     public final void setDefaultSSLContext()
     {
@@ -126,6 +132,8 @@ public class ReloadingCertificateHandler implements CertificateHandler
             {
                 SSLContext sslContext = SSLContext.getInstance("TLS");
                 initSSLContext(context, sslContext);
+                sslContext.getClientSessionContext().setSessionCacheSize(SSL_SESSION_CACHE_SIZE);
+                sslContext.getClientSessionContext().setSessionTimeout(SSL_SESSION_TIMEOUT_SECONDS);
                 SSLContext.setDefault(sslContext);
                 LOG.info("Default SSLContext set for JVM");
             }
@@ -144,10 +152,18 @@ public class ReloadingCertificateHandler implements CertificateHandler
         {
             return null;
         }
+        if (myCachedSSLContext != null && myCachedSSLContextSource == context) // NOPMD CompareObjectsWithEquals - intentional identity check
+        {
+            return myCachedSSLContext;
+        }
         try
         {
             SSLContext sslContext = SSLContext.getInstance("TLS");
             initSSLContext(context, sslContext);
+            sslContext.getClientSessionContext().setSessionCacheSize(SSL_SESSION_CACHE_SIZE);
+            sslContext.getClientSessionContext().setSessionTimeout(SSL_SESSION_TIMEOUT_SECONDS);
+            myCachedSSLContext = sslContext;
+            myCachedSSLContextSource = context;
             return sslContext;
         }
         catch (Exception e)


### PR DESCRIPTION
Apply session cache bounds (size=50, timeout=3600s) in both setDefaultSSLContext() and getSSLContext(). Cache the SSLContext instance in getSSLContext() to avoid creating a new one on every call
- only recreate when certificates change.

Previously, Jolokia's HttpClient instances used the unbounded JVM default SSLContext, accumulating ~667 sessions/hour and causing ~1Mi/hour container RSS growth.

Closes #1620 