### PR TITLE
Add javax.net.ssl.sessionCacheSize=50 to jvm.options

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Version 1.0.2 (Not yet Released)
 
+* Add javax.net.ssl.sessionCacheSize=50 to jvm.options to bound Jolokia SSL sessions - Issue #1626
+
 ## Version 1.0.1
 
 * Enable removeOnCancelPolicy on RepairHangMonitor shared executor - Issue #1621

--- a/ecchronos-binary/src/resources/jvm.options
+++ b/ecchronos-binary/src/resources/jvm.options
@@ -72,3 +72,12 @@
 # which causes completed exchange objects to be retained on pooled connections,
 # leading to steady memory growth.
 -Djdk.httpclient.keepalive.timeout=5
+
+####################
+# SSL/TLS SETTINGS #
+####################
+
+# Limit SSL session cache size for all SSLContexts in the JVM.
+# Prevents unbounded session accumulation from third-party libraries
+# (e.g., Jolokia) that create their own SSLContext without cache bounds.
+-Djavax.net.ssl.sessionCacheSize=50


### PR DESCRIPTION
Sets JVM-wide default SSL session cache size to 50 for all newly created SSLContexts, including those created internally by the Jolokia library which are unreachable from application code. Prevents unbounded SSLSessionImpl accumulation (~670/hour) from frequent TLS handshakes.

Closes #1626 