### PR TITLE
Add local lock gate to eliminate intra-instance CAS contention

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Version 1.0.2 (Not yet Released)
 
+* Add local lock gate to eliminate intra-instance CAS contention - Issue #1640
 * Add runtime configuration of scheduler parameters via ecctool - Issue #1638
 * Implement Batched Lock Acquisition Strategy to Improve Repair Throughput in Large Clusters - Issue #1618
 * Add javax.net.ssl.sessionCacheSize=50 to jvm.options to bound Jolokia SSL sessions - Issue #1626

--- a/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/RepairLockFactoryImpl.java
+++ b/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/RepairLockFactoryImpl.java
@@ -19,6 +19,7 @@ import com.ericsson.bss.cassandra.ecchronos.core.locks.LockFactory;
 import com.ericsson.bss.cassandra.ecchronos.core.repair.RepairLockFactory;
 import com.ericsson.bss.cassandra.ecchronos.core.repair.RepairResource;
 import com.ericsson.bss.cassandra.ecchronos.utils.exceptions.LockException;
+import com.google.common.annotations.VisibleForTesting;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -26,6 +27,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.slf4j.Logger;
@@ -38,6 +41,18 @@ public class RepairLockFactoryImpl implements RepairLockFactory
     private static final int DEFAULT_LOCKS_PER_RESOURCE = 3;
     private static final AtomicInteger CONFIGURED_LOCKS_PER_RESOURCE = new AtomicInteger(DEFAULT_LOCKS_PER_RESOURCE);
     private static final AtomicInteger LOCK_COUNTER = new AtomicInteger(0);
