### PR TITLE
Fix lambda snapshot capture in RepairStateImpl

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Version 1.0.1 (Not yet Released)
 
+* Fix lambda snapshot capture in RepairStateImpl preventing GC of old snapshots - Issue #1622
 * Fix RepairStateSnapshot retention by decoupling RepairGroup from snapshot object graph - Issue #1616
 * Set HttpClient keepalive timeout to 5s to prevent connection pool memory growth - Issue #1614
 * Add MaxMetaspaceSize and ReservedCodeCacheSize to jvm.options - Issue #1610

--- a/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/state/RepairStateImpl.java
+++ b/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/state/RepairStateImpl.java
@@ -105,10 +105,11 @@ public class RepairStateImpl implements RepairState
             myTableRepairMetrics.lastRepairedAt(myTableReference,
                     newRepairStateSnapshot.lastCompletedAt());
 
+            long estimatedRepairTime = newRepairStateSnapshot.getEstimatedRepairTime();
             int nonRepairedRanges
                     = (int) newRepairStateSnapshot.getVnodeRepairStates().getVnodeRepairStates()
                     .stream()
-                    .filter(v -> vnodeIsRepairable(v, newRepairStateSnapshot,
+                    .filter(v -> vnodeIsRepairable(v, estimatedRepairTime,
                             System.currentTimeMillis()))
                     .count();
 
@@ -150,9 +151,10 @@ public class RepairStateImpl implements RepairState
 
         VnodeRepairStates updatedVnodeRepairStates = vnodeRepairStates.combineWithRepairedAt(repairedAt);
 
+        long estimatedRepairTime = old != null ? old.getEstimatedRepairTime() : 0L;
         List<VnodeRepairState> repairableVnodes = updatedVnodeRepairStates.getVnodeRepairStates().stream()
                 .filter(this::replicasAreRepairable)
-                .filter(v -> vnodeIsRepairable(v, old, System.currentTimeMillis()))
+                .filter(v -> vnodeIsRepairable(v, estimatedRepairTime, System.currentTimeMillis()))
                 .collect(Collectors.toList());
 
         List<ReplicaRepairGroup> replicaRepairGroups
@@ -285,14 +287,9 @@ public class RepairStateImpl implements RepairState
     }
 
     private boolean vnodeIsRepairable(final VnodeRepairState vnodeRepairState,
-            final RepairStateSnapshot snapshot,
+            final long estimatedRepairTime,
             final long now)
     {
-        long estimatedRepairTime = 0L;
-        if (snapshot != null)
-        {
-            estimatedRepairTime = snapshot.getEstimatedRepairTime();
-        }
         return isRepairNeeded(vnodeRepairState.lastRepairedAt(), estimatedRepairTime, now);
     }
 }


### PR DESCRIPTION
Extract estimatedRepairTime scalar before lambdas in generateSnapshotForVnode() and update() to avoid capturing the full RepairStateSnapshot object. Change vnodeIsRepairable() to accept long instead of RepairStateSnapshot.

Previously, 482 concurrent refreshState() calls each pinned an old snapshot via lambda capture, growing at ~21 snapshots/hour.

Close #1622 