### PR TITLE
Disable central-publishing execution for standalone-integration

### DIFF
--- a/standalone-integration/pom.xml
+++ b/standalone-integration/pom.xml
@@ -190,9 +190,12 @@
             <plugin>
                 <groupId>org.sonatype.central</groupId>
                 <artifactId>central-publishing-maven-plugin</artifactId>
-                <configuration>
-                    <skipPublishing>true</skipPublishing>
-                </configuration>
+                <executions>
+                    <execution>
+                        <id>default-deploy</id>
+                        <phase>none</phase>
+                    </execution>
+                </executions>
             </plugin>
 
             <plugin>


### PR DESCRIPTION
Binding the execution to phase 'none' prevents the plugin from running, since skipPublishing and excludeArtifacts do not prevent the goal from requiring an assembled artifact.