### PR TITLE
Add runtime configuration of scheduler parameters via ecctool

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Version 1.0.2 (Not yet Released)
 
+* Add runtime configuration of scheduler parameters via ecctool - Issue #1638
 * Implement Batched Lock Acquisition Strategy to Improve Repair Throughput in Large Clusters - Issue #1618
 * Add javax.net.ssl.sessionCacheSize=50 to jvm.options to bound Jolokia SSL sessions - Issue #1626
 

--- a/application/src/main/java/com/ericsson/bss/cassandra/ecchronos/application/SpringBooter.java
+++ b/application/src/main/java/com/ericsson/bss/cassandra/ecchronos/application/SpringBooter.java
@@ -14,6 +14,7 @@
  */
 package com.ericsson.bss.cassandra.ecchronos.application;
 
+import com.ericsson.bss.cassandra.ecchronos.rest.ConfigManagementRESTImpl;
 import com.ericsson.bss.cassandra.ecchronos.rest.MetricsRESTImpl;
 import com.ericsson.bss.cassandra.ecchronos.rest.OnDemandRepairManagementRESTImpl;
 import com.ericsson.bss.cassandra.ecchronos.rest.RejectConfigREST;
@@ -30,7 +31,7 @@ import org.springframework.context.annotation.Import;
 @SpringBootApplication
 @Import(value = { RepairManagementRESTImpl.class, ScheduleRepairManagementRESTImpl.class,
         OnDemandRepairManagementRESTImpl.class, StateManagementRESTImpl.class, MetricsRESTImpl.class,
-        RejectConfigREST.class})
+        RejectConfigREST.class, ConfigManagementRESTImpl.class})
 public class SpringBooter extends SpringBootServletInitializer
 {
     private static final Logger LOG = LoggerFactory.getLogger(SpringBooter.class);

--- a/application/src/main/java/com/ericsson/bss/cassandra/ecchronos/application/spring/ECChronos.java
+++ b/application/src/main/java/com/ericsson/bss/cassandra/ecchronos/application/spring/ECChronos.java
@@ -50,6 +50,7 @@ import com.ericsson.bss.cassandra.ecchronos.core.impl.repair.vnode.VnodeRepairSt
 import com.ericsson.bss.cassandra.ecchronos.core.impl.table.TimeBasedRunPolicy;
 import com.ericsson.bss.cassandra.ecchronos.core.repair.RepairStatsProvider;
 import com.ericsson.bss.cassandra.ecchronos.core.repair.scheduler.OnDemandRepairScheduler;
+import com.ericsson.bss.cassandra.ecchronos.core.repair.scheduler.ScheduleManager;
 import com.ericsson.bss.cassandra.ecchronos.core.repair.scheduler.RepairScheduler;
 import com.ericsson.bss.cassandra.ecchronos.core.state.ReplicationState;
 import com.ericsson.bss.cassandra.ecchronos.core.table.ReplicatedTableProvider;
@@ -196,6 +197,12 @@ public class ECChronos implements Closeable
     public OnDemandRepairScheduler onDemandRepairScheduler()
     {
         return myOnDemandRepairSchedulerImpl;
+    }
+
+    @Bean
+    public ScheduleManager scheduleManager()
+    {
+        return myECChronosInternals.getScheduleManager();
     }
 
     @Bean

--- a/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/RepairLockFactoryImpl.java
+++ b/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/RepairLockFactoryImpl.java
@@ -55,7 +55,11 @@ public class RepairLockFactoryImpl implements RepairLockFactory
         LOG.info("RepairLockFactory configured with {} locks per resource", locksPerResource);
     }
 
-    private int getLocksPerResource()
+    /**
+     * Get the current locks per resource value.
+     * @return current locks per resource
+     */
+    public static int getLocksPerResource()
     {
         return CONFIGURED_LOCKS_PER_RESOURCE.get();
     }

--- a/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/scheduler/ScheduleManagerImpl.java
+++ b/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/scheduler/ScheduleManagerImpl.java
@@ -66,8 +66,8 @@ public final class ScheduleManagerImpl implements ScheduleManager, Closeable
 
     private final ScheduledThreadPoolExecutor myExecutor;
     private final long myRunIntervalInMs;
