### PR TITLE
Remove zip format from binary assembly, keep only tar.gz

### DIFF
--- a/ecchronos-binary/src/assembly/assembly.xml
+++ b/ecchronos-binary/src/assembly/assembly.xml
@@ -18,7 +18,6 @@
     <id>binary</id>
     <formats>
         <format>tar.gz</format>
-        <format>zip</format>
     </formats>
     <files>
         <file>


### PR DESCRIPTION
Should half the size of the release.