### PR TITLE
Fix TLS certificate hot-reload for Jolokia HTTP client

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Version 1.0.2 (Not yet Released)
 
+* Fix TLS certificate hot-reload for Jolokia HTTP client - Issue #1657
 * Add resource-level blocking gate to serialize overlapping lock acquisition - Issue #1643
 * Add local lock gate to eliminate intra-instance CAS contention - Issue #1640
 * Add runtime configuration of scheduler parameters via ecctool - Issue #1638

--- a/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/jmx/JolokiaHttpClient.java
+++ b/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/jmx/JolokiaHttpClient.java
@@ -1,0 +1,315 @@
+/*
+ * Copyright 2026 Telefonaktiebolaget LM Ericsson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ericsson.bss.cassandra.ecchronos.core.impl.jmx;
+
+import com.ericsson.bss.cassandra.ecchronos.core.impl.jmx.http.ClientRegisterResponse;
+import com.ericsson.bss.cassandra.ecchronos.core.impl.jmx.http.NotificationRegisterResponse;
+import com.ericsson.bss.cassandra.ecchronos.connection.CertificateHandler;
+import com.ericsson.bss.cassandra.ecchronos.connection.DistributedNativeConnectionProvider;
+import com.ericsson.bss.cassandra.ecchronos.data.iptranslator.IpTranslator;
+import com.google.common.annotations.VisibleForTesting;
+import com.ericsson.bss.cassandra.ecchronos.utils.dns.ReverseDNS;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.net.ssl.SSLContext;
+import java.io.IOException;
+import java.net.URI;
+import java.net.UnknownHostException;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+final class JolokiaHttpClient
+{
+    private static final Logger LOG = LoggerFactory.getLogger(JolokiaHttpClient.class);
+    private static final int HTTP_TIMEOUT_SECONDS = 5;
+    private static final int HTTP_REQUEST_TIMEOUT_SECONDS = 10;
+    private static final int SSL_SESSION_CACHE_SIZE = 50;
+    private static final int SSL_SESSION_TIMEOUT_SECONDS = 3600;
+    private static final int MAX_RETRIES = 3;
+    private static final long INITIAL_RETRY_DELAY_IN_MS = 500;
+    private static final String CLIENT_ID_PROPERTY = "clientID";
+    private static final String SS_OBJ_NAME = "org.apache.cassandra.db:type=StorageService";
+    public static final String NO_BROADCAST_ADDRESS = "0.0.0.0"; //NOPMD AvoidUsingHardCodedIP
+
+    private final Map<UUID, Map<String, String>> myClientIdMap = new ConcurrentHashMap<>();
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final CertificateHandler myCertificateHandler;
+    private final DistributedNativeConnectionProvider myNativeConnectionProvider;
+    private final int myJolokiaPort;
+    private final boolean myReverseDNSResolution;
+    private final String myURLPrefix;
+    private final IpTranslator myIpTranslator;
+    private volatile HttpClient myHttpClient;
+    private volatile SSLContext myCurrentSSLContext;
+
+    JolokiaHttpClient(final CertificateHandler certificateHandler,
+                      final DistributedNativeConnectionProvider nativeConnectionProvider,
+                      final int jolokiaPort,
+                      final boolean jolokiaPEM,
+                      final boolean reverseDNSResolution,
+                      final IpTranslator ipTranslator)
+    {
+        myCertificateHandler = certificateHandler;
+        myNativeConnectionProvider = nativeConnectionProvider;
+        myJolokiaPort = jolokiaPort;
+        myURLPrefix = jolokiaPEM ? "https" : "http";
+        myReverseDNSResolution = reverseDNSResolution;
+        myIpTranslator = ipTranslator;
+        myHttpClient = buildHttpClient();
+    }
+
+    @VisibleForTesting
+    HttpClient getHttpClient()
+    {
+        if (myCertificateHandler != null)
+        {
+            SSLContext latestContext = myCertificateHandler.getSSLContext();
+            if (latestContext != null && latestContext != myCurrentSSLContext) // NOPMD CompareObjectsWithEquals
+            {
+                myHttpClient = buildHttpClient();
+            }
+        }
+        return myHttpClient;
+    }
+
+    private HttpClient buildHttpClient()
+    {
+        HttpClient.Builder builder = HttpClient.newBuilder()
+                .connectTimeout(java.time.Duration.ofSeconds(HTTP_TIMEOUT_SECONDS));
+        if (myCertificateHandler != null)
+        {
+            SSLContext sslContext = myCertificateHandler.getSSLContext();
+            if (sslContext != null)
+            {
+                sslContext.getClientSessionContext().setSessionCacheSize(SSL_SESSION_CACHE_SIZE);
+                sslContext.getClientSessionContext().setSessionTimeout(SSL_SESSION_TIMEOUT_SECONDS);
+                builder.sslContext(sslContext);
+                myCurrentSSLContext = sslContext;
+            }
+        }
+        return builder.build();
+    }
+
+    public String getClientId(final UUID nodeID)
+    {
+        Map<String, String> clientInfo = myClientIdMap.get(nodeID);
+        return clientInfo != null ? clientInfo.get(CLIENT_ID_PROPERTY) : null;
+    }
+
+    public void registerClientId(final UUID nodeID) throws IOException, InterruptedException
+    {
+        String url = mountJolokiaBaseURL(nodeID) + "/notification/register";
+
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(url))
+                .timeout(java.time.Duration.ofSeconds(HTTP_REQUEST_TIMEOUT_SECONDS))
+                .GET()
+                .build();
+
+        HttpResponse<String> response = getHttpClient().send(request, HttpResponse.BodyHandlers.ofString());
+
+        LOG.debug("Raw response from {}: Status={}, Body={}", url, response.statusCode(), response.body());
+
+        ClientRegisterResponse clientRegisterResponse = objectMapper.readValue(
+                decodeHtmlEntities(response.body()), ClientRegisterResponse.class);
+
+        Map<String, String> properties = new HashMap<>();
+        properties.put(CLIENT_ID_PROPERTY, clientRegisterResponse.getValue().getId());
+        properties.put("store", clientRegisterResponse.getValue().getBackend().getPull().getStore());
+
+        myClientIdMap.put(nodeID, properties);
+    }
+
+    public String registerJolokiaNotification(final UUID nodeID) throws IOException, InterruptedException
+    {
+        String url = mountJolokiaBaseURL(nodeID) + "/notification";
+
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(url))
+                .timeout(java.time.Duration.ofSeconds(HTTP_REQUEST_TIMEOUT_SECONDS))
+                .POST(HttpRequest.BodyPublishers.ofString(jolokiaCreateNotificationOptions(nodeID)))
+                .build();
+        HttpResponse<String> response = getHttpClient().send(request, HttpResponse.BodyHandlers.ofString());
+
+        NotificationRegisterResponse notificationRegisterResponse = objectMapper.readValue(
+                decodeHtmlEntities(response.body()), NotificationRegisterResponse.class);
+
+        return notificationRegisterResponse.getValue();
+    }
+
+    public void removeJolokiaNotification(final UUID nodeID, final String notificationID) throws UnknownHostException
+    {
+        String url = mountJolokiaBaseURL(nodeID) + "/notification";
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(url))
+                .timeout(java.time.Duration.ofSeconds(HTTP_REQUEST_TIMEOUT_SECONDS))
+                .POST(HttpRequest.BodyPublishers.ofString(
+                        jolokiaRemoveNotificationOptions(nodeID, notificationID)))
+                .build();
+        try
+        {
+            getHttpClient().send(request, HttpResponse.BodyHandlers.ofString());
+        }
+        catch (IOException | InterruptedException e)
+        {
+            LOG.error("Error trying to remove NotificationListener with ID {} in node {}",
+                    notificationID, nodeID, e);
+        }
+    }
+
+    public String checkForNotificationsWithRetry(final UUID nodeID, final String notificationID)
+            throws IOException, InterruptedException
+    {
+        IOException lastException = null;
+        for (int attempt = 1; attempt <= MAX_RETRIES; attempt++)
+        {
+            try
+            {
+                return checkForNotifications(nodeID, notificationID);
+            }
+            catch (IOException e)
+            {
+                lastException = e;
+                LOG.debug("Notification check attempt {}/{} failed for node {}",
+                        attempt, MAX_RETRIES, nodeID, e);
+                if (attempt < MAX_RETRIES)
+                {
+                    long delay = INITIAL_RETRY_DELAY_IN_MS * (1L << (attempt - 1));
+                    Thread.sleep(delay);
+                }
+            }
+        }
+        LOG.debug("All {} retries failed for node {}, attempting client re-registration", MAX_RETRIES, nodeID);
+        try
+        {
+            registerClientId(nodeID);
+            return checkForNotifications(nodeID, notificationID);
+        }
+        catch (IOException e)
+        {
+            LOG.warn("Re-registration attempt also failed for node {}", nodeID, e);
+        }
+        throw lastException;
+    }
+
+    private String checkForNotifications(final UUID nodeID, final String notificationID)
+            throws IOException, InterruptedException
+    {
+        Map<String, String> clientInfo = myClientIdMap.get(nodeID);
+        if (clientInfo == null)
+        {
+            LOG.debug("No client info found for node {}, skipping notification check", nodeID);
+            return "{}";
+        }
+
+        String url = mountJolokiaBaseURL(nodeID) + "/exec/" + clientInfo.get("store") + "/pull/"
+            + clientInfo.get(CLIENT_ID_PROPERTY) + "/" + notificationID;
+
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(url))
+                .timeout(java.time.Duration.ofSeconds(HTTP_REQUEST_TIMEOUT_SECONDS))
+                .GET()
+                .build();
+
+        HttpResponse<String> response = getHttpClient().send(request, HttpResponse.BodyHandlers.ofString());
+        return decodeHtmlEntities(response.body());
+    }
+
+    private String mountJolokiaBaseURL(final UUID nodeID) throws UnknownHostException
+    {
+        String host = myNativeConnectionProvider.getNodes().get(nodeID).getBroadcastRpcAddress().get().getAddress().getHostAddress();
+        if (NO_BROADCAST_ADDRESS.equals(host))
+        {
+            host = myNativeConnectionProvider.getNodes().get(nodeID).getListenAddress().get().getHostString();
+        }
+        if (myIpTranslator.isActive())
+        {
+            host = myIpTranslator.getInternalIp(host);
+        }
+        if (myReverseDNSResolution)
+        {
+            host = ReverseDNS.fromHostString(host);
+        }
+        if (host.contains(":") && !host.startsWith("[") && !host.endsWith("]"))
+        {
+            host = "[" + host + "]";
+        }
+        return myURLPrefix + "://" + host + ":" + myJolokiaPort + "/jolokia";
+    }
+
+    private String jolokiaCreateNotificationOptions(final UUID nodeID)
+    {
+        Map<String, Object> params = new HashMap<>();
+        params.put("type", "notification");
+        params.put("command", "add");
+        params.put("client", myClientIdMap.get(nodeID).get(CLIENT_ID_PROPERTY));
+        params.put("mode", "pull");
+        params.put("mbean", SS_OBJ_NAME);
+        List<String> filter = List.of(
+                "progress",
+                "jmx.remote.connection.lost.notifications",
+                "jmx.remote.connection.failed",
+                "jmx.remote.connection.closed"
+        );
+        params.put("filter", filter);
+
+        try
+        {
+            return objectMapper.writeValueAsString(params);
+        }
+        catch (JsonProcessingException e)
+        {
+            LOG.error("Unable to serialize notification options for node {}", nodeID, e);
+        }
+        return "";
+    }
+
+    private String jolokiaRemoveNotificationOptions(final UUID nodeID, final String notificationID)
+    {
+        Map<String, Object> params = new HashMap<>();
+        params.put("type", "notification");
+        params.put("command", "remove");
+        params.put("client", myClientIdMap.get(nodeID).get(CLIENT_ID_PROPERTY));
+        params.put("handle", notificationID);
+
+        try
+        {
+            return objectMapper.writeValueAsString(params);
+        }
+        catch (JsonProcessingException e)
+        {
+            LOG.error("Unable to serialize Jolokia Notification Options for node {}", nodeID, e);
+        }
+        return "";
+    }
+
+    private String decodeHtmlEntities(final String input)
+    {
+        return input
+                .replace("&quot;", "\"")
+                .replace("&lt;", "<")
+                .replace("&gt;", ">")
+                .replace("&amp;", "&");
+    }
+}

--- a/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/jmx/JolokiaNotificationController.java
+++ b/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/jmx/JolokiaNotificationController.java
@@ -20,6 +20,7 @@ import com.ericsson.bss.cassandra.ecchronos.core.impl.jmx.http.NotificationRegis
 import com.ericsson.bss.cassandra.ecchronos.connection.CertificateHandler;
 import com.ericsson.bss.cassandra.ecchronos.connection.DistributedNativeConnectionProvider;
 import com.ericsson.bss.cassandra.ecchronos.data.iptranslator.IpTranslator;
+import com.google.common.annotations.VisibleForTesting;
 import com.ericsson.bss.cassandra.ecchronos.utils.dns.ReverseDNS;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -52,7 +53,7 @@ import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.ReentrantLock;
 
-public class JolokiaNotificationController implements Closeable
+public class JolokiaNotificationController implements Closeable // NOPMD GodClass
 {
     private static final Logger LOG = LoggerFactory.getLogger(JolokiaNotificationController.class);
     private static final int SHUTDOWN_TIMEOUT_SECONDS = 1;
@@ -81,7 +82,8 @@ public class JolokiaNotificationController implements Closeable
 
     private final ObjectMapper objectMapper = new ObjectMapper();
     private final CertificateHandler myCertificateHandler;
-    private final HttpClient myHttpClient;
+    private volatile HttpClient myHttpClient;
+    private volatile SSLContext myCurrentSSLContext;
     private final ConcurrentHashMap<UUID, ReentrantLock> myNodeLocks = new ConcurrentHashMap<>();
     private final Semaphore myPollingSemaphore;
 
@@ -107,6 +109,20 @@ public class JolokiaNotificationController implements Closeable
         myHttpClient = buildHttpClient();
     }
 
+    @VisibleForTesting
+    final HttpClient getHttpClient()
+    {
+        if (myCertificateHandler != null)
+        {
+            SSLContext latestContext = myCertificateHandler.getSSLContext();
+            if (latestContext != null && latestContext != myCurrentSSLContext) // NOPMD CompareObjectsWithEquals - intentional identity check
+            {
+                myHttpClient = buildHttpClient();
+            }
+        }
+        return myHttpClient;
+    }
+
     private HttpClient buildHttpClient()
     {
         HttpClient.Builder builder = HttpClient.newBuilder()
@@ -119,6 +135,7 @@ public class JolokiaNotificationController implements Closeable
                 sslContext.getClientSessionContext().setSessionCacheSize(SSL_SESSION_CACHE_SIZE);
                 sslContext.getClientSessionContext().setSessionTimeout(SSL_SESSION_TIMEOUT_SECONDS);
                 builder.sslContext(sslContext);
+                myCurrentSSLContext = sslContext;
             }
         }
         return builder.build();
@@ -351,35 +368,28 @@ public class JolokiaNotificationController implements Closeable
         }
     }
 
-    private void registerClientId(final UUID nodeID)
+    private void registerClientId(final UUID nodeID) throws IOException, InterruptedException
     {
-        try
-        {
-            String url = mountJolokiaBaseURL(nodeID) + "/notification/register";
+        String url = mountJolokiaBaseURL(nodeID) + "/notification/register";
 
-            HttpRequest request = HttpRequest.newBuilder()
-                    .uri(URI.create(url))
-                    .timeout(java.time.Duration.ofSeconds(HTTP_REQUEST_TIMEOUT_SECONDS))
-                    .GET()
-                    .build();
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(url))
+                .timeout(java.time.Duration.ofSeconds(HTTP_REQUEST_TIMEOUT_SECONDS))
+                .GET()
+                .build();
 
-            HttpResponse<String> response = myHttpClient.send(request, HttpResponse.BodyHandlers.ofString());
+        HttpResponse<String> response = getHttpClient().send(request, HttpResponse.BodyHandlers.ofString());
 
-            LOG.debug("Raw response from {}: Status={}, Body={}", url, response.statusCode(), response.body());
+        LOG.debug("Raw response from {}: Status={}, Body={}", url, response.statusCode(), response.body());
 
-            ClientRegisterResponse clientRegisterResponse = objectMapper.readValue(
-                    decodeHtmlEntities(response.body()), ClientRegisterResponse.class);
+        ClientRegisterResponse clientRegisterResponse = objectMapper.readValue(
+                decodeHtmlEntities(response.body()), ClientRegisterResponse.class);
 
-            Map<String, String> properties = new HashMap<>();
-            properties.put(CLIENT_ID_PROPERTY, clientRegisterResponse.getValue().getId());
-            properties.put("store", clientRegisterResponse.getValue().getBackend().getPull().getStore());
+        Map<String, String> properties = new HashMap<>();
+        properties.put(CLIENT_ID_PROPERTY, clientRegisterResponse.getValue().getId());
+        properties.put("store", clientRegisterResponse.getValue().getBackend().getPull().getStore());
 
-            myClientIdMap.put(nodeID, properties);
-        }
-        catch (IOException | InterruptedException e)
-        {
-            LOG.error("Unable to register Jolokia Client in node with ID {}", nodeID, e);
-        }
+        myClientIdMap.put(nodeID, properties);
     }
 
     private String registerJolokiaNotification(final UUID nodeID) throws IOException, InterruptedException
@@ -391,7 +401,7 @@ public class JolokiaNotificationController implements Closeable
                 .timeout(java.time.Duration.ofSeconds(HTTP_REQUEST_TIMEOUT_SECONDS))
                 .POST(HttpRequest.BodyPublishers.ofString(jolokiaCreateNotificationOptions(nodeID)))
                 .build();
-        HttpResponse<String> response = myHttpClient.send(request, HttpResponse.BodyHandlers.ofString());
+        HttpResponse<String> response = getHttpClient().send(request, HttpResponse.BodyHandlers.ofString());
 
         NotificationRegisterResponse notificationRegisterResponse = objectMapper.readValue(
                 decodeHtmlEntities(response.body()), NotificationRegisterResponse.class);
@@ -410,7 +420,7 @@ public class JolokiaNotificationController implements Closeable
                 .build();
         try
         {
-            myHttpClient.send(request, HttpResponse.BodyHandlers.ofString());
+            getHttpClient().send(request, HttpResponse.BodyHandlers.ofString());
         }
         catch (IOException | InterruptedException e)
         {
@@ -545,7 +555,7 @@ public class JolokiaNotificationController implements Closeable
                 .GET()
                 .build();
 
-        HttpResponse<String> response = myHttpClient.send(request, HttpResponse.BodyHandlers.ofString());
+        HttpResponse<String> response = getHttpClient().send(request, HttpResponse.BodyHandlers.ofString());
         return decodeHtmlEntities(response.body());
     }
 

--- a/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/jmx/JolokiaNotificationController.java
+++ b/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/jmx/JolokiaNotificationController.java
@@ -14,15 +14,10 @@
  */
 package com.ericsson.bss.cassandra.ecchronos.core.impl.jmx;
 