-    private final long mySessionWindowInMs;
-    private final long myCooldownInMs;
+    private volatile long mySessionWindowInMs;
+    private volatile long myCooldownInMs;
 
     private ScheduleManagerImpl(final Builder builder)
     {
@@ -138,6 +138,68 @@ public final class ScheduleManagerImpl implements ScheduleManager, Closeable
         {
             return "";
         }
+    }
+
+    /**
+     * Get the current session window in milliseconds.
+     * @return session window in ms
+     */
+    @Override
+    public long getSessionWindowInMs()
+    {
+        return mySessionWindowInMs;
+    }
+
+    /**
+     * Set the session window at runtime.
+     * @param sessionWindowInMs new session window in milliseconds, must be greater than 0
+     */
+    @Override
+    public void setSessionWindowInMs(final long sessionWindowInMs)
+    {
+        if (sessionWindowInMs <= 0)
+        {
+            throw new IllegalArgumentException("session_window must be > 0");
+        }
+        mySessionWindowInMs = sessionWindowInMs;
+        LOG.info("Session window updated to {} ms", sessionWindowInMs);
+    }
+
+    /**
+     * Get the current cooldown in milliseconds.
+     * @return cooldown in ms
+     */
+    @Override
+    public long getCooldownInMs()
+    {
+        return myCooldownInMs;
+    }
+
+    /**
+     * Set the cooldown at runtime.
+     * @param cooldownInMs new cooldown in milliseconds, must be greater than or equal to 0
+     */
+    @Override
+    public void setCooldownInMs(final long cooldownInMs)
+    {
+        if (cooldownInMs < 0)
+        {
+            throw new IllegalArgumentException("cooldown must be >= 0");
+        }
+        myCooldownInMs = cooldownInMs;
+        LOG.info("Cooldown updated to {} ms", cooldownInMs);
+    }
+
+    @Override
+    public int getLocksPerResource()
+    {
+        return RepairLockFactoryImpl.getLocksPerResource();
+    }
+
+    @Override
+    public void setLocksPerResource(final int locksPerResource)
+    {
+        RepairLockFactoryImpl.configure(locksPerResource);
     }
 
     /**

--- a/core.impl/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/TestRepairLockFactoryImpl.java
+++ b/core.impl/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/TestRepairLockFactoryImpl.java
@@ -14,6 +14,7 @@
  */
 package com.ericsson.bss.cassandra.ecchronos.core.impl.repair;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -194,6 +195,33 @@ public class TestRepairLockFactoryImpl
         verifyExceptionIsThrownWhenGettingLock(repairLockFactory, priority, metadata, repairResourceDc1, repairResourceDc2);
         verifyNoLockWasTried();
         verify(mockLock, never()).close();
+    }
+
+    @Test
+    public void testGetLocksPerResourceReturnsConfiguredValue()
+    {
+        assertThat(RepairLockFactoryImpl.getLocksPerResource()).isEqualTo(LOCKS_PER_RESOURCE);
+    }
+
+    @Test
+    public void testRuntimeReconfiguration()
+    {
+        try
+        {
+            RepairLockFactoryImpl.configure(5);
+            assertThat(RepairLockFactoryImpl.getLocksPerResource()).isEqualTo(5);
+        }
+        finally
+        {
+            RepairLockFactoryImpl.configure(LOCKS_PER_RESOURCE);
+        }
+    }
+
+    @Test
+    public void testConfigureWithInvalidValueThrows()
+    {
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> RepairLockFactoryImpl.configure(0));
     }
 
     private void verifyNoLockWasTried() throws LockException

