### PR TITLE
Reduce binary tar.gz release size

### DIFF
--- a/application/pom.xml
+++ b/application/pom.xml
@@ -93,16 +93,27 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-thymeleaf</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.tomcat.embed</groupId>
+                    <artifactId>tomcat-embed-el</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.tomcat.embed</groupId>
+                    <artifactId>tomcat-embed-websocket</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
             <groupId>org.springdoc</groupId>
-            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <artifactId>springdoc-openapi-starter-webmvc-api</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-starter-validation</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- Metrics -->

--- a/ecchronos-binary/pom.xml
+++ b/ecchronos-binary/pom.xml
@@ -74,21 +74,6 @@
             </plugin>
 
             <plugin>
-                <artifactId>maven-project-info-reports-plugin</artifactId>
-                <version>3.4.5</version>
-                <executions>
-                    <execution>
-                        <id>licenses</id>
-                        <phase>prepare-package</phase>
-                        <goals>
-                            <goal>dependencies</goal>
-                            <goal>licenses</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-
-            <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>license-maven-plugin</artifactId>
                 <executions>

--- a/ecchronos-binary/src/assembly/assembly.xml
+++ b/ecchronos-binary/src/assembly/assembly.xml
@@ -54,6 +54,10 @@
         <fileSet>
             <directory>${project.basedir}/src/pylib</directory>
             <outputDirectory>pylib</outputDirectory>
+            <excludes>
+                <exclude>**/__pycache__/**</exclude>
+                <exclude>**/*.pyc</exclude>
+            </excludes>
         </fileSet>
         <fileSet>
             <directory>.</directory>
@@ -76,10 +80,7 @@
                 <include>THIRD-PARTY.txt</include>
             </includes>
         </fileSet>
-        <fileSet>
-            <directory>${project.basedir}/target/site</directory>
-            <outputDirectory>site</outputDirectory>
-        </fileSet>
+
     </fileSets>
     <dependencySets>
         <dependencySet>

--- a/pom.xml
+++ b/pom.xml
@@ -110,10 +110,10 @@
         <!-- Spring boot -->
         <org.springframework.boot.spring-boot.version>3.5.15</org.springframework.boot.spring-boot.version>
         <org.springframework.spring.version>6.2.19</org.springframework.spring.version>
-        <org.springdoc.openapi-starter-webmvc-ui.version>2.8.17</org.springdoc.openapi-starter-webmvc-ui.version>
+        <org.springdoc.openapi-starter-webmvc-api.version>2.8.17</org.springdoc.openapi-starter-webmvc-api.version>
         <jakarta.servlet-api.version>6.1.0</jakarta.servlet-api.version>
         <jakarta.validation-api.version>3.1.1</jakarta.validation-api.version>
-        <swagger-annotations.version>2.2.51</swagger-annotations.version>
+        <swagger-annotations.version>2.2.47</swagger-annotations.version>
 
         <!-- Metrics -->
         <io.micrometer.version>1.17.0</io.micrometer.version>
@@ -228,12 +228,6 @@
             <!-- Spring boot -->
             <dependency>
                 <groupId>org.springframework.boot</groupId>
-                <artifactId>spring-boot-starter-thymeleaf</artifactId>
-                <version>${org.springframework.boot.spring-boot.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-starter-web</artifactId>
                 <version>${org.springframework.boot.spring-boot.version}</version>
             </dependency>
@@ -246,8 +240,8 @@
 
             <dependency>
                 <groupId>org.springdoc</groupId>
-                <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-                <version>${org.springdoc.openapi-starter-webmvc-ui.version}</version>
+                <artifactId>springdoc-openapi-starter-webmvc-api</artifactId>
+                <version>${org.springdoc.openapi-starter-webmvc-api.version}</version>
             </dependency>
 
             <dependency>
@@ -261,18 +255,36 @@
                 <groupId>io.micrometer</groupId>
                 <artifactId>micrometer-core</artifactId>
                 <version>${io.micrometer.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.jspecify</groupId>
+                        <artifactId>jspecify</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <dependency>
                 <groupId>io.micrometer</groupId>
                 <artifactId>micrometer-registry-prometheus</artifactId>
                 <version>${io.micrometer.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.jspecify</groupId>
+                        <artifactId>jspecify</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <dependency>
                 <groupId>io.micrometer</groupId>
                 <artifactId>micrometer-registry-jmx</artifactId>
                 <version>${io.micrometer.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.jspecify</groupId>
+                        <artifactId>jspecify</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <dependency>
@@ -362,11 +374,39 @@
                 <groupId>com.github.ben-manes.caffeine</groupId>
                 <artifactId>caffeine</artifactId>
                 <version>${caffeine.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>com.google.errorprone</groupId>
+                        <artifactId>error_prone_annotations</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.jspecify</groupId>
+                        <artifactId>jspecify</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
                 <version>${guava.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>com.google.errorprone</groupId>
+                        <artifactId>error_prone_annotations</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>com.google.j2objc</groupId>
+                        <artifactId>j2objc-annotations</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>com.google.guava</groupId>
+                        <artifactId>listenablefuture</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.jspecify</groupId>
+                        <artifactId>jspecify</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <dependency>
@@ -450,16 +490,10 @@
 
             <dependency>
                 <groupId>io.swagger.core.v3</groupId>
-                <artifactId>swagger-annotations</artifactId>
+                <artifactId>swagger-annotations-jakarta</artifactId>
                 <version>${swagger-annotations.version}</version>
             </dependency>
 
-            <!-- Other -->
-            <dependency>
-                <groupId>io.micrometer</groupId>
-                <artifactId>micrometer-core</artifactId>
-                <version>${io.micrometer.version}</version>
-            </dependency>
 
             <!-- test -->
             <dependency>

--- a/rest/pom.xml
+++ b/rest/pom.xml
@@ -99,7 +99,7 @@
         <!-- OpenAPI annotations -->
         <dependency>
             <groupId>io.swagger.core.v3</groupId>
-            <artifactId>swagger-annotations</artifactId>
+            <artifactId>swagger-annotations-jakarta</artifactId>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
  - Remove site/ from assembly and drop maven-project-info-reports-plugin
  - Exclude __pycache__ and .pyc files from pylib in assembly
  - Remove unused spring-boot-starter-thymeleaf dependency
  - Replace springdoc-openapi-starter-webmvc-ui with -api (no embedded Swagger UI)
  - Exclude hibernate-validator and spring-boot-starter-validation (not used at runtime)
  - Exclude tomcat-embed-el and tomcat-embed-websocket
  - Consolidate swagger-annotations to swagger-annotations-jakarta:2.2.47
  - Exclude compile-only annotation JARs (error_prone, j2objc, listenablefuture, jspecify)
  - Remove duplicate micrometer-core entry from dependencyManagement

  Reduces tar.gz from 38 MB to 35 MB and JARs from 105 to 91.