-import com.ericsson.bss.cassandra.ecchronos.core.impl.jmx.http.ClientRegisterResponse;
 import com.ericsson.bss.cassandra.ecchronos.core.impl.jmx.http.NotificationListenerResponse;
-import com.ericsson.bss.cassandra.ecchronos.core.impl.jmx.http.NotificationRegisterResponse;
 import com.ericsson.bss.cassandra.ecchronos.connection.CertificateHandler;
 import com.ericsson.bss.cassandra.ecchronos.connection.DistributedNativeConnectionProvider;
 import com.ericsson.bss.cassandra.ecchronos.data.iptranslator.IpTranslator;
-import com.google.common.annotations.VisibleForTesting;
-import com.ericsson.bss.cassandra.ecchronos.utils.dns.ReverseDNS;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.slf4j.Logger;
@@ -30,14 +25,9 @@ import org.slf4j.LoggerFactory;
 
 import javax.management.Notification;
 import javax.management.NotificationListener;
-import javax.net.ssl.SSLContext;
 import java.io.Closeable;
 import java.io.IOException;
-import java.net.URI;
 import java.net.UnknownHostException;
-import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
-import java.net.http.HttpResponse;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
@@ -53,20 +43,11 @@ import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.ReentrantLock;
 
-public class JolokiaNotificationController implements Closeable // NOPMD GodClass
+public class JolokiaNotificationController implements Closeable
 {
     private static final Logger LOG = LoggerFactory.getLogger(JolokiaNotificationController.class);
     private static final int SHUTDOWN_TIMEOUT_SECONDS = 1;
-    private static final int HTTP_TIMEOUT_SECONDS = 5;
-    private static final int HTTP_REQUEST_TIMEOUT_SECONDS = 10;
-    private static final int SSL_SESSION_CACHE_SIZE = 50;
-    private static final int SSL_SESSION_TIMEOUT_SECONDS = 3600;
-    private static final int MAX_RETRIES = 3;
-    private static final long INITIAL_RETRY_DELAY_IN_MS = 500;
     private static final int MAX_CONSECUTIVE_FAILURES = 5;
-    private static final String CLIENT_ID_PROPERTY = "clientID";
-    private static final String SS_OBJ_NAME = "org.apache.cassandra.db:type=StorageService";
-    public static final String NO_BROADCAST_ADDRESS = "0.0.0.0"; //NOPMD AvoidUsingHardCodedIP
 
     private static final int NOTIFICATION_THREAD_POOL_SIZE = 4;
 
@@ -76,69 +57,28 @@ public class JolokiaNotificationController implements Closeable // NOPMD GodClas
             NOTIFICATION_THREAD_POOL_SIZE,
             new ThreadFactoryBuilder().setNameFormat("NotificationRefresher-%d").build());
 
