### PR TITLE
Reduce binary tar.gz release size

### DIFF
--- a/application/pom.xml
+++ b/application/pom.xml
@@ -114,12 +114,6 @@
         <dependency>
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-starter-webmvc-api</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.springframework.boot</groupId>
-                    <artifactId>spring-boot-starter-validation</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <dependency>

--- a/application/pom.xml
+++ b/application/pom.xml
@@ -94,11 +94,16 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-thymeleaf</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.tomcat.embed</groupId>
+                    <artifactId>tomcat-embed-el</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.tomcat.embed</groupId>
+                    <artifactId>tomcat-embed-websocket</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
@@ -108,7 +113,13 @@
 
         <dependency>
             <groupId>org.springdoc</groupId>
-            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <artifactId>springdoc-openapi-starter-webmvc-api</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-starter-validation</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
@@ -120,6 +131,12 @@
         <dependency>
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-registry-prometheus</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.jspecify</groupId>
+                    <artifactId>jspecify</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/ecchronos-binary/pom.xml
+++ b/ecchronos-binary/pom.xml
@@ -69,21 +69,6 @@
             </plugin>
 
             <plugin>
-                <artifactId>maven-project-info-reports-plugin</artifactId>
-                <version>3.9.0</version>
-                <executions>
-                    <execution>
-                        <id>licenses</id>
-                        <phase>prepare-package</phase>
-                        <goals>
-                            <goal>dependencies</goal>
-                            <goal>licenses</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-
-            <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>license-maven-plugin</artifactId>
                 <executions>

--- a/ecchronos-binary/src/assembly/assembly.xml
+++ b/ecchronos-binary/src/assembly/assembly.xml
@@ -76,9 +76,17 @@
                 <include>THIRD-PARTY.txt</include>
             </includes>
         </fileSet>
-        <fileSet>
-            <directory>${project.basedir}/target/site</directory>
-            <outputDirectory>site</outputDirectory>
+
+    </fileSets>
+    <dependencySets>
+        <dependencySet>
+            <outputDirectory>lib</outputDirectory>
+            <useProjectArtifact>true</useProjectArtifact>
+            <scope>runtime</scope>
+        </dependencySet>
+    </dependencySets>
+</assembly>
+tputDirectory>
         </fileSet>
     </fileSets>
     <dependencySets>

--- a/ecchronos-binary/src/assembly/assembly.xml
+++ b/ecchronos-binary/src/assembly/assembly.xml
@@ -54,6 +54,10 @@
         <fileSet>
             <directory>${project.basedir}/src/pylib</directory>
             <outputDirectory>pylib</outputDirectory>
+            <excludes>
+                <exclude>**/__pycache__/**</exclude>
+                <exclude>**/*.pyc</exclude>
+            </excludes>
         </fileSet>
         <fileSet>
             <directory>.</directory>
@@ -77,17 +81,6 @@
             </includes>
         </fileSet>
 
-    </fileSets>
-    <dependencySets>
-        <dependencySet>
-            <outputDirectory>lib</outputDirectory>
-            <useProjectArtifact>true</useProjectArtifact>
-            <scope>runtime</scope>
-        </dependencySet>
-    </dependencySets>
-</assembly>
-tputDirectory>
-        </fileSet>
     </fileSets>
     <dependencySets>
         <dependencySet>

--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
         <org.apache.commons.commons-compress.version>1.28.0</org.apache.commons.commons-compress.version>
         <org.apache.httpcomponents.client5.httpclient5.version>5.6.1</org.apache.httpcomponents.client5.httpclient5.version>
         <org.bouncycastle.bcpkix-jdk18on.version>1.84</org.bouncycastle.bcpkix-jdk18on.version>
-        <org.springdoc.openapi-starter-webmvc-ui.version>2.8.17</org.springdoc.openapi-starter-webmvc-ui.version>
+        <org.springdoc.openapi-starter-webmvc-api.version>2.8.17</org.springdoc.openapi-starter-webmvc-api.version>
         <org.springframework.boot.spring-boot.version>3.5.15</org.springframework.boot.spring-boot.version>
         <org.springframework.spring-test.version>6.2.19</org.springframework.spring-test.version>
         <org.yaml.snakeyaml.version>2.6</org.yaml.snakeyaml.version>
@@ -337,20 +337,14 @@
 
             <dependency>
                 <groupId>org.springframework.boot</groupId>
-                <artifactId>spring-boot-starter-thymeleaf</artifactId>
-                <version>${org.springframework.boot.spring-boot.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-starter-web</artifactId>
                 <version>${org.springframework.boot.spring-boot.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>org.springdoc</groupId>
-                <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-                <version>${org.springdoc.openapi-starter-webmvc-ui.version}</version>
+                <artifactId>springdoc-openapi-starter-webmvc-api</artifactId>
+                <version>${org.springdoc.openapi-starter-webmvc-api.version}</version>
             </dependency>
 
             <!-- OpenAPI annotations -->
@@ -362,7 +356,7 @@
 
             <dependency>
                 <groupId>io.swagger.core.v3</groupId>
-                <artifactId>swagger-annotations</artifactId>
+                <artifactId>swagger-annotations-jakarta</artifactId>
                 <version>${swagger-annotations.version}</version>
             </dependency>
 

--- a/rest/pom.xml
+++ b/rest/pom.xml
@@ -80,7 +80,7 @@
         <!-- OpenAPI annotations -->
         <dependency>
             <groupId>io.swagger.core.v3</groupId>
-            <artifactId>swagger-annotations</artifactId>
+            <artifactId>swagger-annotations-jakarta</artifactId>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
- Remove site/ from assembly and drop maven-project-info-reports-plugin
- Exclude __pycache__ and .pyc files from pylib in assembly
- Remove unused spring-boot-starter-thymeleaf dependency
- Replace springdoc-openapi-starter-webmvc-ui with -api (no embedded Swagger UI)
- Exclude hibernate-validator and spring-boot-starter-validation (not used at runtime)
- Exclude tomcat-embed-el and tomcat-embed-websocket
- Exclude jspecify compile-only annotation JAR
- Switch swagger-annotations to swagger-annotations-jakarta