### PR TITLE
Fix schedule discovery failure during DC upgrade never retried

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Version 1.0.3 (Not yet Released)
 
+* Fix schedule discovery failure during DC upgrade never retried - Issue #1670
 * Fix orphaned HttpClient thread/exchange leak on TLS cert reload - Issue #1662
 * Fix repeated refreshState() in batched lock session causing snapshot accumulation - Issue #1661
 

--- a/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/jmx/AbstractDistributedJmxProxy.java
+++ b/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/jmx/AbstractDistributedJmxProxy.java
@@ -38,6 +38,7 @@ import javax.management.remote.JMXConnector;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Optional;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -118,7 +119,13 @@ abstract class AbstractDistributedJmxProxy implements DistributedJmxProxy
         if (!myNodesMap.containsKey(nodeID))
         {
             LOG.debug("Node {} is not managed by local instance, using random connection to get live nodes", nodeID);
-            nodeIdConnection = myDistributedJmxConnectionProvider.getJmxConnections().keySet().stream().findFirst().get();
+            Optional<UUID> firstNode = myDistributedJmxConnectionProvider.getJmxConnections().keySet().stream().findFirst();
+            if (firstNode.isEmpty())
+            {
+                LOG.warn("No JMX connections available, cannot get live nodes for {}", nodeID);
+                throw new IllegalStateException("No JMX connections available to query live nodes for node " + nodeID);
+            }
+            nodeIdConnection = firstNode.get();
             nodeConnection = myDistributedJmxConnectionProvider.getJmxConnector(nodeIdConnection);
         }
         else
@@ -171,7 +178,13 @@ abstract class AbstractDistributedJmxProxy implements DistributedJmxProxy
         if (!myNodesMap.containsKey(nodeID))
         {
             LOG.debug("Node {} is not managed by local instance, using random connection to get unreachable nodes", nodeID);
-            nodeIdConnection = myDistributedJmxConnectionProvider.getJmxConnections().keySet().stream().findFirst().get();
+            Optional<UUID> firstNode = myDistributedJmxConnectionProvider.getJmxConnections().keySet().stream().findFirst();
+            if (firstNode.isEmpty())
+            {
+                LOG.warn("No JMX connections available, cannot get unreachable nodes for {}", nodeID);
+                throw new IllegalStateException("No JMX connections available to query unreachable nodes for node " + nodeID);
+            }
+            nodeIdConnection = firstNode.get();
             nodeConnection = myDistributedJmxConnectionProvider.getJmxConnector(nodeIdConnection);
         }
         else

--- a/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/scheduler/RepairSchedulerImpl.java
+++ b/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/scheduler/RepairSchedulerImpl.java
@@ -48,8 +48,8 @@ import java.util.AbstractMap;
 import java.util.Collection;
 
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
@@ -63,13 +63,14 @@ import javax.management.RuntimeMBeanException;
 public final class RepairSchedulerImpl implements RepairScheduler, Closeable
 {
     private static final int DEFAULT_TERMINATION_WAIT_IN_SECONDS = 10;
+    private static final long SCHEDULE_RETRY_DELAY_SECONDS = 30;
 
     private static final Logger LOG = LoggerFactory.getLogger(RepairSchedulerImpl.class);
 
     private final Map<UUID, Map<TableReference, Set<ScheduledRepairJob>>> myScheduledJobs = new ConcurrentHashMap<>();
     private final java.util.concurrent.locks.ReadWriteLock myLock = new java.util.concurrent.locks.ReentrantReadWriteLock();
 
-    private final ExecutorService myExecutor;
+    private final ScheduledExecutorService myExecutor;
     private final ScheduleManager myScheduleManager;
     private final ScheduledRepairJobFactory myJobFactory;
 
@@ -246,7 +247,11 @@ public final class RepairSchedulerImpl implements RepairScheduler, Closeable
         }
         catch (Exception e)
         {
-            LOG.error("Unexpected error during schedule change of {}:", tableReference, e);
+            LOG.error("Unexpected error during schedule change of {}, retrying in {}s:",
+                    tableReference, SCHEDULE_RETRY_DELAY_SECONDS, e);
+            myExecutor.schedule(
+                    () -> handleTableConfigurationChange(node, tableReference, repairConfigurations),
+                    SCHEDULE_RETRY_DELAY_SECONDS, TimeUnit.SECONDS);
         }
         finally
         {


### PR DESCRIPTION
1. Handle empty JMX connections map in getLiveNodes/getUnreachableNodes by returning empty list instead of throwing NoSuchElementException.

2. Retry failed handleTableConfigurationChange after 30s delay instead of silently dropping the table from scheduling. Uses the existing ScheduledExecutorService to re-submit on failure.

Closes #1670 