### PR TITLE
Add resource-level blocking gate for overlapping lock acquisition

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Version 1.0.2 (Not yet Released)
 
+* Add resource-level blocking gate to serialize overlapping lock acquisition - Issue #1643
 * Add local lock gate to eliminate intra-instance CAS contention - Issue #1640
 * Add runtime configuration of scheduler parameters via ecctool - Issue #1638
 * Implement Batched Lock Acquisition Strategy to Improve Repair Throughput in Large Clusters - Issue #1618

--- a/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/RepairLockFactoryImpl.java
+++ b/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/RepairLockFactoryImpl.java
@@ -22,6 +22,7 @@ import com.ericsson.bss.cassandra.ecchronos.utils.exceptions.LockException;
 import com.google.common.annotations.VisibleForTesting;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -30,6 +31,7 @@ import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -44,6 +46,7 @@ public class RepairLockFactoryImpl implements RepairLockFactory
     // Entries accumulate for each unique resource name seen (typically <20 for a few DCs × slots).
     // Not bounded, but growth is negligible (~100 bytes per entry).
     private static final ConcurrentHashMap<String, Semaphore> LOCAL_GATES = new ConcurrentHashMap<>();
+    private static final ConcurrentHashMap<RepairResource, Semaphore> RESOURCE_GATES = new ConcurrentHashMap<>();
 
     /**
      * Reset local gates. Intended for testing only.
@@ -52,6 +55,7 @@ public class RepairLockFactoryImpl implements RepairLockFactory
     static void resetLocalGates()
     {
         LOCAL_GATES.clear();
+        RESOURCE_GATES.clear();
     }
 
     /**
@@ -129,9 +133,22 @@ public class RepairLockFactoryImpl implements RepairLockFactory
                                                                            final UUID nodeId)
                                                                                                throws LockException
     {
+        // Sort resources to prevent ABBA deadlock
+        List<RepairResource> sorted = repairResources.stream()
+                .sorted(Comparator.comparing(RepairResource::toString))
+                .collect(Collectors.toList());
+
+        List<Semaphore> heldResourceGates = new ArrayList<>();
+        for (RepairResource resource : sorted)
+        {
+            Semaphore gate = RESOURCE_GATES.computeIfAbsent(resource, k -> new Semaphore(1));
+            gate.acquireUninterruptibly();
+            heldResourceGates.add(gate);
+        }
+
         try (TemporaryLockHolder lockHolder = new TemporaryLockHolder())
         {
-            for (RepairResource repairResource : repairResources)
+            for (RepairResource repairResource : sorted)
             {
                 try
                 {
@@ -148,6 +165,13 @@ public class RepairLockFactoryImpl implements RepairLockFactory
             }
 
             return lockHolder.getAndClear();
+        }
+        finally
+        {
+            for (Semaphore gate : heldResourceGates)
+            {
+                gate.release();
+            }
         }
     }
 

--- a/core.impl/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/TestRepairLockFactoryImpl.java
+++ b/core.impl/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/TestRepairLockFactoryImpl.java
@@ -290,6 +290,149 @@ public class TestRepairLockFactoryImpl
         verify(mockLockFactory, times(6)).tryLock(anyString(), anyString(), anyInt(), anyMap(), any());
     }
 
+    @Test
+    public void testResourceGateBlocksOverlappingThreads() throws Exception
+    {
+        RepairResource shared = new RepairResource("DC1", "shared-res");
+        Map<String, String> metadata = Collections.singletonMap("key", "value");
+        int priority = 1;
+
+        java.util.concurrent.CountDownLatch t1InCAS = new java.util.concurrent.CountDownLatch(1);
+        java.util.concurrent.CountDownLatch t1Proceed = new java.util.concurrent.CountDownLatch(1);
+        java.util.concurrent.CountDownLatch t2Started = new java.util.concurrent.CountDownLatch(1);
+        java.util.concurrent.CountDownLatch t2Acquired = new java.util.concurrent.CountDownLatch(1);
+        java.util.concurrent.atomic.AtomicBoolean t2WasBlocked = new java.util.concurrent.atomic.AtomicBoolean(false);
+
+        // t1's CAS blocks until we signal it to proceed
+        for (int slot = 1; slot <= LOCKS_PER_RESOURCE; slot++)
+        {
+            when(mockLockFactory.tryLock(eq("DC1"), eq(shared.getResourceName(slot)), eq(priority), eq(metadata), any()))
+                    .thenAnswer(invocation -> {
+                        t1InCAS.countDown(); // Signal t1 is inside CAS (holding resource gate)
+                        t1Proceed.await();   // Wait until test signals to proceed
+                        return mockLock;
+                    });
+        }
+
+        Thread t1 = new Thread(() -> {
+            try
+            {
+                repairLockFactory.getLock(mockLockFactory, Sets.newHashSet(shared), metadata, priority, UUID.randomUUID());
+            }
+            catch (Exception ignored) { }
+        });
+
+        Thread t2 = new Thread(() -> {
+            try
+            {
+                t2Started.countDown();
+                repairLockFactory.getLock(mockLockFactory, Sets.newHashSet(shared), metadata, priority, UUID.randomUUID());
+            }
+            catch (Exception ignored) { }
+            t2Acquired.countDown();
+        });
+
+        t1.start();
+        t1InCAS.await(); // t1 is now inside CAS, holding the resource gate
+
+        t2.start();
+        t2Started.await();
+        Thread.sleep(20); // Give t2 time to hit the resource gate
+
+        // t2 should be blocked (not yet acquired)
+        t2WasBlocked.set(t2Acquired.getCount() == 1);
+
+        // Release t1
+        t1Proceed.countDown();
+
+        // t2 should now complete
+        assertThat(t2Acquired.await(2, java.util.concurrent.TimeUnit.SECONDS)).isTrue();
+        assertThat(t2WasBlocked.get()).isTrue();
+
+        t1.join(2000);
+        t2.join(2000);
+    }
+
+    @Test
+    public void testResourceGateAllowsNonOverlappingThreads() throws Exception
+    {
+        RepairResource res1 = new RepairResource("DC1", "disjoint-a");
+        RepairResource res2 = new RepairResource("DC1", "disjoint-b");
+        Map<String, String> metadata = Collections.singletonMap("key", "value");
+        int priority = 1;
+
+        java.util.concurrent.CountDownLatch bothInCAS = new java.util.concurrent.CountDownLatch(2);
+        java.util.concurrent.CountDownLatch proceed = new java.util.concurrent.CountDownLatch(1);
+
+        // Both resources' CAS blocks until signaled — if they're serialized, we'd deadlock
+        for (int slot = 1; slot <= LOCKS_PER_RESOURCE; slot++)
+        {
+            when(mockLockFactory.tryLock(eq("DC1"), eq(res1.getResourceName(slot)), eq(priority), eq(metadata), any()))
+                    .thenAnswer(invocation -> {
+                        bothInCAS.countDown();
+                        proceed.await();
+                        return mockLock;
+                    });
+            when(mockLockFactory.tryLock(eq("DC1"), eq(res2.getResourceName(slot)), eq(priority), eq(metadata), any()))
+                    .thenAnswer(invocation -> {
+                        bothInCAS.countDown();
+                        proceed.await();
+                        return mockLock;
+                    });
+        }
+
+        Thread t1 = new Thread(() -> {
+            try { repairLockFactory.getLock(mockLockFactory, Sets.newHashSet(res1), metadata, priority, UUID.randomUUID()); }
+            catch (Exception ignored) { }
+        });
+        Thread t2 = new Thread(() -> {
+            try { repairLockFactory.getLock(mockLockFactory, Sets.newHashSet(res2), metadata, priority, UUID.randomUUID()); }
+            catch (Exception ignored) { }
+        });
+
+        t1.start();
+        t2.start();
+
+        // Both threads must reach CAS concurrently (non-overlapping resources = no blocking)
+        assertThat(bothInCAS.await(2, java.util.concurrent.TimeUnit.SECONDS)).isTrue();
+
+        proceed.countDown();
+        t1.join(2000);
+        t2.join(2000);
+    }
+
+    @Test
+    public void testResourceGateReleasedOnLockFailure() throws Exception
+    {
+        RepairResource resource = new RepairResource("DC1", "fail-release");
+        Map<String, String> metadata = Collections.singletonMap("key", "value");
+        int priority = 1;
+
+        for (int slot = 1; slot <= LOCKS_PER_RESOURCE; slot++)
+        {
+            when(mockLockFactory.tryLock(eq("DC1"), eq(resource.getResourceName(slot)), eq(priority), eq(metadata), any()))
+                    .thenThrow(new LockException("fail"));
+        }
+
+        // First attempt fails
+        assertThatExceptionOfType(LockException.class)
+                .isThrownBy(() -> repairLockFactory.getLock(
+                        mockLockFactory, Sets.newHashSet(resource), metadata, priority, UUID.randomUUID()));
+
+        // Resource gate must be released - second attempt should not deadlock
+        java.util.concurrent.CountDownLatch done = new java.util.concurrent.CountDownLatch(1);
+        Thread t = new Thread(() -> {
+            try
+            {
+                repairLockFactory.getLock(mockLockFactory, Sets.newHashSet(resource), metadata, priority, UUID.randomUUID());
+            }
+            catch (LockException ignored) { }
+            done.countDown();
+        });
+        t.start();
+        assertThat(done.await(2, java.util.concurrent.TimeUnit.SECONDS)).isTrue();
+    }
+
     private void verifyNoLockWasTried() throws LockException
     {
         verify(mockLockFactory, never()).tryLock(anyString(), anyString(), anyInt(), anyMap(), any());

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -180,6 +180,8 @@ As some jobs might take more than 10 minutes to run the lease is continuously up
   <figcaption>Figure 3: Compare-And-Set.</figcaption>
 </div>
 
+**Two-layer local gating:** Before attempting distributed CAS locks, ecChronos serializes threads that need overlapping repair resources. This ensures only one thread at a time performs the multi-resource lock acquisition for a given resource, preventing wasted Paxos rounds and rollback cascades. Threads with non-overlapping resources proceed fully in parallel. Within each resource's slot iteration, a non-blocking slot gate further prevents redundant CAS attempts on the same lock row.
+
 ### Scheduling flow
 
 The scheduling in ecChronos is handled by the `schedule manager`.


### PR DESCRIPTION
Serialize threads with overlapping RepairResource sets using a blocking Semaphore(1) per resource. Resources acquired in sorted order to prevent deadlock. Gate held only during lock acquisition phase (~10-100ms), not during the repair itself.

Complements #1640's slot-level non-blocking gate. Together they eliminate both intra-instance slot contention and overlapping multi-resource waste.

Closes #1643 