### PR TITLE
Fix stale Jolokia connection after Cassandra pod recreation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Version 1.0.4
 
+* Fix stale Jolokia connection after Cassandra pod recreation - Issue #1682
+
 ## Version 1.0.3
 
 * Fix schedule discovery failure during DC upgrade never retried - Issue #1670

--- a/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/jmx/AbstractDistributedJmxProxy.java
+++ b/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/jmx/AbstractDistributedJmxProxy.java
@@ -36,6 +36,8 @@ import javax.management.ReflectionException;
 import javax.management.RuntimeMBeanException;
 import javax.management.remote.JMXConnector;
 import java.io.IOException;
+import java.net.ConnectException;
+import java.net.http.HttpConnectTimeoutException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Optional;
@@ -159,6 +161,7 @@ abstract class AbstractDistributedJmxProxy implements DistributedJmxProxy
                    | UncheckedJmxAdapterException e)
             {
                 rethrowIfOutOfMemory(e);
+                invalidateIfConnectionStale(nodeIdConnection, e);
                 LOG.error("Unable to get live nodes for node {}", nodeID, e);
             }
         }
@@ -219,6 +222,7 @@ abstract class AbstractDistributedJmxProxy implements DistributedJmxProxy
                    | UncheckedJmxAdapterException e)
             {
                 rethrowIfOutOfMemory(e);
+                invalidateIfConnectionStale(nodeIdConnection, e);
                 LOG.error("Unable to get unreachable nodes for node {}", nodeID, e);
             }
         }
@@ -277,6 +281,7 @@ abstract class AbstractDistributedJmxProxy implements DistributedJmxProxy
             catch (InstanceNotFoundException | MBeanException | ReflectionException | IOException | UncheckedJmxAdapterException e)
             {
                 rethrowIfOutOfMemory(e);
+                invalidateIfConnectionStale(nodeID, e);
                 LOG.error("Unable to repair node {}", nodeID, e);
             }
         }
@@ -328,6 +333,7 @@ abstract class AbstractDistributedJmxProxy implements DistributedJmxProxy
             catch (InstanceNotFoundException | MBeanException | ReflectionException | IOException | UncheckedJmxAdapterException e)
             {
                 rethrowIfOutOfMemory(e);
+                invalidateIfConnectionStale(nodeID, e);
                 LOG.error("Unable to terminate repair sessions for node {}", nodeID, e);
             }
         }
@@ -393,6 +399,7 @@ abstract class AbstractDistributedJmxProxy implements DistributedJmxProxy
                    | UncheckedJmxAdapterException e)
             {
                 rethrowIfOutOfMemory(e);
+                invalidateIfConnectionStale(nodeID, e);
                 LOG.error("Unable to retrieve disk space usage for table {} in node {}", tableReference,
                         nodeID,
                         e);
@@ -475,6 +482,7 @@ abstract class AbstractDistributedJmxProxy implements DistributedJmxProxy
                    | UncheckedJmxAdapterException e)
             {
                 rethrowIfOutOfMemory(e);
+                invalidateIfConnectionStale(nodeID, e);
                 LOG.error("Unable to retrieve percent repaired for {} in node {}",
                         tableReference, nodeID, e);
             }
@@ -529,6 +537,7 @@ abstract class AbstractDistributedJmxProxy implements DistributedJmxProxy
                    | UncheckedJmxAdapterException e)
             {
                 rethrowIfOutOfMemory(e);
+                invalidateIfConnectionStale(nodeID, e);
                 LOG.error("Unable to retrieve node status for {}", nodeID, e);
             }
         }
@@ -573,6 +582,7 @@ abstract class AbstractDistributedJmxProxy implements DistributedJmxProxy
             catch (Exception e)
             {
                 rethrowIfOutOfMemory(e);
+                invalidateIfConnectionStale(nodeID, e);
                 LOG.warn("Unable to check active repair status for command {} on node {}, assuming still active",
                         command, nodeID, e);
                 return true;
@@ -617,6 +627,42 @@ abstract class AbstractDistributedJmxProxy implements DistributedJmxProxy
         else
         {
             LOG.info("Node {} is not managed by local instance, cannot mark as unavailable", nodeID);
+        }
+    }
+
+    /**
+     * Invalidate the JMX connection for a node, forcing reconnection on next use.
+     * Called when HTTP timeouts indicate the cached connection points to a stale address.
+     */
+    protected void invalidateConnection(final UUID nodeID)
+    {
+        try
+        {
+            getConnectionProvider().close(nodeID);
+            LOG.info("Invalidated JMX connection for node {} to force reconnection", nodeID);
+        }
+        catch (IOException e)
+        {
+            LOG.debug("Error closing stale connection for node {}", nodeID, e);
+        }
+    }
+
+    /**
+     * Check if the exception indicates a stale connection (HTTP connect timeout)
+     * and invalidate the connection if so.
+     */
+    protected void invalidateIfConnectionStale(final UUID nodeID, final Throwable t)
+    {
+        Throwable cause = t;
+        while (cause != null)
+        {
+            if (cause instanceof HttpConnectTimeoutException
+                    || cause instanceof ConnectException)
+            {
+                invalidateConnection(nodeID);
+                return;
+            }
+            cause = cause.getCause();
         }
     }
 
