### PR TITLE
Enable removeOnCancelPolicy on RepairHangMonitor shared executor

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Version 1.0.1 (Not yet Released)
 
+* Enable removeOnCancelPolicy on RepairHangMonitor shared executor - Issue #1621
 * Fix RepairStateSnapshot retention by decoupling RepairGroup from snapshot object graph - Issue #1616
 * Set HttpClient keepalive timeout to 5s to prevent connection pool memory growth - Issue #1614
 * Add MaxMetaspaceSize and ReservedCodeCacheSize to jvm.options - Issue #1610

--- a/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/RepairHangMonitor.java
+++ b/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/RepairHangMonitor.java
@@ -25,9 +25,9 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.UUID;
-import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -45,9 +45,14 @@ public class RepairHangMonitor
     private static final int DEFAULT_HEALTH_CHECK_INTERVAL_MINUTES = 1;
     private static final int SHARED_POOL_SIZE = 2;
 
-    private static final ScheduledExecutorService SHARED_EXECUTOR = Executors.newScheduledThreadPool(
-            SHARED_POOL_SIZE,
-            new ThreadFactoryBuilder().setNameFormat("HangPreventingTask-%d").setDaemon(true).build());
+    private static final ScheduledExecutorService SHARED_EXECUTOR;
+    static
+    {
+        ScheduledThreadPoolExecutor executor = new ScheduledThreadPoolExecutor(SHARED_POOL_SIZE,
+                new ThreadFactoryBuilder().setNameFormat("HangPreventingTask-%d").setDaemon(true).build());
+        executor.setRemoveOnCancelPolicy(true);
+        SHARED_EXECUTOR = executor;
+    }
 
     private final ScheduledExecutorService myExecutor;
     private final DistributedJmxProxyFactory myJmxProxyFactory;


### PR DESCRIPTION
Use ScheduledThreadPoolExecutor with removeOnCancelPolicy(true) so cancelled HangPreventingTask objects are immediately removed from the work queue instead of accumulating until expiry.

Closes #1621 