### PR TITLE
Exclude spring-boot-starter-logging from distribution

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Version 1.0.4
 
+* Exclude spring-boot-starter-logging from distribution - Issue #1687
 * Fix stale Jolokia connection after Cassandra pod recreation - Issue #1682
 
 ## Version 1.0.3

--- a/application/pom.xml
+++ b/application/pom.xml
@@ -102,6 +102,10 @@
                     <groupId>org.apache.tomcat.embed</groupId>
                     <artifactId>tomcat-embed-websocket</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-starter-logging</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 


### PR DESCRIPTION
Add exclusion for spring-boot-starter-logging on spring-boot-starter-web. The project already declares logback-classic and slf4j-api explicitly. Removes redundant jul-to-slf4j and log4j-to-slf4j bridge JARs.

Closes #1687 