### PR TITLE
Remove springdoc runtime dependency from distribution

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -194,7 +194,7 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ matrix.name }}-ecchronos-logs
-          path: ./ecchronos-binary/target/test/ecchronos-binary-agent-1.0.0-SNAPSHOT/logs/
+          path: ./ecchronos-binary/target/test/ecchronos-binary-agent-*/logs/
           if-no-files-found: 'ignore'
 
       - name: Upload coverage to Codecov

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Version 1.0.4
 
+* Remove springdoc runtime dependency from packaged distribution - Issue #1686
 * Fix stale Jolokia connection after Cassandra pod recreation - Issue #1682
 
 ## Version 1.0.3

--- a/application/pom.xml
+++ b/application/pom.xml
@@ -108,6 +108,7 @@
         <dependency>
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-starter-webmvc-api</artifactId>
+            <scope>provided</scope>
         </dependency>
 
         <!-- Metrics -->

--- a/application/src/main/java/com/ericsson/bss/cassandra/ecchronos/application/config/security/ReloadingCertificateHandler.java
+++ b/application/src/main/java/com/ericsson/bss/cassandra/ecchronos/application/config/security/ReloadingCertificateHandler.java
@@ -18,7 +18,7 @@ import com.datastax.oss.driver.api.core.metadata.EndPoint;
 import com.ericsson.bss.cassandra.ecchronos.connection.CertificateHandler;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.handler.ssl.SslContext;
-import jakarta.xml.bind.DatatypeConverter;
+import java.util.HexFormat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -299,7 +299,7 @@ public class ReloadingCertificateHandler implements CertificateHandler
         {
             MessageDigest md5 = MessageDigest.getInstance("MD5");
             byte[] digestBytes = md5.digest(Files.readAllBytes(Paths.get(file)));
-            return DatatypeConverter.printHexBinary(digestBytes);
+            return HexFormat.of().formatHex(digestBytes);
         }
     }
 }

--- a/rest/pom.xml
+++ b/rest/pom.xml
@@ -100,6 +100,7 @@
         <dependency>
             <groupId>io.swagger.core.v3</groupId>
             <artifactId>swagger-annotations-jakarta</artifactId>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Change springdoc-openapi-starter-webmvc-api to provided scope in application/pom.xml and swagger-annotations-jakarta to provided in rest/pom.xml. This keeps them available for compilation and integration tests but excludes them from the packaged binary (~2.5-3 MB savings).

The OpenAPI spec is still generated and validated during integration tests via the live springdoc endpoint (provided scope includes the test classpath).

Closes #1686 