--- a/core.impl/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/scheduler/TestScheduleManagerRuntimeConfig.java
+++ b/core.impl/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/scheduler/TestScheduleManagerRuntimeConfig.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2026 Telefonaktiebolaget LM Ericsson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ericsson.bss.cassandra.ecchronos.core.impl.repair.scheduler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+import com.datastax.oss.driver.api.core.metadata.Node;
+import com.ericsson.bss.cassandra.ecchronos.connection.DistributedNativeConnectionProvider;
+import com.ericsson.bss.cassandra.ecchronos.core.impl.locks.CASLockFactory;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+@RunWith(MockitoJUnitRunner.Silent.class)
+public class TestScheduleManagerRuntimeConfig
+{
+    @Mock
+    private CASLockFactory myLockFactory;
+
+    @Mock
+    private DistributedNativeConnectionProvider myNativeConnectionProvider;
+
+    @Mock
+    private Node myNode;
+
+    private final UUID myNodeID = UUID.randomUUID();
+    private ScheduleManagerImpl myScheduler;
+
+    @Before
+    public void setup()
+    {
+        when(myNativeConnectionProvider.getNodes()).thenReturn(Map.of(myNodeID, myNode));
+        myScheduler = ScheduleManagerImpl.builder()
+                .withNodeIDList(Collections.singletonList(myNodeID))
+                .withNativeConnectionProvider(myNativeConnectionProvider)
+                .withLockFactory(myLockFactory)
+                .withSessionWindow(5, TimeUnit.MINUTES)
+                .withCooldown(10, TimeUnit.SECONDS)
+                .build();
+    }
+
+    @After
+    public void teardown()
+    {
+        myScheduler.close();
+    }
+
+    @Test
+    public void testGetSessionWindowReturnsConfiguredValue()
+    {
+        assertThat(myScheduler.getSessionWindowInMs()).isEqualTo(TimeUnit.MINUTES.toMillis(5));
+    }
+
+    @Test
+    public void testGetCooldownReturnsConfiguredValue()
+    {
+        assertThat(myScheduler.getCooldownInMs()).isEqualTo(TimeUnit.SECONDS.toMillis(10));
+    }
+
+    @Test
+    public void testSetSessionWindowUpdatesValue()
+    {
+        myScheduler.setSessionWindowInMs(600000L);
+        assertThat(myScheduler.getSessionWindowInMs()).isEqualTo(600000L);
+    }
+
+    @Test
+    public void testSetCooldownUpdatesValue()
+    {
+        myScheduler.setCooldownInMs(30000L);
+        assertThat(myScheduler.getCooldownInMs()).isEqualTo(30000L);
+    }
+
+    @Test
+    public void testSetCooldownToZeroIsAllowed()
+    {
+        myScheduler.setCooldownInMs(0L);
+        assertThat(myScheduler.getCooldownInMs()).isEqualTo(0L);
+    }
+
+    @Test
+    public void testSetSessionWindowToZeroThrows()
+    {
+        assertThatThrownBy(() -> myScheduler.setSessionWindowInMs(0L))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void testSetSessionWindowToNegativeThrows()
+    {
+        assertThatThrownBy(() -> myScheduler.setSessionWindowInMs(-1L))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void testSetCooldownToNegativeThrows()
+    {
+        assertThatThrownBy(() -> myScheduler.setCooldownInMs(-1L))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void testSetLocksPerResourceUpdatesValue()
+    {
+        int original = myScheduler.getLocksPerResource();
+        try
+        {
+            myScheduler.setLocksPerResource(5);
+            assertThat(myScheduler.getLocksPerResource()).isEqualTo(5);
+        }
+        finally
+        {
+            myScheduler.setLocksPerResource(original);
+        }
+    }
+
+    @Test
+    public void testSetLocksPerResourceToZeroThrows()
+    {
+        assertThatThrownBy(() -> myScheduler.setLocksPerResource(0))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/repair/scheduler/ScheduleManager.java
+++ b/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/repair/scheduler/ScheduleManager.java
@@ -61,4 +61,40 @@ public interface ScheduleManager
      * @param nodeID the node to remove
      */
     void removeScheduleFutureForNode(UUID nodeID);
+
+    /**
+     * Get the current session window in milliseconds.
+     * @return session window in ms
+     */
+    long getSessionWindowInMs();
+
+    /**
+     * Set the session window at runtime.
+     * @param sessionWindowInMs new session window in milliseconds, must be greater than 0
+     */
+    void setSessionWindowInMs(long sessionWindowInMs);
+
+    /**
+     * Get the current cooldown in milliseconds.
+     * @return cooldown in ms
+     */
+    long getCooldownInMs();
+
+    /**
+     * Set the cooldown at runtime.
+     * @param cooldownInMs new cooldown in milliseconds, must be greater than or equal to 0
+     */
+    void setCooldownInMs(long cooldownInMs);
+
+    /**
+     * Get the current locks per resource value.
+     * @return locks per resource
+     */
+    int getLocksPerResource();
+
+    /**
+     * Set locks per resource at runtime.
+     * @param locksPerResource new value, must be at least 1
+     */
+    void setLocksPerResource(int locksPerResource);
 }

--- a/docs/ECCTOOL_EXAMPLES.md
+++ b/docs/ECCTOOL_EXAMPLES.md
@@ -491,3 +491,42 @@ ecctool repair-info --keyspace test --table table1 --id 8a9d2a57-1388-42be-aab6-
 ```
 
 If the `output` option is set to JSON, the `columns` option will be ignored and a full JSON will be returned.
+
+## ecctool config
+
+### View current configuration
+
+```console
+$ ecctool config
+{
+  "session_window_ms": 300000,
+  "cooldown_ms": 0,
+  "locks_per_resource": 3
+}
+```
+
+### Update session window to 10 minutes
+
+```console
+$ ecctool config --session-window 10m
+{
+  "session_window_ms": 600000,
+  "cooldown_ms": 0,
+  "locks_per_resource": 3
+}
+```
+
+### Update multiple parameters
+
+```console
+$ ecctool config --session-window 5m --cooldown 30s --locks-per-resource 5
+{
+  "session_window_ms": 300000,
+  "cooldown_ms": 30000,
+  "locks_per_resource": 5
+}
+```
+
+Duration values accept: `5m` (minutes), `30s` (seconds), `2h` (hours), `500ms` (milliseconds), or raw milliseconds as integers.
+
+Changes are in-memory only. Restarting ecChronos restores values from `ecc.yml`.

--- a/docs/autogenerated/ECCTOOL.md
+++ b/docs/autogenerated/ECCTOOL.md
@@ -484,6 +484,28 @@ output formats: json (defaults to no format)
 ### -p &lt;pidfile&gt;, --pidfile &lt;pidfile&gt;
 file containing process id
 
+## ecctool config
+
+Show or update ecChronos runtime configuration. Changes are in-memory only — restarting ecChronos restores values from `ecc.yml`.
+
+```console
+usage: ecctool config [-h] [--session-window SESSION_WINDOW] [--cooldown COOLDOWN] [--locks-per-resource LOCKS_PER_RESOURCE] [-u URL]
+```
+
+When called without arguments, displays the current configuration. When called with one or more parameters, updates the specified values.
+
+### --session-window &lt;duration&gt;
+Time window for batched lock sessions. Accepts duration format: `5m`, `30s`, `2h`, `500ms`, or raw milliseconds.
+
+### --cooldown &lt;duration&gt;
+Cooldown period after a session completes. Accepts same duration format as `--session-window`.
+
+### --locks-per-resource &lt;int&gt;
+Number of concurrent locks per datacenter resource. Must be >= 1.
+
+### -u &lt;url&gt;, --url &lt;url&gt;
+ecchronos host URL (format: [http:/](http:/)/&lt;host&gt;:&lt;port&gt;)
+
 # Examples
 
 For example usage and explanation about output refer to [ECCTOOL_EXAMPLES.md](../ECCTOOL_EXAMPLES.md)

--- a/ecchronos-binary/src/bin/ecctool.py
+++ b/ecchronos-binary/src/bin/ecctool.py
@@ -213,9 +213,11 @@ def add_config_subcommand(sub_parsers):
 
 def config(arguments):
     request = rest.ConfigRequest(base_url=arguments.url)
-    has_updates = (arguments.session_window is not None
-                   or arguments.cooldown is not None
-                   or arguments.locks_per_resource is not None)
+    has_updates = (
+        arguments.session_window is not None
+        or arguments.cooldown is not None
+        or arguments.locks_per_resource is not None
+    )
     if has_updates:
         session_window_ms = parse_duration_ms(arguments.session_window) if arguments.session_window else None
         cooldown_ms = parse_duration_ms(arguments.cooldown) if arguments.cooldown else None

--- a/ecchronos-binary/src/bin/ecctool.py
+++ b/ecchronos-binary/src/bin/ecctool.py
@@ -18,6 +18,7 @@
 from __future__ import print_function
 
 import os
+import json
 import signal
 import sys
 import glob
@@ -159,6 +160,7 @@ def get_parser():
     )
     sub_parsers = parser.add_subparsers(dest="subcommand", help="")
 
+    add_config_subcommand(sub_parsers)
     add_rejections_subcommand(sub_parsers)
     add_repair_info_subcommand(sub_parsers)
     add_repairs_subcommand(sub_parsers)
@@ -177,6 +179,59 @@ def add_running_job_subcommand(sub_parsers):
     parser_repairs = sub_parsers.add_parser("running-job", description="Show which (if any) job is currently running.")
     add_common_arg(parser_repairs, ARG_OUTPUT_JSON)
     add_common_arg(parser_repairs, ARG_URL)
+
+
+def parse_duration_ms(value):
+    """Parse duration string (e.g. '5m', '30s', '300000') to milliseconds."""
+    try:
+        if value.endswith("ms"):
+            result = int(value[:-2])
+        elif value.endswith("s"):
+            result = int(value[:-1]) * 1000
+        elif value.endswith("m"):
+            result = int(value[:-1]) * 60 * 1000
+        elif value.endswith("h"):
+            result = int(value[:-1]) * 3600 * 1000
+        else:
+            result = int(value)
+    except ValueError:
+        print(f"Invalid duration format: '{value}'. Use e.g. 5m, 30s, 2h, 500ms, or raw milliseconds.")
+        sys.exit(1)
+    if result < 0:
+        print(f"Duration must not be negative: '{value}'")
+        sys.exit(1)
+    return result
+
+
+def add_config_subcommand(sub_parsers):
+    parser_config = sub_parsers.add_parser("config", description="Show or update ecChronos configuration.")
+    parser_config.add_argument("--session-window", type=str, help="session window duration (e.g. 5m, 30s, 300000)")
+    parser_config.add_argument("--cooldown", type=str, help="cooldown duration (e.g. 5m, 30s, 300000)")
+    parser_config.add_argument("--locks-per-resource", type=int, help="locks per resource")
+    add_common_arg(parser_config, ARG_URL)
+
+
+def config(arguments):
+    request = rest.ConfigRequest(base_url=arguments.url)
+    has_updates = (arguments.session_window is not None
+                   or arguments.cooldown is not None
+                   or arguments.locks_per_resource is not None)
+    if has_updates:
+        session_window_ms = parse_duration_ms(arguments.session_window) if arguments.session_window else None
+        cooldown_ms = parse_duration_ms(arguments.cooldown) if arguments.cooldown else None
+        result = request.patch(
+            session_window_ms=session_window_ms,
+            cooldown_ms=cooldown_ms,
+            locks_per_resource=arguments.locks_per_resource,
+        )
+    else:
+        result = request.get()
+
+    if result.is_successful():
+        print(json.dumps(result.data, indent=2))
+    else:
+        print(result.format_exception())
+        sys.exit(1)
 
 
 def add_repairs_subcommand(sub_parsers):
@@ -760,7 +815,10 @@ def running_job(arguments):
 
 
 def run_subcommand(arguments):
-    if arguments.subcommand == "rejections":
+    if arguments.subcommand == "config":
+        status(arguments)
+        config(arguments)
+    elif arguments.subcommand == "rejections":
         status(arguments)
         rejections(arguments)
     elif arguments.subcommand == "repair-info":

--- a/ecchronos-binary/src/pylib/ecchronoslib/rest.py
+++ b/ecchronos-binary/src/pylib/ecchronoslib/rest.py
@@ -382,6 +382,27 @@ class RejectionsRequest(RestRequest):
         return result
 
 
+class ConfigRequest(RestRequest):
+    URL = "repair-management/v2/config"
+
+    def __init__(self, base_url=None):
+        RestRequest.__init__(self, base_url)
+
+    def get(self):
+        return self.request(ConfigRequest.URL)
+
+    def patch(self, session_window_ms=None, cooldown_ms=None, locks_per_resource=None):
+        body = {}
+        if session_window_ms is not None:
+            body["session_window_ms"] = session_window_ms
+        if cooldown_ms is not None:
+            body["cooldown_ms"] = cooldown_ms
+        if locks_per_resource is not None:
+            body["locks_per_resource"] = locks_per_resource
+        headers = {"Content-Type": "application/json"}
+        return self.request(ConfigRequest.URL, "PATCH", body=body, headers=headers)
+
+
 def _create_response(request):
     cert_file = os.getenv("ECCTOOL_CERT_FILE")
     key_file = os.getenv("ECCTOOL_KEY_FILE")

--- a/ecchronos-binary/src/test/behave/features/ecc-rest-config.feature
+++ b/ecchronos-binary/src/test/behave/features/ecc-rest-config.feature
@@ -1,0 +1,42 @@
+Feature: API to manage runtime configuration
+
+  Scenario: Get current configuration
+    Given I use the url localhost:8080/repair-management/v2/config
+    When I send a GET request
+    Then the response is successful
+    And the response contains session_window_ms
+    And the response contains cooldown_ms
+    And the response contains locks_per_resource
+
+  Scenario: Update session window
+    Given I use the url localhost:8080/repair-management/v2/config
+    When I send a PATCH request with body {"session_window_ms": 120000}
+    Then the response is successful
+    And the response has session_window_ms equal to 120000
+
+  Scenario: Update cooldown
+    Given I use the url localhost:8080/repair-management/v2/config
+    When I send a PATCH request with body {"cooldown_ms": 5000}
+    Then the response is successful
+    And the response has cooldown_ms equal to 5000
+
+  Scenario: Update locks per resource
+    Given I use the url localhost:8080/repair-management/v2/config
+    When I send a PATCH request with body {"locks_per_resource": 5}
+    Then the response is successful
+    And the response has locks_per_resource equal to 5
+
+  Scenario: Update multiple parameters
+    Given I use the url localhost:8080/repair-management/v2/config
+    When I send a PATCH request with body {"session_window_ms": 600000, "cooldown_ms": 10000}
+    Then the response is successful
+    And the response has session_window_ms equal to 600000
+    And the response has cooldown_ms equal to 10000
+
+  Scenario: Get config reflects previous update
+    Given I use the url localhost:8080/repair-management/v2/config
+    When I send a PATCH request with body {"cooldown_ms": 7777}
+    Then the response is successful
+    When I send a GET request
+    Then the response is successful
+    And the response has cooldown_ms equal to 7777

--- a/ecchronos-binary/src/test/behave/features/steps/ecc_rest_config.py
+++ b/ecchronos-binary/src/test/behave/features/steps/ecc_rest_config.py
@@ -27,8 +27,9 @@ def step_send_patch_request(context, body):
     headers = {"Content-Type": "application/json"}
     if client_cert and client_key and client_ca:
         url = "https://" + context.url
-        context.response = requests.patch(url, data=body, headers=headers,
-                                          cert=(client_cert, client_key), verify=client_ca, timeout=10)
+        context.response = requests.patch(
+            url, data=body, headers=headers, cert=(client_cert, client_key), verify=client_ca, timeout=10
+        )
     else:
         url = "http://" + context.url
         context.response = requests.patch(url, data=body, headers=headers, timeout=10)

--- a/ecchronos-binary/src/test/behave/features/steps/ecc_rest_config.py
+++ b/ecchronos-binary/src/test/behave/features/steps/ecc_rest_config.py
@@ -1,0 +1,51 @@
+#
+# Copyright 2026 Telefonaktiebolaget LM Ericsson
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import json
+import requests
+from behave import when, then  # pylint: disable=no-name-in-module
+
+
+@when("I send a PATCH request with body {body}")
+def step_send_patch_request(context, body):
+    assert context.url is not None
+    client_cert = context.config.userdata.get("ecc_client_cert")
+    client_key = context.config.userdata.get("ecc_client_key")
+    client_ca = context.config.userdata.get("ecc_client_ca")
+    headers = {"Content-Type": "application/json"}
+    if client_cert and client_key and client_ca:
+        url = "https://" + context.url
+        context.response = requests.patch(url, data=body, headers=headers,
+                                          cert=(client_cert, client_key), verify=client_ca, timeout=10)
+    else:
+        url = "http://" + context.url
+        context.response = requests.patch(url, data=body, headers=headers, timeout=10)
+
+
+@then("the response contains {field}")
+def step_response_contains_field(context, field):
+    assert context.response is not None
+    data = context.response.json()
+    assert field in data, f"Field '{field}' not found in response: {data}"
+
+
+@then("the response has {field} equal to {value}")
+def step_response_field_equals(context, field, value):
+    assert context.response is not None
+    data = context.response.json()
+    assert field in data, f"Field '{field}' not found in response: {data}"
+    expected = json.loads(value)
+    actual = data[field]
+    assert actual == expected, f"Expected {field}={expected}, got {actual}"

--- a/ecchronos-binary/src/test/bin/test_ecctool_config.py
+++ b/ecchronos-binary/src/test/bin/test_ecctool_config.py
@@ -1,0 +1,74 @@
+#
+# Copyright 2026 Telefonaktiebolaget LM Ericsson
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Tests for ecctool config subcommand — duration parsing and CLI arg handling."""
+import sys
+import os
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "bin"))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "pylib"))
+
+
+def test_parse_duration_ms_seconds():
+    from ecctool import parse_duration_ms
+    assert parse_duration_ms("30s") == 30000
+
+
+def test_parse_duration_ms_minutes():
+    from ecctool import parse_duration_ms
+    assert parse_duration_ms("5m") == 300000
+
+
+def test_parse_duration_ms_hours():
+    from ecctool import parse_duration_ms
+    assert parse_duration_ms("2h") == 7200000
+
+
+def test_parse_duration_ms_milliseconds():
+    from ecctool import parse_duration_ms
+    assert parse_duration_ms("500ms") == 500
+
+
+def test_parse_duration_ms_raw_int():
+    from ecctool import parse_duration_ms
+    assert parse_duration_ms("300000") == 300000
+
+
+def test_parse_duration_ms_one_second():
+    from ecctool import parse_duration_ms
+    assert parse_duration_ms("1s") == 1000
+
+
+def test_parse_duration_ms_zero():
+    from ecctool import parse_duration_ms
+    assert parse_duration_ms("0") == 0
+
+
+def test_parse_duration_ms_invalid_format():
+    from ecctool import parse_duration_ms
+    try:
+        parse_duration_ms("abc")
+        assert False, "Should have raised SystemExit"
+    except SystemExit as e:
+        assert e.code == 1
+
+
+def test_parse_duration_ms_negative():
+    from ecctool import parse_duration_ms
+    try:
+        parse_duration_ms("-5m")
+        assert False, "Should have raised SystemExit"
+    except SystemExit as e:
+        assert e.code == 1

--- a/ecchronos-binary/src/test/bin/test_ecctool_config.py
+++ b/ecchronos-binary/src/test/bin/test_ecctool_config.py
@@ -23,41 +23,49 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "pylib"))
 
 def test_parse_duration_ms_seconds():
     from ecctool import parse_duration_ms
+
     assert parse_duration_ms("30s") == 30000
 
 
 def test_parse_duration_ms_minutes():
     from ecctool import parse_duration_ms
+
     assert parse_duration_ms("5m") == 300000
 
 
 def test_parse_duration_ms_hours():
     from ecctool import parse_duration_ms
+
     assert parse_duration_ms("2h") == 7200000
 
 
 def test_parse_duration_ms_milliseconds():
     from ecctool import parse_duration_ms
+
     assert parse_duration_ms("500ms") == 500
 
 
 def test_parse_duration_ms_raw_int():
     from ecctool import parse_duration_ms
+
     assert parse_duration_ms("300000") == 300000
 
 
 def test_parse_duration_ms_one_second():
     from ecctool import parse_duration_ms
+
     assert parse_duration_ms("1s") == 1000
 
 
 def test_parse_duration_ms_zero():
     from ecctool import parse_duration_ms
+
     assert parse_duration_ms("0") == 0
 
 
 def test_parse_duration_ms_invalid_format():
     from ecctool import parse_duration_ms
+
     try:
         parse_duration_ms("abc")
         assert False, "Should have raised SystemExit"
@@ -67,6 +75,7 @@ def test_parse_duration_ms_invalid_format():
 
 def test_parse_duration_ms_negative():
     from ecctool import parse_duration_ms
+
     try:
         parse_duration_ms("-5m")
         assert False, "Should have raised SystemExit"

--- a/pom.xml
+++ b/pom.xml
@@ -699,7 +699,7 @@ limitations under the License.
                         <headerSections>
                             <headerSection>
                                 <key>YEAR</key>
-                                <defaultValue>2024</defaultValue>
+                                <defaultValue>2026</defaultValue>
                                 <ensureMatch>[0-9-]+</ensureMatch>
                             </headerSection>
                         </headerSections>

--- a/rest/src/main/java/com/ericsson/bss/cassandra/ecchronos/rest/ConfigManagementRESTImpl.java
+++ b/rest/src/main/java/com/ericsson/bss/cassandra/ecchronos/rest/ConfigManagementRESTImpl.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2026 Telefonaktiebolaget LM Ericsson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ericsson.bss.cassandra.ecchronos.rest;
+
+import com.ericsson.bss.cassandra.ecchronos.core.repair.scheduler.ScheduleManager;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static com.ericsson.bss.cassandra.ecchronos.rest.RestUtils.REPAIR_MANAGEMENT_ENDPOINT_PREFIX;
+
+@RestController
+public final class ConfigManagementRESTImpl
+{
+    private static final String KEY_SESSION_WINDOW = "session_window_ms";
+    private static final String KEY_COOLDOWN = "cooldown_ms";
+    private static final String KEY_LOCKS_PER_RESOURCE = "locks_per_resource";
+    private static final int MIN_LOCKS_PER_RESOURCE = 1;
+
+    private final ScheduleManager myScheduleManager;
+
+    @Autowired
+    public ConfigManagementRESTImpl(final ScheduleManager scheduleManager)
+    {
+        myScheduleManager = scheduleManager;
+    }
+
+    @GetMapping(value = REPAIR_MANAGEMENT_ENDPOINT_PREFIX + "/v2/config", produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<Map<String, Object>> getConfig()
+    {
+        return ResponseEntity.ok(buildResponse());
+    }
+
+    @PatchMapping(value = REPAIR_MANAGEMENT_ENDPOINT_PREFIX + "/v2/config", produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<Map<String, Object>> patchConfig(@RequestBody final Map<String, Object> body)
+    {
+        try
+        {
+            validatePatchBody(body);
+            applyPatchBody(body);
+        }
+        catch (IllegalArgumentException e)
+        {
+            Map<String, Object> error = new LinkedHashMap<>();
+            error.put("error", e.getMessage());
+            return ResponseEntity.badRequest().body(error);
+        }
+        return ResponseEntity.ok(buildResponse());
+    }
+
+    private void validatePatchBody(final Map<String, Object> body)
+    {
+        validateMin(body, KEY_SESSION_WINDOW, 1, "session_window must be > 0");
+        validateMin(body, KEY_COOLDOWN, 0, "cooldown must be >= 0");
+        validateMin(body, KEY_LOCKS_PER_RESOURCE, MIN_LOCKS_PER_RESOURCE, "locks_per_resource must be >= 1");
+    }
+
+    private void validateMin(final Map<String, Object> body, final String key, final long min, final String message)
+    {
+        if (body.containsKey(key) && ((Number) body.get(key)).longValue() < min)
+        {
+            throw new IllegalArgumentException(message);
+        }
+    }
+
+    private void applyPatchBody(final Map<String, Object> body)
+    {
+        if (body.containsKey(KEY_SESSION_WINDOW))
+        {
+            myScheduleManager.setSessionWindowInMs(((Number) body.get(KEY_SESSION_WINDOW)).longValue());
+        }
+        if (body.containsKey(KEY_COOLDOWN))
+        {
+            myScheduleManager.setCooldownInMs(((Number) body.get(KEY_COOLDOWN)).longValue());
+        }
+        if (body.containsKey(KEY_LOCKS_PER_RESOURCE))
+        {
+            myScheduleManager.setLocksPerResource(((Number) body.get(KEY_LOCKS_PER_RESOURCE)).intValue());
+        }
+    }
+
+    private Map<String, Object> buildResponse()
+    {
+        Map<String, Object> config = new LinkedHashMap<>();
+        config.put(KEY_SESSION_WINDOW, myScheduleManager.getSessionWindowInMs());
+        config.put(KEY_COOLDOWN, myScheduleManager.getCooldownInMs());
+        config.put(KEY_LOCKS_PER_RESOURCE, myScheduleManager.getLocksPerResource());
+        return config;
+    }
+}

--- a/rest/src/test/java/com/ericsson/bss/cassandra/ecchronos/rest/ITConfigManagement.java
+++ b/rest/src/test/java/com/ericsson/bss/cassandra/ecchronos/rest/ITConfigManagement.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2026 Telefonaktiebolaget LM Ericsson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ericsson.bss.cassandra.ecchronos.rest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.datastax.oss.driver.api.core.metadata.Node;
+import com.ericsson.bss.cassandra.ecchronos.connection.DistributedNativeConnectionProvider;
+import com.ericsson.bss.cassandra.ecchronos.core.impl.locks.CASLockFactory;
+import com.ericsson.bss.cassandra.ecchronos.core.impl.repair.RepairLockFactoryImpl;
+import com.ericsson.bss.cassandra.ecchronos.core.impl.repair.scheduler.ScheduleManagerImpl;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.http.ResponseEntity;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Integration test: round-trip GET/PATCH via ConfigManagementRESTImpl
+ * with a real ScheduleManagerImpl to verify parameters are persisted and readable.
+ */
+public class ITConfigManagement
+{
+    private ConfigManagementRESTImpl myController;
+    private ScheduleManagerImpl myScheduleManager;
+    private int originalLocksPerResource;
+
+    @Before
+    public void setup()
+    {
+        UUID nodeId = UUID.randomUUID();
+        Node mockNode = mock(Node.class);
+        DistributedNativeConnectionProvider ncp = mock(DistributedNativeConnectionProvider.class);
+        when(ncp.getNodes()).thenReturn(Map.of(nodeId, mockNode));
+        CASLockFactory lockFactory = mock(CASLockFactory.class);
+
+        myScheduleManager = ScheduleManagerImpl.builder()
+                .withNodeIDList(Collections.singletonList(nodeId))
+                .withNativeConnectionProvider(ncp)
+                .withLockFactory(lockFactory)
+                .build();
+
+        myController = new ConfigManagementRESTImpl(myScheduleManager);
+        originalLocksPerResource = RepairLockFactoryImpl.getLocksPerResource();
+    }
+
+    @After
+    public void teardown()
+    {
+        myScheduleManager.close();
+        RepairLockFactoryImpl.configure(originalLocksPerResource);
+    }
+
+    @Test
+    public void testGetReturnsCurrentConfig()
+    {
+        ResponseEntity<Map<String, Object>> response = myController.getConfig();
+
+        assertThat(response.getStatusCode().value()).isEqualTo(200);
+        Map<String, Object> body = response.getBody();
+        assertThat(((Number) body.get("session_window_ms")).longValue()).isEqualTo(300000L);
+        assertThat(((Number) body.get("cooldown_ms")).longValue()).isEqualTo(0L);
+        assertThat(((Number) body.get("locks_per_resource")).intValue()).isEqualTo(originalLocksPerResource);
+    }
+
+    @Test
+    public void testPatchSessionWindowRoundTrip()
+    {
+        Map<String, Object> patch = new HashMap<>();
+        patch.put("session_window_ms", 120000L);
+
+        myController.patchConfig(patch);
+
+        ResponseEntity<Map<String, Object>> response = myController.getConfig();
+        assertThat(((Number) response.getBody().get("session_window_ms")).longValue()).isEqualTo(120000L);
+        assertThat(myScheduleManager.getSessionWindowInMs()).isEqualTo(120000L);
+    }
+
+    @Test
+    public void testPatchCooldownRoundTrip()
+    {
+        Map<String, Object> patch = new HashMap<>();
+        patch.put("cooldown_ms", 15000L);
+
+        myController.patchConfig(patch);
+
+        assertThat(myScheduleManager.getCooldownInMs()).isEqualTo(15000L);
+    }
+
+    @Test
+    public void testPatchLocksPerResourceRoundTrip()
+    {
+        Map<String, Object> patch = new HashMap<>();
+        patch.put("locks_per_resource", 5);
+
+        myController.patchConfig(patch);
+
+        assertThat(RepairLockFactoryImpl.getLocksPerResource()).isEqualTo(5);
+    }
+
+    @Test
+    public void testPatchMultipleParametersRoundTrip()
+    {
+        Map<String, Object> patch = new HashMap<>();
+        patch.put("session_window_ms", 600000L);
+        patch.put("cooldown_ms", 5000L);
+        patch.put("locks_per_resource", 2);
+
+        ResponseEntity<Map<String, Object>> response = myController.patchConfig(patch);
+        Map<String, Object> body = response.getBody();
+
+        assertThat(((Number) body.get("session_window_ms")).longValue()).isEqualTo(600000L);
+        assertThat(((Number) body.get("cooldown_ms")).longValue()).isEqualTo(5000L);
+        assertThat(((Number) body.get("locks_per_resource")).intValue()).isEqualTo(2);
+    }
+
+    @Test
+    public void testPatchDoesNotAffectUnspecifiedParameters()
+    {
+        long beforeSessionWindow = myScheduleManager.getSessionWindowInMs();
+
+        Map<String, Object> patch = new HashMap<>();
+        patch.put("cooldown_ms", 7000L);
+
+        myController.patchConfig(patch);
+
+        assertThat(myScheduleManager.getSessionWindowInMs()).isEqualTo(beforeSessionWindow);
+        assertThat(RepairLockFactoryImpl.getLocksPerResource()).isEqualTo(originalLocksPerResource);
+    }
+}

--- a/rest/src/test/java/com/ericsson/bss/cassandra/ecchronos/rest/TestConfigManagementRESTImpl.java
+++ b/rest/src/test/java/com/ericsson/bss/cassandra/ecchronos/rest/TestConfigManagementRESTImpl.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2026 Telefonaktiebolaget LM Ericsson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ericsson.bss.cassandra.ecchronos.rest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.ericsson.bss.cassandra.ecchronos.core.repair.scheduler.ScheduleManager;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.http.ResponseEntity;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@RunWith(MockitoJUnitRunner.Silent.class)
+public class TestConfigManagementRESTImpl
+{
+    @Mock
+    private ScheduleManager myScheduleManager;
+
+    private ConfigManagementRESTImpl controller;
+
+    @Before
+    public void setup()
+    {
+        controller = new ConfigManagementRESTImpl(myScheduleManager);
+        when(myScheduleManager.getSessionWindowInMs()).thenReturn(300000L);
+        when(myScheduleManager.getCooldownInMs()).thenReturn(0L);
+        when(myScheduleManager.getLocksPerResource()).thenReturn(3);
+    }
+
+    @Test
+    public void testGetConfig()
+    {
+        ResponseEntity<Map<String, Object>> response = controller.getConfig();
+
+        assertThat(response.getStatusCode().value()).isEqualTo(200);
+        Map<String, Object> body = response.getBody();
+        assertThat(body.get("session_window_ms")).isEqualTo(300000L);
+        assertThat(body.get("cooldown_ms")).isEqualTo(0L);
+        assertThat(body.get("locks_per_resource")).isEqualTo(3);
+    }
+
+    @Test
+    public void testPatchSessionWindow()
+    {
+        Map<String, Object> patch = new HashMap<>();
+        patch.put("session_window_ms", 600000L);
+
+        controller.patchConfig(patch);
+
+        verify(myScheduleManager).setSessionWindowInMs(600000L);
+    }
+
+    @Test
+    public void testPatchCooldown()
+    {
+        Map<String, Object> patch = new HashMap<>();
+        patch.put("cooldown_ms", 30000L);
+
+        controller.patchConfig(patch);
+
+        verify(myScheduleManager).setCooldownInMs(30000L);
+    }
+
+    @Test
+    public void testPatchLocksPerResource()
+    {
+        Map<String, Object> patch = new HashMap<>();
+        patch.put("locks_per_resource", 5);
+
+        controller.patchConfig(patch);
+
+        verify(myScheduleManager).setLocksPerResource(5);
+    }
+
+    @Test
+    public void testPatchMultipleFields()
+    {
+        Map<String, Object> patch = new HashMap<>();
+        patch.put("session_window_ms", 120000L);
+        patch.put("cooldown_ms", 5000L);
+
+        controller.patchConfig(patch);
+
+        verify(myScheduleManager).setSessionWindowInMs(120000L);
+        verify(myScheduleManager).setCooldownInMs(5000L);
+    }
+
+    @Test
+    public void testPatchEmptyBodyChangesNothing()
+    {
+        Map<String, Object> patch = new HashMap<>();
+
+        ResponseEntity<Map<String, Object>> response = controller.patchConfig(patch);
+
+        assertThat(response.getStatusCode().value()).isEqualTo(200);
+    }
+
+    @Test
+    public void testPatchInvalidSessionWindowReturns400()
+    {
+        Map<String, Object> patch = new HashMap<>();
+        patch.put("session_window_ms", -1L);
+
+        ResponseEntity<Map<String, Object>> response = controller.patchConfig(patch);
+
+        assertThat(response.getStatusCode().value()).isEqualTo(400);
+        assertThat(response.getBody().get("error")).isEqualTo("session_window must be > 0");
+    }
+
+    @Test
+    public void testPatchInvalidLocksPerResourceReturns400()
+    {
+        Map<String, Object> patch = new HashMap<>();
+        patch.put("locks_per_resource", 0);
+
+        ResponseEntity<Map<String, Object>> response = controller.patchConfig(patch);
+
+        assertThat(response.getStatusCode().value()).isEqualTo(400);
+        assertThat(response.getBody().get("error")).isEqualTo("locks_per_resource must be >= 1");
+    }
+}


### PR DESCRIPTION
Add GET/PATCH /repair-management/v2/config endpoints and ecctool config subcommand to view and modify session_window, cooldown, and locks_per_resource at runtime without restart.

- ScheduleManagerImpl: volatile fields with getters/setters
- RepairLockFactoryImpl: public static getLocksPerResource()
- ConfigManagementRESTImpl: GET/PATCH controller
- ecctool: config subcommand with duration parsing (5m, 30s, etc)

Changes are in-memory only; restart restores ecc.yml values.

Closes #1638 