-    private final Map<UUID, Map<String, String>> myClientIdMap = new ConcurrentHashMap<>();
     private final Map<UUID, Map<String, NotificationListener>> myNodeListenersMap = new ConcurrentHashMap<>();
     private final Map<UUID, Map<String, ScheduledFuture<?>>> myNotificationMonitors = new ConcurrentHashMap<>();
 
     private final ObjectMapper objectMapper = new ObjectMapper();
-    private final CertificateHandler myCertificateHandler;
-    private volatile HttpClient myHttpClient;
-    private volatile SSLContext myCurrentSSLContext;
     private final ConcurrentHashMap<UUID, ReentrantLock> myNodeLocks = new ConcurrentHashMap<>();
     private final Semaphore myPollingSemaphore;
 
-    private final DistributedNativeConnectionProvider myNativeConnectionProvider;
-    private final int myJolokiaPort;
-    private final boolean myJolokiaPEM;
-    private final boolean myReverseDNSResolution;
-    private final String myURLPrefix;
+    private final JolokiaHttpClient myJolokiaHttpClient;
     private final long myRunDelay;
-    private final IpTranslator myIpTranslator;
 
     public JolokiaNotificationController(final Builder builder)
     {
-        myNativeConnectionProvider = builder.myNativeConnection;
-        myJolokiaPort = builder.myJolokiaPort;
-        myJolokiaPEM = builder.myJolokiaPEM;
-        myURLPrefix = myJolokiaPEM ? "https" : "http";
-        myReverseDNSResolution = builder.myReverseDNSResolution;
         myRunDelay = builder.myRunDelay;
-        myIpTranslator = builder.myIpTranslator;
-        myCertificateHandler = builder.myCertificateHandler;
         myPollingSemaphore = new Semaphore(NOTIFICATION_THREAD_POOL_SIZE);
-        myHttpClient = buildHttpClient();
-    }
-
-    @VisibleForTesting
-    final HttpClient getHttpClient()
-    {
-        if (myCertificateHandler != null)
-        {
-            SSLContext latestContext = myCertificateHandler.getSSLContext();
-            if (latestContext != null && latestContext != myCurrentSSLContext) // NOPMD CompareObjectsWithEquals - intentional identity check
-            {
-                myHttpClient = buildHttpClient();
-            }
-        }
-        return myHttpClient;
-    }
-
-    private HttpClient buildHttpClient()
-    {
-        HttpClient.Builder builder = HttpClient.newBuilder()
-                .connectTimeout(java.time.Duration.ofSeconds(HTTP_TIMEOUT_SECONDS));
-        if (myCertificateHandler != null)
-        {
-            SSLContext sslContext = myCertificateHandler.getSSLContext();
-            if (sslContext != null)
-            {
-                sslContext.getClientSessionContext().setSessionCacheSize(SSL_SESSION_CACHE_SIZE);
-                sslContext.getClientSessionContext().setSessionTimeout(SSL_SESSION_TIMEOUT_SECONDS);
-                builder.sslContext(sslContext);
-                myCurrentSSLContext = sslContext;
-            }
-        }
-        return builder.build();
+        myJolokiaHttpClient = new JolokiaHttpClient(
+                builder.myCertificateHandler,
+                builder.myNativeConnection,
+                builder.myJolokiaPort,
+                builder.myJolokiaPEM,
+                builder.myReverseDNSResolution,
+                builder.myIpTranslator
+        );
     }
 
     private ReentrantLock getNodeLock(final UUID nodeID)
