### PR TITLE
test: cover successful scheduled job not rerun before interval

### DIFF
--- a/core.impl/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/scheduler/TestScheduleManager.java
+++ b/core.impl/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/scheduler/TestScheduleManager.java
@@ -119,6 +119,23 @@ public class TestScheduleManager
     }
 
     @Test
+    public void testSuccessfulJobIsNotRunAgainBeforeRunInterval() throws LockException
+    {
+        TestJob job = new TestJob(ScheduledJob.Priority.LOW, 1, nodeID1, "dc1", "resource1");
+        myScheduler.schedule(nodeID1, job);
+
+        when(myLockFactory.tryLock(any(), anyString(), anyInt(), anyMap(), any()))
+                .thenReturn(new DummyLock());
+
+        myScheduler.run(nodeID1);
+        myScheduler.run(nodeID1);
+
+        assertThat(job.getTaskRuns()).isEqualTo(1);
+        assertThat(myScheduler.getQueueSize(nodeID1)).isEqualTo(1);
+        verify(myLockFactory, times(1)).tryLock(any(), anyString(), anyInt(), anyMap(), any());
+    }
+
+    @Test
     public void testRunningMultipleJobsInSingleTick()
     {
         DummyJob job1 = new DummyJob(ScheduledJob.Priority.LOW, nodeID1);


### PR DESCRIPTION
Adds regression coverage for ScheduleManagerImpl to verify that a successfully executed scheduled job is not executed again on an immediate subsequent scheduler run.

The job remains queued, but after successful execution it should be PARKED until its configured run interval has elapsed. The test also verifies that the repair lock is acquired only once.

Validation:
mvn -pl core.impl -am -Dtest=TestScheduleManager -Dsurefire.failIfNoSpecifiedTests=false test