### PR TITLE
Fix release build: allow jar creation for standalone-integration

### DIFF
--- a/standalone-integration/pom.xml
+++ b/standalone-integration/pom.xml
@@ -190,12 +190,9 @@
             <plugin>
                 <groupId>org.sonatype.central</groupId>
                 <artifactId>central-publishing-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>default-deploy</id>
-                        <phase>none</phase>
-                    </execution>
-                </executions>
+                <configuration>
+                    <excludeArtifacts>standalone-integration</excludeArtifacts>
+                </configuration>
             </plugin>
 
             <plugin>
@@ -206,22 +203,7 @@
             </plugin>
 
             <plugin>
-                <artifactId>maven-jar-plugin</artifactId>
-                <configuration>
-                    <skipIfEmpty>true</skipIfEmpty>
-                </configuration>
-            </plugin>
-
-            <plugin>
                 <artifactId>maven-install-plugin</artifactId>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
-            </plugin>
-
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-gpg-plugin</artifactId>
                 <configuration>
                     <skip>true</skip>
                 </configuration>


### PR DESCRIPTION
Remove skipIfEmpty and GPG skip - the jar plugin must produce an artifact for the central-publishing-maven-plugin (reactor aggregator) to complete. The excludeArtifacts config ensures it won't be published to Central.