@@ -148,9 +88,9 @@ public class JolokiaNotificationController implements Closeable // NOPMD GodClas
 
     public final void addStorageServiceListener(final UUID nodeID, final NotificationListener listener) throws IOException, InterruptedException
     {
-        registerClientId(nodeID);
+        myJolokiaHttpClient.registerClientId(nodeID);
 
-        String jolokiaNotificationID = registerJolokiaNotification(nodeID);
+        String jolokiaNotificationID = myJolokiaHttpClient.registerJolokiaNotification(nodeID);
 
         synchronized (myNodeListenersMap)
         {
@@ -176,7 +116,7 @@ public class JolokiaNotificationController implements Closeable // NOPMD GodClas
             }
             try
             {
-                removeJolokiaNotification(nodeID, jolokiaNotificationID);
+                myJolokiaHttpClient.removeJolokiaNotification(nodeID, jolokiaNotificationID);
             }
             catch (Exception removeEx)
             {
@@ -196,7 +136,7 @@ public class JolokiaNotificationController implements Closeable // NOPMD GodClas
             LOG.warn("No Jolokia notification ID found for listener on node {}, skipping removal", nodeID);
             return;
         }
-        removeJolokiaNotification(nodeID, jolokiaNotificationID);
+        myJolokiaHttpClient.removeJolokiaNotification(nodeID, jolokiaNotificationID);
         synchronized (myNotificationMonitors)
         {
             Map<String, ScheduledFuture<?>> monitors = myNotificationMonitors.get(nodeID);
@@ -272,7 +212,7 @@ public class JolokiaNotificationController implements Closeable // NOPMD GodClas
                 lock.lock();
                 try
                 {
-                    String response = checkForNotificationsWithRetry(myNodeID, myNotificationID);
+                    String response = myJolokiaHttpClient.checkForNotificationsWithRetry(myNodeID, myNotificationID);
                     NotificationListenerResponse notificationListenerResponse = objectMapper.readValue(response,
                             NotificationListenerResponse.class);
 
@@ -368,206 +308,6 @@ public class JolokiaNotificationController implements Closeable // NOPMD GodClas
         }
     }
 
-    private void registerClientId(final UUID nodeID) throws IOException, InterruptedException
-    {
-        String url = mountJolokiaBaseURL(nodeID) + "/notification/register";
-
-        HttpRequest request = HttpRequest.newBuilder()
-                .uri(URI.create(url))
-                .timeout(java.time.Duration.ofSeconds(HTTP_REQUEST_TIMEOUT_SECONDS))
-                .GET()
-                .build();
-
-        HttpResponse<String> response = getHttpClient().send(request, HttpResponse.BodyHandlers.ofString());
-
-        LOG.debug("Raw response from {}: Status={}, Body={}", url, response.statusCode(), response.body());
-
-        ClientRegisterResponse clientRegisterResponse = objectMapper.readValue(
-                decodeHtmlEntities(response.body()), ClientRegisterResponse.class);
-
-        Map<String, String> properties = new HashMap<>();
-        properties.put(CLIENT_ID_PROPERTY, clientRegisterResponse.getValue().getId());
-        properties.put("store", clientRegisterResponse.getValue().getBackend().getPull().getStore());
-
-        myClientIdMap.put(nodeID, properties);
-    }
-
-    private String registerJolokiaNotification(final UUID nodeID) throws IOException, InterruptedException
-    {
-        String url = mountJolokiaBaseURL(nodeID) + "/notification";
-
-        HttpRequest request = HttpRequest.newBuilder()
-                .uri(URI.create(url))
-                .timeout(java.time.Duration.ofSeconds(HTTP_REQUEST_TIMEOUT_SECONDS))
-                .POST(HttpRequest.BodyPublishers.ofString(jolokiaCreateNotificationOptions(nodeID)))
-                .build();
-        HttpResponse<String> response = getHttpClient().send(request, HttpResponse.BodyHandlers.ofString());
-
-        NotificationRegisterResponse notificationRegisterResponse = objectMapper.readValue(
-                decodeHtmlEntities(response.body()), NotificationRegisterResponse.class);
-
-        return notificationRegisterResponse.getValue();
-    }
-
-    private void removeJolokiaNotification(final UUID nodeID, final String notificationID) throws UnknownHostException
-    {
-        String url = mountJolokiaBaseURL(nodeID) + "/notification";
-        HttpRequest request = HttpRequest.newBuilder()
-                .uri(URI.create(url))
-                .timeout(java.time.Duration.ofSeconds(HTTP_REQUEST_TIMEOUT_SECONDS))
-                .POST(HttpRequest.BodyPublishers.ofString(
-                        jolokiaRemoveNotificationOptions(nodeID, notificationID)))
-                .build();
-        try
-        {
-            getHttpClient().send(request, HttpResponse.BodyHandlers.ofString());
-        }
-        catch (IOException | InterruptedException e)
-        {
-            LOG.error("Error trying to remove NotificationListener with ID {} in node {}",
-                    notificationID, nodeID, e);
-        }
-    }
-
-    private String jolokiaCreateNotificationOptions(final UUID nodeID)
-    {
-        Map<String, Object> params = new HashMap<>();
-        params.put("type", "notification");
-        params.put("command", "add");
-        params.put("client", myClientIdMap.get(nodeID).get(CLIENT_ID_PROPERTY));
-        params.put("mode", "pull");
-        params.put("mbean", SS_OBJ_NAME);
-        List<String> filter = List.of(
-                "progress",
-                "jmx.remote.connection.lost.notifications",
-                "jmx.remote.connection.failed",
-                "jmx.remote.connection.closed"
-        );
-        params.put("filter", filter);
-
-        try
-        {
-            return objectMapper.writeValueAsString(params);
-        }
-        catch (JsonProcessingException e)
-        {
-            LOG.error("Unable to serialize notification options for node {}", nodeID, e);
-        }
-        return "";
-    }
-
-    private String jolokiaRemoveNotificationOptions(final UUID nodeID, final String notificationID)
-    {
-        Map<String, Object> params = new HashMap<>();
-        params.put("type", "notification");
-        params.put("command", "remove");
-        params.put("client", myClientIdMap.get(nodeID).get(CLIENT_ID_PROPERTY));
-        params.put("handle", notificationID);
-
-        try
-        {
-            return objectMapper.writeValueAsString(params);
-        }
-        catch (JsonProcessingException e)
-        {
-            LOG.error("Unable to serialize Jolokia Notification Options for node {}", nodeID,
-                    e);
-        }
-        return "";
-    }
-
-    private String mountJolokiaBaseURL(final UUID nodeID) throws UnknownHostException
-    {
-        String host = myNativeConnectionProvider.getNodes().get(nodeID).getBroadcastRpcAddress().get().getAddress().getHostAddress();
-        if (NO_BROADCAST_ADDRESS.equals(host))
-        {
-            host = myNativeConnectionProvider.getNodes().get(nodeID).getListenAddress().get().getHostString();
-        }
-        if (myIpTranslator.isActive())
-        {
-            host = myIpTranslator.getInternalIp(host);
-        }
-        if (myReverseDNSResolution)
-        {
-            host = ReverseDNS.fromHostString(host);
-        }
-        if (host.contains(":") && !host.startsWith("[") && !host.endsWith("]"))
-        {
-            // Use square brackets to surround IPv6 addresses
-            host = "[" + host + "]";
-        }
-        return myURLPrefix + "://" + host + ":" + myJolokiaPort + "/jolokia";
-    }
-
-    private String checkForNotificationsWithRetry(final UUID nodeID, final String notificationID)
-            throws IOException, InterruptedException
-    {
-        IOException lastException = null;
-        for (int attempt = 1; attempt <= MAX_RETRIES; attempt++)
-        {
-            try
-            {
-                return checkForNotifications(nodeID, notificationID);
-            }
-            catch (IOException e)
-            {
-                lastException = e;
-                LOG.debug("Notification check attempt {}/{} failed for node {}",
-                        attempt, MAX_RETRIES, nodeID, e);
-                if (attempt < MAX_RETRIES)
-                {
-                    long delay = INITIAL_RETRY_DELAY_IN_MS * (1L << (attempt - 1));
-                    Thread.sleep(delay);
-                }
-            }
-        }
-        // All retries failed — attempt to re-register client and try once more
-        LOG.debug("All {} retries failed for node {}, attempting client re-registration", MAX_RETRIES, nodeID);
-        try
-        {
-            registerClientId(nodeID);
-            return checkForNotifications(nodeID, notificationID);
-        }
-        catch (IOException e)
-        {
-            LOG.warn("Re-registration attempt also failed for node {}", nodeID, e);
-        }
-        throw lastException;
-    }
-
-    private String checkForNotifications(final UUID nodeID, final String notificationID)
-            throws IOException, InterruptedException
-    {
-        String url;
-        Map<String, String> clientInfo = myClientIdMap.get(nodeID);
-        if (clientInfo == null)
-        {
-            LOG.debug("No client info found for node {}, skipping notification check", nodeID);
-            return "{}";
-        }
-
-        url = mountJolokiaBaseURL(nodeID) + "/exec/" + clientInfo.get("store") + "/pull/"
-            + clientInfo.get(CLIENT_ID_PROPERTY) + "/" + notificationID;
-
-        HttpRequest request = HttpRequest.newBuilder()
-                .uri(URI.create(url))
-                .timeout(java.time.Duration.ofSeconds(HTTP_REQUEST_TIMEOUT_SECONDS))
-                .GET()
-                .build();
-
-        HttpResponse<String> response = getHttpClient().send(request, HttpResponse.BodyHandlers.ofString());
-        return decodeHtmlEntities(response.body());
-    }
-
-    private String decodeHtmlEntities(final String input)
-    {
-        return input
-                .replace("&quot;", "\"")
-                .replace("&lt;", "<")
-                .replace("&gt;", ">")
-                .replace("&amp;", "&");
-    }
-
     @Override
     public final void close()
     {
@@ -579,7 +319,7 @@ public class JolokiaNotificationController implements Closeable // NOPMD GodClas
             {
                 try
                 {
-                    removeJolokiaNotification(nodeID, notificationID);
+                    myJolokiaHttpClient.removeJolokiaNotification(nodeID, notificationID);
                 }
                 catch (Exception e)
                 {
@@ -603,7 +343,6 @@ public class JolokiaNotificationController implements Closeable // NOPMD GodClas
 
         myNodeListenersMap.clear();
         myJolokiaRelationshipListeners.clear();
-        myClientIdMap.clear();
         myNodeLocks.clear();
 
         // Shutdown executor

--- a/core.impl/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/impl/jmx/TestJolokiaHttpClientCertReload.java
+++ b/core.impl/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/impl/jmx/TestJolokiaHttpClientCertReload.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2026 Telefonaktiebolaget LM Ericsson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ericsson.bss.cassandra.ecchronos.core.impl.jmx;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.ericsson.bss.cassandra.ecchronos.connection.CertificateHandler;
+import com.ericsson.bss.cassandra.ecchronos.connection.DistributedNativeConnectionProvider;
+import org.junit.Test;
+
+import javax.net.ssl.SSLContext;
+import java.net.http.HttpClient;
+
+public class TestJolokiaHttpClientCertReload
+{
+    @Test
+    public void testHttpClientRebuildsWhenSSLContextChanges() throws Exception
+    {
+        CertificateHandler certHandler = mock(CertificateHandler.class);
+        DistributedNativeConnectionProvider ncp = mock(DistributedNativeConnectionProvider.class);
+
+        SSLContext ctx1 = SSLContext.getInstance("TLS");
+        ctx1.init(null, null, null);
+        SSLContext ctx2 = SSLContext.getInstance("TLS");
+        ctx2.init(null, null, null);
+
+        // Initial context
+        when(certHandler.getSSLContext()).thenReturn(ctx1);
+
+        JolokiaNotificationController controller = new JolokiaNotificationController.Builder()
+                .withNativeConnection(ncp)
+                .withCertificateHandler(certHandler)
+                .withJolokiaPort(8778)
+                .withJolokiaPEM(true)
+                .withRunDelay(500)
+                .build();
+
+        HttpClient client1 = controller.getHttpClient();
+        assertThat(client1).isNotNull();
+
+        // Same context — no rebuild
+        HttpClient client1Again = controller.getHttpClient();
+        assertThat(client1Again).isSameAs(client1);
+
+        // New context — should rebuild
+        when(certHandler.getSSLContext()).thenReturn(ctx2);
+        HttpClient client2 = controller.getHttpClient();
+        assertThat(client2).isNotSameAs(client1);
+
+        // Same new context — no rebuild
+        HttpClient client2Again = controller.getHttpClient();
+        assertThat(client2Again).isSameAs(client2);
+    }
+
+    @Test
+    public void testHttpClientNotRebuiltWhenNoCertHandler()
+    {
+        DistributedNativeConnectionProvider ncp = mock(DistributedNativeConnectionProvider.class);
+
+        JolokiaNotificationController controller = new JolokiaNotificationController.Builder()
+                .withNativeConnection(ncp)
+                .withJolokiaPort(8778)
+                .withJolokiaPEM(false)
+                .withRunDelay(500)
+                .build();
+
+        HttpClient client1 = controller.getHttpClient();
+        HttpClient client2 = controller.getHttpClient();
+        assertThat(client2).isSameAs(client1);
+    }
+}

--- a/core.impl/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/impl/jmx/TestJolokiaHttpClientCertReload.java
+++ b/core.impl/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/impl/jmx/TestJolokiaHttpClientCertReload.java
@@ -20,6 +20,7 @@ import static org.mockito.Mockito.when;
 
 import com.ericsson.bss.cassandra.ecchronos.connection.CertificateHandler;
 import com.ericsson.bss.cassandra.ecchronos.connection.DistributedNativeConnectionProvider;
+import com.ericsson.bss.cassandra.ecchronos.data.iptranslator.IpTranslator;
 import org.junit.Test;
 
 import javax.net.ssl.SSLContext;
@@ -32,6 +33,7 @@ public class TestJolokiaHttpClientCertReload
     {
         CertificateHandler certHandler = mock(CertificateHandler.class);
         DistributedNativeConnectionProvider ncp = mock(DistributedNativeConnectionProvider.class);
+        IpTranslator ipTranslator = mock(IpTranslator.class);
 
         SSLContext ctx1 = SSLContext.getInstance("TLS");
         ctx1.init(null, null, null);
@@ -41,28 +43,22 @@ public class TestJolokiaHttpClientCertReload
         // Initial context
         when(certHandler.getSSLContext()).thenReturn(ctx1);
 
-        JolokiaNotificationController controller = new JolokiaNotificationController.Builder()
-                .withNativeConnection(ncp)
-                .withCertificateHandler(certHandler)
-                .withJolokiaPort(8778)
-                .withJolokiaPEM(true)
-                .withRunDelay(500)
-                .build();
+        JolokiaHttpClient client = new JolokiaHttpClient(certHandler, ncp, 8778, true, false, ipTranslator);
 
-        HttpClient client1 = controller.getHttpClient();
+        HttpClient client1 = client.getHttpClient();
         assertThat(client1).isNotNull();
 
         // Same context — no rebuild
-        HttpClient client1Again = controller.getHttpClient();
+        HttpClient client1Again = client.getHttpClient();
         assertThat(client1Again).isSameAs(client1);
 
         // New context — should rebuild
         when(certHandler.getSSLContext()).thenReturn(ctx2);
-        HttpClient client2 = controller.getHttpClient();
+        HttpClient client2 = client.getHttpClient();
         assertThat(client2).isNotSameAs(client1);
 
         // Same new context — no rebuild
-        HttpClient client2Again = controller.getHttpClient();
+        HttpClient client2Again = client.getHttpClient();
         assertThat(client2Again).isSameAs(client2);
     }
 
@@ -70,16 +66,12 @@ public class TestJolokiaHttpClientCertReload
     public void testHttpClientNotRebuiltWhenNoCertHandler()
     {
         DistributedNativeConnectionProvider ncp = mock(DistributedNativeConnectionProvider.class);
+        IpTranslator ipTranslator = mock(IpTranslator.class);
 
-        JolokiaNotificationController controller = new JolokiaNotificationController.Builder()
-                .withNativeConnection(ncp)
-                .withJolokiaPort(8778)
-                .withJolokiaPEM(false)
-                .withRunDelay(500)
-                .build();
+        JolokiaHttpClient client = new JolokiaHttpClient(null, ncp, 8778, false, false, ipTranslator);
 
-        HttpClient client1 = controller.getHttpClient();
-        HttpClient client2 = controller.getHttpClient();
+        HttpClient client1 = client.getHttpClient();
+        HttpClient client2 = client.getHttpClient();
         assertThat(client2).isSameAs(client1);
     }
 }


### PR DESCRIPTION
Rebuild the shared HttpClient when the CertificateHandler returns a
different SSLContext (indicating certificates were rotated). Track the
current SSLContext and compare by identity on each request.

Also propagate exceptions from registerClientId() instead of swallowing
them, so addStorageServiceListener() fails fast with a meaningful error
rather than proceeding to an NPE in jolokiaCreateNotificationOptions().

Extract all Jolokia HTTP communication into a dedicated JolokiaHttpClient
class to resolve PMD GodClass warning. The controller now delegates HTTP
operations to the new class and focuses on notification lifecycle management.

JolokiaHttpClient owns:
- HttpClient lifecycle with TLS cert hot-reload
- All Jolokia REST API calls (register, notify, remove)
- URL construction and retry logic
- Client ID tracking

Closes #1657 