### PR TITLE
Fix publishing skip for standalone-integration module

### DIFF
--- a/standalone-integration/pom.xml
+++ b/standalone-integration/pom.xml
@@ -191,7 +191,7 @@
                 <groupId>org.sonatype.central</groupId>
                 <artifactId>central-publishing-maven-plugin</artifactId>
                 <configuration>
-                    <excludeArtifacts>standalone-integration</excludeArtifacts>
+                    <skipPublishing>true</skipPublishing>
                 </configuration>
             </plugin>
 


### PR DESCRIPTION
Replace excludeArtifacts with skipPublishing to prevent the central-publishing-maven-plugin from requiring an artifact file.