+    // Entries accumulate for each unique resource name seen (typically <20 for a few DCs × slots).
+    // Not bounded, but growth is negligible (~100 bytes per entry).
+    private static final ConcurrentHashMap<String, Semaphore> LOCAL_GATES = new ConcurrentHashMap<>();
+
+    /**
+     * Reset local gates. Intended for testing only.
+     */
+    @VisibleForTesting
+    static void resetLocalGates()
+    {
+        LOCAL_GATES.clear();
+    }
 
     /**
      * Configure the global locks per resource value.
@@ -153,13 +168,20 @@ public class RepairLockFactoryImpl implements RepairLockFactory
         {
             int lockNumber = ((startLock + i) % locksPerResource) + 1;
             String resource = repairResource.getResourceName(lockNumber);
+
+            Semaphore gate = LOCAL_GATES.computeIfAbsent(resource, k -> new Semaphore(1));
+            if (!gate.tryAcquire())
+            {
+                LOG.debug("Local gate busy for {}, trying next slot", resource);
+                continue;
+            }
+
             try
             {
                 myLock = lockFactory.tryLock(dataCenter, resource, priority, metadata, nodeId);
-
                 if (myLock != null)
                 {
-                    return myLock;
+                    return new LocallyGatedLock(myLock, gate);
                 }
             }
             catch (LockException e)
@@ -169,11 +191,37 @@ public class RepairLockFactoryImpl implements RepairLockFactory
                         dataCenter,
                         e);
             }
+            gate.release();
         }
 
         String msg = String.format("Lock resources exhausted for %s", repairResource);
         LOG.warn(msg);
         throw new LockException(msg);
+    }
+
+    private static final class LocallyGatedLock implements LockFactory.DistributedLock
+    {
+        private final LockFactory.DistributedLock myDelegate;
+        private final Semaphore myGate;
+
+        LocallyGatedLock(final LockFactory.DistributedLock delegate, final Semaphore gate)
+        {
+            myDelegate = delegate;
+            myGate = gate;
+        }
+
+        @Override
+        public void close()
+        {
+            try
+            {
+                myDelegate.close();
+            }
+            finally
+            {
+                myGate.release();
+            }
+        }
     }
 
     static class TemporaryLockHolder implements AutoCloseable

--- a/core.impl/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/TestRepairLockFactoryImpl.java
+++ b/core.impl/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/TestRepairLockFactoryImpl.java
@@ -22,6 +22,7 @@ import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -64,6 +65,7 @@ public class TestRepairLockFactoryImpl
     @Before
     public void setup()
     {
+        RepairLockFactoryImpl.resetLocalGates();
         when(mockLockFactory.getCachedFailure(any(UUID.class), anyString(), anyString())).thenReturn(Optional.empty());
     }
 
@@ -222,6 +224,70 @@ public class TestRepairLockFactoryImpl
     {
         assertThatExceptionOfType(IllegalArgumentException.class)
                 .isThrownBy(() -> RepairLockFactoryImpl.configure(0));
+    }
+
+    @Test
+    public void testLocalGateBlocksConcurrentAccessToSameSlot() throws LockException
+    {
+        RepairResource repairResource = new RepairResource("DC1", "gate-test");
+        Map<String, String> metadata = Collections.singletonMap("key", "value");
+        int priority = 1;
+
+        for (int slot = 1; slot <= LOCKS_PER_RESOURCE; slot++)
+        {
+            when(mockLockFactory.tryLock(eq("DC1"), eq(repairResource.getResourceName(slot)), eq(priority), eq(metadata), any()))
+                    .thenReturn(mockLock);
+        }
+
+        // Acquire all 3 slots
+        LockFactory.DistributedLock lock1 = repairLockFactory.getLock(
+                mockLockFactory, Sets.newHashSet(repairResource), metadata, priority, UUID.randomUUID());
+        LockFactory.DistributedLock lock2 = repairLockFactory.getLock(
+                mockLockFactory, Sets.newHashSet(repairResource), metadata, priority, UUID.randomUUID());
+        LockFactory.DistributedLock lock3 = repairLockFactory.getLock(
+                mockLockFactory, Sets.newHashSet(repairResource), metadata, priority, UUID.randomUUID());
+
+        // Fourth acquire fails - all local gates held
+        assertThatExceptionOfType(LockException.class)
+                .isThrownBy(() -> repairLockFactory.getLock(
+                        mockLockFactory, Sets.newHashSet(repairResource), metadata, priority, UUID.randomUUID()));
+
+        // Release one - next acquire succeeds
+        lock1.close();
+        LockFactory.DistributedLock lock4 = repairLockFactory.getLock(
+                mockLockFactory, Sets.newHashSet(repairResource), metadata, priority, UUID.randomUUID());
+        assertThat(lock4).isNotNull();
+
+        lock2.close();
+        lock3.close();
+        lock4.close();
+    }
+
+    @Test
+    public void testLocalGateReleasedOnCASFailure() throws LockException
+    {
+        RepairResource repairResource = new RepairResource("DC1", "cas-fail-test");
+        Map<String, String> metadata = Collections.singletonMap("key", "value");
+        int priority = 1;
+
+        for (int slot = 1; slot <= LOCKS_PER_RESOURCE; slot++)
+        {
+            when(mockLockFactory.tryLock(eq("DC1"), eq(repairResource.getResourceName(slot)), eq(priority), eq(metadata), any()))
+                    .thenThrow(new LockException("CAS failed"));
+        }
+
+        // First attempt fails, gates released
+        assertThatExceptionOfType(LockException.class)
+                .isThrownBy(() -> repairLockFactory.getLock(
+                        mockLockFactory, Sets.newHashSet(repairResource), metadata, priority, UUID.randomUUID()));
+
+        // Second attempt also tries CAS (gates were released)
+        assertThatExceptionOfType(LockException.class)
+                .isThrownBy(() -> repairLockFactory.getLock(
+                        mockLockFactory, Sets.newHashSet(repairResource), metadata, priority, UUID.randomUUID()));
+
+        // 6 CAS attempts total (3 slots × 2 rounds)
+        verify(mockLockFactory, times(6)).tryLock(anyString(), anyString(), anyInt(), anyMap(), any());
     }
 
     private void verifyNoLockWasTried() throws LockException


### PR DESCRIPTION
Introduce a JVM-local Semaphore per lock slot in RepairLockFactoryImpl. Threads that cannot acquire the local gate are rejected instantly without making a CAS network call. Only threads that pass the gate attempt the distributed lock, eliminating wasted Paxos rounds from intra-instance competition.

With 50 nodes and 3 slots, this reduces CAS attempts from 50 to at most 3 per scheduling cycle.

Closes #1640 