@@ -701,6 +747,7 @@ abstract class AbstractDistributedJmxProxy implements DistributedJmxProxy
         catch (MBeanException | ReflectionException | IOException | UncheckedJmxAdapterException e)
         {
             rethrowIfOutOfMemory(e);
+            invalidateIfConnectionStale(nodeID, e);
             LOG.error("Unable to get maxRepaired for table {} in node {}", tableReference, nodeID, e);
         }
         catch (ClassCastException e)

--- a/core.impl/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/impl/jmx/TestInvalidateConnectionStale.java
+++ b/core.impl/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/impl/jmx/TestInvalidateConnectionStale.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2026 Telefonaktiebolaget LM Ericsson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ericsson.bss.cassandra.ecchronos.core.impl.jmx;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.ericsson.bss.cassandra.ecchronos.connection.DistributedJmxConnectionProvider;
+import com.ericsson.bss.cassandra.ecchronos.data.sync.EccNodesSync;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.net.ConnectException;
+import java.net.http.HttpConnectTimeoutException;
+import java.util.Map;
+import java.util.UUID;
+
+public class TestInvalidateConnectionStale
+{
+    private DistributedJmxConnectionProvider myConnectionProvider;
+    private EccNodesSync myEccNodesSync;
+    private RMIJmxProxy myProxy;
+    private UUID myNodeId;
+
+    @Before
+    public void setup() throws Exception
+    {
+        myConnectionProvider = mock(DistributedJmxConnectionProvider.class);
+        myEccNodesSync = mock(EccNodesSync.class);
+        myNodeId = UUID.randomUUID();
+        when(myConnectionProvider.getJmxConnections()).thenReturn(new java.util.concurrent.ConcurrentHashMap<>());
+
+        myProxy = new RMIJmxProxy(myConnectionProvider, Map.of(), myEccNodesSync);
+    }
+
+    @Test
+    public void testInvalidatesOnHttpConnectTimeout() throws IOException
+    {
+        Exception wrapper = new RuntimeException(new HttpConnectTimeoutException("timed out"));
+        myProxy.invalidateIfConnectionStale(myNodeId, wrapper);
+
+        verify(myConnectionProvider).close(myNodeId);
+    }
+
+    @Test
+    public void testInvalidatesOnConnectException() throws IOException
+    {
+        Exception wrapper = new RuntimeException(new ConnectException("Connection refused"));
+        myProxy.invalidateIfConnectionStale(myNodeId, wrapper);
+
+        verify(myConnectionProvider).close(myNodeId);
+    }
+
+    @Test
+    public void testDoesNotInvalidateOnUnrelatedIOException() throws IOException
+    {
+        Exception wrapper = new RuntimeException(new IOException("generic IO error"));
+        myProxy.invalidateIfConnectionStale(myNodeId, wrapper);
+
+        verify(myConnectionProvider, never()).close(myNodeId);
+    }
+
+    @Test
+    public void testDoesNotInvalidateOnNullPointerException() throws IOException
+    {
+        myProxy.invalidateIfConnectionStale(myNodeId, new NullPointerException());
+
+        verify(myConnectionProvider, never()).close(myNodeId);
+    }
+}


### PR DESCRIPTION
When JMX operations fail with HttpConnectTimeoutException or ConnectException (indicating the cached connection points to a stale IP), close the connection to force reconnection on the next attempt.

Previously, Jolokia HTTP connectors appeared 'connected' to isConnected() since they're stateless — the connector object remained valid while the URL pointed to a non-existent IP. Repairs stayed IN_QUEUE until the daily connection reload cycle triggered.

Added invalidateIfConnectionStale() that walks the exception cause chain and calls close(nodeID) when a connection-level timeout is detected.

Closes #1682 