### PR TITLE
Fix repair jobs stuck ON_TIME due to empty Jolokia response

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 
 * Upgrade ecChronos to Spring Boot 4 - Issue #1711
 * Add JSON output format for ecctool state - Issue #1739
+* Fix repair jobs stuck ON_TIME when Jolokia returns empty body due to transient network issues - Issue #1740
 
 ## Version 1.0.6
 

--- a/application/src/main/java/com/ericsson/bss/cassandra/ecchronos/application/spring/BeanConfigurator.java
+++ b/application/src/main/java/com/ericsson/bss/cassandra/ecchronos/application/spring/BeanConfigurator.java
@@ -33,6 +33,7 @@ import com.ericsson.bss.cassandra.ecchronos.data.sync.EccNodesSync;
 import com.ericsson.bss.cassandra.ecchronos.fm.RepairFaultReporter;
 import com.ericsson.bss.cassandra.ecchronos.utils.exceptions.ConfigurationException;
 import com.ericsson.bss.cassandra.ecchronos.utils.exceptions.EcChronosException;
+import com.ericsson.bss.cassandra.ecchronos.utils.enums.sync.NodeStatus;
 import java.net.InetAddress;
 import java.io.IOException;
 import java.net.UnknownHostException;
@@ -329,7 +330,7 @@ public class BeanConfigurator
                     LOG.warn("Marking node {} as UNAVAILABLE after consecutive Jolokia notification failures",
                             nodeID);
                     eccNodesSync.updateNodeStatus(
-                            com.ericsson.bss.cassandra.ecchronos.utils.enums.sync.NodeStatus.UNAVAILABLE,
+                            NodeStatus.UNAVAILABLE,
                             node.getDatacenter(), nodeID);
                 }
             })

--- a/application/src/main/java/com/ericsson/bss/cassandra/ecchronos/application/spring/BeanConfigurator.java
+++ b/application/src/main/java/com/ericsson/bss/cassandra/ecchronos/application/spring/BeanConfigurator.java
@@ -15,6 +15,7 @@
 package com.ericsson.bss.cassandra.ecchronos.application.spring;
 
 import com.datastax.oss.driver.api.core.CqlSession;
+import com.datastax.oss.driver.api.core.metadata.Node;
 import com.ericsson.bss.cassandra.ecchronos.application.ReflectionUtils;
 import com.ericsson.bss.cassandra.ecchronos.application.config.repair.Interval;
 import com.ericsson.bss.cassandra.ecchronos.application.config.security.ReloadingCertificateHandler;
@@ -288,18 +289,21 @@ public class BeanConfigurator
     public JolokiaNotificationController jolokiaNotificationController(
         final Config config,
         final DistributedNativeConnectionProvider nativeConnectionProvider,
-        final IpTranslator ipTranslator
+        final IpTranslator ipTranslator,
+        final EccNodesSync eccNodesSync
     )
     {
         LOG.info("Creating JolokiaNotificationController");
-        return getJolokiaNotificationController(config, nativeConnectionProvider, jmxSecurity::get, ipTranslator);
+        return getJolokiaNotificationController(config, nativeConnectionProvider, jmxSecurity::get, ipTranslator,
+                eccNodesSync);
     }
 
     private JolokiaNotificationController getJolokiaNotificationController(
         final Config config,
         final DistributedNativeConnectionProvider nativeConnectionProvider,
         final Supplier<Security.JmxSecurity> securitySupplier,
-        final IpTranslator ipTranslator
+        final IpTranslator ipTranslator,
+        final EccNodesSync eccNodesSync
     )
     {
         Supplier<TLSConfig> jmxTlsSupplier = () -> securitySupplier.get().getJmxTlsConfig();
@@ -317,6 +321,18 @@ public class BeanConfigurator
             .withRunDelay(config.getConnectionConfig().getJmxConnection().getRunDelay())
             .withIpTranslator(ipTranslator)
             .withCertificateHandler(certificateHandler)
+            .withNodeUnavailableCallback(nodeID ->
+            {
+                Node node = nativeConnectionProvider.getNodes().get(nodeID);
+                if (node != null)
+                {
+                    LOG.warn("Marking node {} as UNAVAILABLE after consecutive Jolokia notification failures",
+                            nodeID);
+                    eccNodesSync.updateNodeStatus(
+                            com.ericsson.bss.cassandra.ecchronos.utils.enums.sync.NodeStatus.UNAVAILABLE,
+                            node.getDatacenter(), nodeID);
+                }
+            })
             .build();
     }
 

--- a/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/jmx/JolokiaHttpClient.java
+++ b/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/jmx/JolokiaHttpClient.java
@@ -15,6 +15,7 @@
 package com.ericsson.bss.cassandra.ecchronos.core.impl.jmx;
 
 import com.ericsson.bss.cassandra.ecchronos.core.impl.jmx.http.ClientRegisterResponse;
+import com.ericsson.bss.cassandra.ecchronos.core.impl.jmx.http.NotificationListenerResponse;
 import com.ericsson.bss.cassandra.ecchronos.core.impl.jmx.http.NotificationRegisterResponse;
 import com.ericsson.bss.cassandra.ecchronos.connection.CertificateHandler;
 import com.ericsson.bss.cassandra.ecchronos.connection.DistributedNativeConnectionProvider;
@@ -52,6 +53,8 @@ final class JolokiaHttpClient implements java.io.Closeable
     private static final int MAX_RETRIES = 3;
     private static final long INITIAL_RETRY_DELAY_IN_MS = 500;
     private static final int HTTP_EXECUTOR_POOL_SIZE = 8;
+    private static final int HTTP_OK = 200;
+    private static final int HTTP_MULTI_CHOICES = 300;
     private static final String CLIENT_ID_PROPERTY = "clientID";
     private static final String SS_OBJ_NAME = "org.apache.cassandra.db:type=StorageService";
     public static final String NO_BROADCAST_ADDRESS = "0.0.0.0"; //NOPMD AvoidUsingHardCodedIP
@@ -193,15 +196,16 @@ final class JolokiaHttpClient implements java.io.Closeable
         }
     }
 
-    public String checkForNotificationsWithRetry(final UUID nodeID, final String notificationID)
-            throws IOException, InterruptedException
+    public NotificationListenerResponse checkForNotificationsWithRetry(final UUID nodeID,
+            final String notificationID) throws IOException, InterruptedException
     {
         IOException lastException = null;
         for (int attempt = 1; attempt <= MAX_RETRIES; attempt++)
         {
             try
             {
-                return checkForNotifications(nodeID, notificationID);
+                String response = checkForNotifications(nodeID, notificationID);
+                return objectMapper.readValue(response, NotificationListenerResponse.class);
             }
             catch (IOException e)
             {
@@ -214,16 +218,35 @@ final class JolokiaHttpClient implements java.io.Closeable
                     Thread.sleep(delay);
                 }
             }
+            catch (JacksonException e)
+            {
+                lastException = new IOException("Failed to parse Jolokia notification response for node "
+                        + nodeID, e);
+                LOG.debug("Notification check attempt {}/{} failed to parse response for node {}",
+                        attempt, MAX_RETRIES, nodeID, e);
+                if (attempt < MAX_RETRIES)
+                {
+                    long delay = INITIAL_RETRY_DELAY_IN_MS * (1L << (attempt - 1));
+                    Thread.sleep(delay);
+                }
+            }
         }
         LOG.debug("All {} retries failed for node {}, attempting client re-registration", MAX_RETRIES, nodeID);
         try
         {
             registerClientId(nodeID);
-            return checkForNotifications(nodeID, notificationID);
+            String response = checkForNotifications(nodeID, notificationID);
+            return objectMapper.readValue(response, NotificationListenerResponse.class);
         }
         catch (IOException e)
         {
             LOG.warn("Re-registration attempt also failed for node {}", nodeID, e);
+        }
+        catch (JacksonException e)
+        {
+            LOG.warn("Re-registration succeeded but response parsing failed for node {}", nodeID, e);
+            lastException = new IOException("Failed to parse Jolokia notification response for node "
+                    + nodeID + " after re-registration", e);
         }
         throw lastException;
     }
@@ -248,7 +271,19 @@ final class JolokiaHttpClient implements java.io.Closeable
                 .build();
 
         HttpResponse<String> response = getHttpClient().send(request, HttpResponse.BodyHandlers.ofString());
-        return decodeHtmlEntities(response.body());
+        int statusCode = response.statusCode();
+        if (statusCode < HTTP_OK || statusCode >= HTTP_MULTI_CHOICES)
+        {
+            throw new IOException("Jolokia notification check for node " + nodeID
+                    + " returned HTTP status " + statusCode);
+        }
+        String body = response.body();
+        if (body == null || body.isBlank())
+        {
+            throw new IOException("Jolokia notification check for node " + nodeID
+                    + " returned empty response body (HTTP " + statusCode + ")");
+        }
+        return decodeHtmlEntities(body);
     }
 
     private String mountJolokiaBaseURL(final UUID nodeID) throws UnknownHostException

--- a/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/jmx/JolokiaNotificationController.java
+++ b/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/jmx/JolokiaNotificationController.java
@@ -18,8 +18,6 @@ import com.ericsson.bss.cassandra.ecchronos.core.impl.jmx.http.NotificationListe
 import com.ericsson.bss.cassandra.ecchronos.connection.CertificateHandler;
 import com.ericsson.bss.cassandra.ecchronos.connection.DistributedNativeConnectionProvider;
 import com.ericsson.bss.cassandra.ecchronos.data.iptranslator.IpTranslator;
-import tools.jackson.databind.ObjectMapper;
-import tools.jackson.databind.json.JsonMapper;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -42,6 +40,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.ReentrantLock;
 
 /**
@@ -64,8 +63,8 @@ public class JolokiaNotificationController implements Closeable
 
     private final Map<UUID, Map<String, NotificationListener>> myNodeListenersMap = new ConcurrentHashMap<>();
     private final Map<UUID, Map<String, ScheduledFuture<?>>> myNotificationMonitors = new ConcurrentHashMap<>();
+    private final Map<UUID, Map<String, NotificationRunTask>> myNotificationTasks = new ConcurrentHashMap<>();
 
-    private final ObjectMapper objectMapper = new JsonMapper();
     private final ConcurrentHashMap<UUID, ReentrantLock> myNodeLocks = new ConcurrentHashMap<>();
     private final Semaphore myPollingSemaphore;
 
@@ -107,6 +106,7 @@ public class JolokiaNotificationController implements Closeable
     public final void addStorageServiceListener(final UUID nodeID, final NotificationListener listener) throws IOException, InterruptedException
     {
         myJolokiaHttpClient.registerClientId(nodeID);
+        resetNotificationFailures(nodeID);
 
         String jolokiaNotificationID = myJolokiaHttpClient.registerJolokiaNotification(nodeID);
 
@@ -145,6 +145,25 @@ public class JolokiaNotificationController implements Closeable
     }
 
     /**
+     * Resets the consecutive failure counters for all notification tasks on the specified node.
+     * This prevents failure counts from a previous repair execution from carrying over
+     * to the next one.
+     *
+     * @param nodeID the identifier of the node.
+     */
+    public void resetNotificationFailures(final UUID nodeID)
+    {
+        Map<String, NotificationRunTask> tasks = myNotificationTasks.get(nodeID);
+        if (tasks != null)
+        {
+            for (NotificationRunTask task : tasks.values())
+            {
+                task.resetConsecutiveFailures();
+            }
+        }
+    }
+
+    /**
      * Removes a previously registered notification listener for the specified node.
      *
      * @param nodeID the identifier of the node.
@@ -173,6 +192,11 @@ public class JolokiaNotificationController implements Closeable
                     future.cancel(true);
                 }
             }
+            Map<String, NotificationRunTask> tasks = myNotificationTasks.get(nodeID);
+            if (tasks != null)
+            {
+                tasks.remove(jolokiaNotificationID);
+            }
         }
         Map<String, NotificationListener> listeners = myNodeListenersMap.get(nodeID);
         if (listeners != null)
@@ -184,14 +208,18 @@ public class JolokiaNotificationController implements Closeable
 
     private void startNotificationMonitor(final UUID nodeID, final String notificationID)
     {
+        NotificationRunTask task = new NotificationRunTask(nodeID, notificationID);
         ScheduledFuture<?> future = myNotificationExecutor.scheduleWithFixedDelay(
-                new NotificationRunTask(nodeID, notificationID), 0, myRunDelay, TimeUnit.MILLISECONDS);
+                task, 0, myRunDelay, TimeUnit.MILLISECONDS);
 
         synchronized (myNotificationMonitors)
         {
             myNotificationMonitors
                     .computeIfAbsent(nodeID, k -> new ConcurrentHashMap<>())
                     .put(notificationID, future);
+            myNotificationTasks
+                    .computeIfAbsent(nodeID, k -> new ConcurrentHashMap<>())
+                    .put(notificationID, task);
         }
     }
 
@@ -214,12 +242,22 @@ public class JolokiaNotificationController implements Closeable
                 return super.add(e);
             }
         };
-        private int consecutiveFailures = 0;
+        private final AtomicInteger consecutiveFailures = new AtomicInteger(0);
 
         private NotificationRunTask(final UUID nodeID, final String notificationID)
         {
             myNodeID = nodeID;
             myNotificationID = notificationID;
+        }
+
+        /**
+         * Resets the consecutive failure counter.
+         * Called when a new repair execution begins to avoid carrying
+         * stale failure counts from a previous repair cycle.
+         */
+        void resetConsecutiveFailures()
+        {
+            consecutiveFailures.set(0);
         }
 
         @Override
@@ -237,9 +275,8 @@ public class JolokiaNotificationController implements Closeable
                 lock.lock();
                 try
                 {
-                    String response = myJolokiaHttpClient.checkForNotificationsWithRetry(myNodeID, myNotificationID);
-                    NotificationListenerResponse notificationListenerResponse = objectMapper.readValue(response,
-                            NotificationListenerResponse.class);
+                    NotificationListenerResponse notificationListenerResponse =
+                            myJolokiaHttpClient.checkForNotificationsWithRetry(myNodeID, myNotificationID);
 
                     if (notificationListenerResponse.getValue() != null)
                     {
@@ -251,7 +288,7 @@ public class JolokiaNotificationController implements Closeable
                             createNotification(notificationObj);
                         }
                     }
-                    consecutiveFailures = 0;
+                    consecutiveFailures.set(0);
                 }
                 finally
                 {
@@ -260,17 +297,17 @@ public class JolokiaNotificationController implements Closeable
             }
             catch (Exception e)
             {
-                consecutiveFailures++;
-                if (consecutiveFailures >= MAX_CONSECUTIVE_FAILURES)
+                int failures = consecutiveFailures.incrementAndGet();
+                if (failures >= MAX_CONSECUTIVE_FAILURES)
                 {
                     LOG.error("Notification check failed {} consecutive times for node {} and notificationID {}. "
-                            + "Signaling connection failure.", consecutiveFailures, myNodeID, myNotificationID);
+                            + "Signaling connection failure.", failures, myNodeID, myNotificationID);
                     signalConnectionFailure();
                 }
                 else
                 {
                     LOG.warn("Transient notification check failure ({}/{}) for node {} and notificationID {}",
-                            consecutiveFailures, MAX_CONSECUTIVE_FAILURES, myNodeID, myNotificationID, e);
+                            failures, MAX_CONSECUTIVE_FAILURES, myNodeID, myNotificationID, e);
                 }
             }
             finally
@@ -368,6 +405,7 @@ public class JolokiaNotificationController implements Closeable
 
         myNodeListenersMap.clear();
         myJolokiaRelationshipListeners.clear();
+        myNotificationTasks.clear();
         myNodeLocks.clear();
 
         // Shutdown executor

--- a/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/jmx/JolokiaNotificationController.java
+++ b/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/jmx/JolokiaNotificationController.java
@@ -42,6 +42,7 @@ import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Consumer;
 
 /**
  * Controller responsible for managing Jolokia-based JMX notification listeners.
@@ -70,6 +71,7 @@ public class JolokiaNotificationController implements Closeable
 
     private final JolokiaHttpClient myJolokiaHttpClient;
     private final long myRunDelay;
+    private final Consumer<UUID> myNodeUnavailableCallback;
 
     /**
      * Constructs a JolokiaNotificationController from the provided builder.
@@ -79,6 +81,7 @@ public class JolokiaNotificationController implements Closeable
     public JolokiaNotificationController(final Builder builder)
     {
         myRunDelay = builder.myRunDelay;
+        myNodeUnavailableCallback = builder.myNodeUnavailableCallback;
         myPollingSemaphore = new Semaphore(NOTIFICATION_THREAD_POOL_SIZE);
         myJolokiaHttpClient = new JolokiaHttpClient(
                 builder.myCertificateHandler,
@@ -336,6 +339,17 @@ public class JolokiaNotificationController implements Closeable
                     }
                 }
             }
+            if (myNodeUnavailableCallback != null)
+            {
+                try
+                {
+                    myNodeUnavailableCallback.accept(myNodeID);
+                }
+                catch (Exception e)
+                {
+                    LOG.warn("Failed to mark node {} as unavailable", myNodeID, e);
+                }
+            }
         }
 
         private void createNotification(final NotificationListenerResponse.Notification notificationObj)
@@ -450,6 +464,7 @@ public class JolokiaNotificationController implements Closeable
         private long myRunDelay = DEFAULT_RUN_DELAY;
         private IpTranslator myIpTranslator;
         private CertificateHandler myCertificateHandler;
+        private Consumer<UUID> myNodeUnavailableCallback;
 
         /**
          * Default constructor.
@@ -547,6 +562,21 @@ public class JolokiaNotificationController implements Closeable
         public Builder withCertificateHandler(final CertificateHandler certificateHandler)
         {
             myCertificateHandler = certificateHandler;
+            return this;
+        }
+
+        /**
+         * Sets the callback invoked when a node is determined to be unavailable
+         * after consecutive notification polling failures. This allows the caller
+         * to mark the node for retry by the {@code RetrySchedulerService}.
+         *
+         * @param callback
+         *         consumer that accepts the node UUID to mark as unavailable
+         * @return Builder
+         */
+        public Builder withNodeUnavailableCallback(final Consumer<UUID> callback)
+        {
+            myNodeUnavailableCallback = callback;
             return this;
         }
 

--- a/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/scheduler/ScheduleManagerImpl.java
+++ b/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/scheduler/ScheduleManagerImpl.java
@@ -36,6 +36,7 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Sets;
@@ -57,10 +58,13 @@ public final class ScheduleManagerImpl implements ScheduleManager, Closeable
     public static final int DEFAULT_KEEP_ALIVE_TIME = 60;
     /** Default timeout in minutes for awaiting executor termination. */
     public static final int DEFAULT_TIMEOUT = 5;
+    /** Maximum consecutive task failures before a job is marked as FAILED. */
+    static final int MAX_CONSECUTIVE_TASK_FAILURES = 5;
 
     private final Map<UUID, ScheduledJobQueue> myQueue = new ConcurrentHashMap<>();
     private final ConcurrentHashMap<UUID, ScheduledJob> currentExecutingJobs = new ConcurrentHashMap<>();
     private final ConcurrentHashMap<ScheduledJob, Long> myContentionBackoff = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<UUID, AtomicInteger> myConsecutiveFailures = new ConcurrentHashMap<>();
     private final Set<RunPolicy> myRunPolicies = Sets.newConcurrentHashSet();
     private final Map<UUID, ScheduledFuture<?>> myRunFuture = new ConcurrentHashMap<>();
     private final Map<UUID, JobRunTask> myRunTasks = new ConcurrentHashMap<>();
@@ -248,6 +252,7 @@ public final class ScheduleManagerImpl implements ScheduleManager, Closeable
             queue.remove(job);
         }
         myContentionBackoff.remove(job);
+        myConsecutiveFailures.remove(job.getJobId());
     }
 
     @Override
@@ -277,6 +282,7 @@ public final class ScheduleManagerImpl implements ScheduleManager, Closeable
         myQueue.clear();
         currentExecutingJobs.clear();
         myContentionBackoff.clear();
+        myConsecutiveFailures.clear();
         myRunPolicies.clear();
     }
 
@@ -528,6 +534,8 @@ public final class ScheduleManagerImpl implements ScheduleManager, Closeable
         {
             int tasksExecuted = 0;
             int index = 0;
+            AtomicInteger failureCounter = myConsecutiveFailures.computeIfAbsent(
+                    job.getJobId(), k -> new AtomicInteger(0));
             for (ScheduledTask task : job)
             {
                 if (!withinSessionWindow(sessionStart))
@@ -543,6 +551,18 @@ public final class ScheduleManagerImpl implements ScheduleManager, Closeable
                     if (successful)
                     {
                         tasksExecuted++;
+                        failureCounter.set(0);
+                    }
+                    else
+                    {
+                        int failures = failureCounter.incrementAndGet();
+                        if (failures >= MAX_CONSECUTIVE_TASK_FAILURES)
+                        {
+                            LOG.error("Job {} on node {} has failed {} consecutive task executions, "
+                                    + "marking as FAILED", job, nodeID, failures);
+                            job.markFailed();
+                            break;
+                        }
                     }
                 }
                 catch (Exception e)

--- a/core.impl/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/impl/jmx/TestJolokiaHttpClientResponseValidation.java
+++ b/core.impl/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/impl/jmx/TestJolokiaHttpClientResponseValidation.java
@@ -1,0 +1,230 @@
+/*
+ * Copyright 2026 Telefonaktiebolaget LM Ericsson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ericsson.bss.cassandra.ecchronos.core.impl.jmx;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.ericsson.bss.cassandra.ecchronos.core.impl.jmx.http.NotificationListenerResponse;
+import com.sun.net.httpserver.HttpServer;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.UnknownHostException;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import com.datastax.oss.driver.api.core.metadata.EndPoint;
+import com.datastax.oss.driver.api.core.metadata.Node;
+import com.ericsson.bss.cassandra.ecchronos.connection.DistributedNativeConnectionProvider;
+import com.ericsson.bss.cassandra.ecchronos.data.iptranslator.IpTranslator;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for JolokiaHttpClient response validation (Bug 1) and retry with JacksonException (Bug 2).
+ * Uses a local JDK HttpServer to simulate Jolokia responses.
+ */
+public class TestJolokiaHttpClientResponseValidation
+{
+    private HttpServer httpServer;
+    private int httpPort;
+    private JolokiaHttpClient jolokiaHttpClient;
+    private DistributedNativeConnectionProvider mockNativeProvider;
+    private final UUID nodeID = UUID.randomUUID();
+    private final String notificationID = "test-notification-1";
+
+    @Before
+    public void setup() throws IOException
+    {
+        httpServer = HttpServer.create(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), 0);
+        httpPort = httpServer.getAddress().getPort();
+
+        mockNativeProvider = mock(DistributedNativeConnectionProvider.class);
+        Node mockNode = mock(Node.class);
+        IpTranslator ipTranslator = mock(IpTranslator.class);
+
+        InetSocketAddress broadcastAddr = new InetSocketAddress(InetAddress.getLoopbackAddress(), 9042);
+        when(mockNode.getBroadcastRpcAddress()).thenReturn(Optional.of(broadcastAddr));
+        when(mockNativeProvider.getNodes()).thenReturn(Map.of(nodeID, mockNode));
+
+        jolokiaHttpClient = new JolokiaHttpClient(null, mockNativeProvider, httpPort, false, false, ipTranslator);
+
+        // Register client ID manually by simulating a register endpoint
+        httpServer.createContext("/jolokia/notification/register", exchange ->
+        {
+            String body = "{\"value\":{\"id\":\"client-1\",\"backend\":{\"pull\":{\"store\":\"myStore\"}}}}";
+            exchange.sendResponseHeaders(200, body.length());
+            try (OutputStream os = exchange.getResponseBody())
+            {
+                os.write(body.getBytes());
+            }
+        });
+
+        httpServer.start();
+
+        // Register the client
+        try
+        {
+            jolokiaHttpClient.registerClientId(nodeID);
+        }
+        catch (InterruptedException e)
+        {
+            Thread.currentThread().interrupt();
+            throw new IOException(e);
+        }
+    }
+
+    @After
+    public void teardown()
+    {
+        if (httpServer != null)
+        {
+            httpServer.stop(0);
+        }
+        if (jolokiaHttpClient != null)
+        {
+            jolokiaHttpClient.close();
+        }
+    }
+
+    @Test
+    public void testEmptyBodyThrowsIOExceptionAndRetriesExhausted()
+    {
+        httpServer.createContext("/jolokia/exec/myStore/pull/client-1/" + notificationID, exchange ->
+        {
+            exchange.sendResponseHeaders(200, 0);
+            exchange.getResponseBody().close();
+        });
+
+        assertThatThrownBy(() -> jolokiaHttpClient.checkForNotificationsWithRetry(nodeID, notificationID))
+                .isInstanceOf(IOException.class)
+                .hasMessageContaining("empty response body");
+    }
+
+    @Test
+    public void testNon200StatusThrowsIOExceptionAndRetriesExhausted()
+    {
+        httpServer.createContext("/jolokia/exec/myStore/pull/client-1/" + notificationID, exchange ->
+        {
+            String body = "Service Unavailable";
+            exchange.sendResponseHeaders(503, body.length());
+            try (OutputStream os = exchange.getResponseBody())
+            {
+                os.write(body.getBytes());
+            }
+        });
+
+        assertThatThrownBy(() -> jolokiaHttpClient.checkForNotificationsWithRetry(nodeID, notificationID))
+                .isInstanceOf(IOException.class)
+                .hasMessageContaining("HTTP status 503");
+    }
+
+    @Test
+    public void testMalformedJsonRetriesAndFails()
+    {
+        httpServer.createContext("/jolokia/exec/myStore/pull/client-1/" + notificationID, exchange ->
+        {
+            String body = "not-valid-json{{{";
+            exchange.sendResponseHeaders(200, body.length());
+            try (OutputStream os = exchange.getResponseBody())
+            {
+                os.write(body.getBytes());
+            }
+        });
+
+        assertThatThrownBy(() -> jolokiaHttpClient.checkForNotificationsWithRetry(nodeID, notificationID))
+                .isInstanceOf(IOException.class)
+                .hasMessageContaining("Failed to parse");
+    }
+
+    @Test
+    public void testValidResponseReturnsParsedObject() throws IOException, InterruptedException
+    {
+        String validJson = "{\"request\":{},\"value\":{\"notifications\":[]},\"status\":200,\"timestamp\":1234567890}";
+        httpServer.createContext("/jolokia/exec/myStore/pull/client-1/" + notificationID, exchange ->
+        {
+            exchange.sendResponseHeaders(200, validJson.length());
+            try (OutputStream os = exchange.getResponseBody())
+            {
+                os.write(validJson.getBytes());
+            }
+        });
+
+        NotificationListenerResponse response =
+                jolokiaHttpClient.checkForNotificationsWithRetry(nodeID, notificationID);
+        assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(200);
+    }
+
+    @Test
+    public void testTransientFailureThenSuccessReturnsValidResponse() throws IOException, InterruptedException
+    {
+        AtomicInteger callCount = new AtomicInteger(0);
+        String validJson = "{\"request\":{},\"value\":{\"notifications\":[]},\"status\":200,\"timestamp\":1234567890}";
+        httpServer.createContext("/jolokia/exec/myStore/pull/client-1/" + notificationID, exchange ->
+        {
+            int attempt = callCount.incrementAndGet();
+            if (attempt <= 2)
+            {
+                // First 2 attempts return empty body
+                exchange.sendResponseHeaders(200, 0);
+                exchange.getResponseBody().close();
+            }
+            else
+            {
+                // Third attempt returns valid response
+                exchange.sendResponseHeaders(200, validJson.length());
+                try (OutputStream os = exchange.getResponseBody())
+                {
+                    os.write(validJson.getBytes());
+                }
+            }
+        });
+
+        NotificationListenerResponse response =
+                jolokiaHttpClient.checkForNotificationsWithRetry(nodeID, notificationID);
+        assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThat(callCount.get()).isEqualTo(3);
+    }
+
+    @Test
+    public void testBlankBodyThrowsIOException()
+    {
+        httpServer.createContext("/jolokia/exec/myStore/pull/client-1/" + notificationID, exchange ->
+        {
+            String body = "   ";
+            exchange.sendResponseHeaders(200, body.length());
+            try (OutputStream os = exchange.getResponseBody())
+            {
+                os.write(body.getBytes());
+            }
+        });
+
+        assertThatThrownBy(() -> jolokiaHttpClient.checkForNotificationsWithRetry(nodeID, notificationID))
+                .isInstanceOf(IOException.class)
+                .hasMessageContaining("empty response body");
+    }
+}

--- a/core.impl/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/impl/jmx/TestJolokiaNotificationControllerUnavailableCallback.java
+++ b/core.impl/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/impl/jmx/TestJolokiaNotificationControllerUnavailableCallback.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright 2026 Telefonaktiebolaget LM Ericsson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ericsson.bss.cassandra.ecchronos.core.impl.jmx;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.ericsson.bss.cassandra.ecchronos.connection.DistributedNativeConnectionProvider;
+import com.ericsson.bss.cassandra.ecchronos.data.iptranslator.IpTranslator;
+import com.sun.net.httpserver.HttpServer;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.TimeUnit;
+
+import com.datastax.oss.driver.api.core.metadata.Node;
+
+import org.awaitility.Awaitility;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.management.Notification;
+import javax.management.NotificationListener;
+
+/**
+ * Tests that the nodeUnavailableCallback is invoked after consecutive
+ * Jolokia notification polling failures.
+ */
+public class TestJolokiaNotificationControllerUnavailableCallback
+{
+    private HttpServer httpServer;
+    private JolokiaNotificationController controller;
+    private final UUID nodeID = UUID.randomUUID();
+    private final CopyOnWriteArrayList<UUID> unavailableNodes = new CopyOnWriteArrayList<>();
+    private final CopyOnWriteArrayList<Notification> receivedNotifications = new CopyOnWriteArrayList<>();
+
+    @Before
+    public void setup() throws IOException, InterruptedException
+    {
+        httpServer = HttpServer.create(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), 0);
+        int httpPort = httpServer.getAddress().getPort();
+
+        DistributedNativeConnectionProvider mockNativeProvider = mock(DistributedNativeConnectionProvider.class);
+        Node mockNode = mock(Node.class);
+        IpTranslator ipTranslator = mock(IpTranslator.class);
+
+        InetSocketAddress broadcastAddr = new InetSocketAddress(InetAddress.getLoopbackAddress(), 9042);
+        when(mockNode.getBroadcastRpcAddress()).thenReturn(Optional.of(broadcastAddr));
+        when(mockNativeProvider.getNodes()).thenReturn(Map.of(nodeID, mockNode));
+
+        // Register client endpoint
+        httpServer.createContext("/jolokia/notification/register", exchange ->
+        {
+            String body = "{\"value\":{\"id\":\"client-1\",\"backend\":{\"pull\":{\"store\":\"myStore\"}}}}";
+            exchange.sendResponseHeaders(200, body.length());
+            try (OutputStream os = exchange.getResponseBody())
+            {
+                os.write(body.getBytes());
+            }
+        });
+
+        // Notification registration endpoint
+        httpServer.createContext("/jolokia/notification", exchange ->
+        {
+            String body = "{\"value\":\"notif-1\"}";
+            exchange.sendResponseHeaders(200, body.length());
+            try (OutputStream os = exchange.getResponseBody())
+            {
+                os.write(body.getBytes());
+            }
+        });
+
+        // Notification polling endpoint — always returns empty body to trigger failures
+        httpServer.createContext("/jolokia/exec/myStore/pull/client-1/notif-1", exchange ->
+        {
+            exchange.sendResponseHeaders(200, 0);
+            exchange.getResponseBody().close();
+        });
+
+        httpServer.start();
+
+        controller = JolokiaNotificationController.newBuilder()
+                .withNativeConnection(mockNativeProvider)
+                .withJolokiaPort(httpPort)
+                .withJolokiaPEM(false)
+                .withReverseDNSResolution(false)
+                .withRunDelay(100)
+                .withIpTranslator(ipTranslator)
+                .withNodeUnavailableCallback(unavailableNodes::add)
+                .build();
+    }
+
+    @After
+    public void teardown()
+    {
+        if (controller != null)
+        {
+            controller.close();
+        }
+        if (httpServer != null)
+        {
+            httpServer.stop(0);
+        }
+    }
+
+    @Test
+    public void testCallbackInvokedAfterConsecutiveFailures() throws IOException, InterruptedException
+    {
+        NotificationListener listener = (notification, handback) -> receivedNotifications.add(notification);
+
+        controller.addStorageServiceListener(nodeID, listener);
+
+        // The poller runs every 100ms and the endpoint always returns empty body.
+        // After 5 consecutive failures (MAX_CONSECUTIVE_FAILURES), the callback should fire.
+        Awaitility.await()
+                .atMost(10, TimeUnit.SECONDS)
+                .untilAsserted(() -> assertThat(unavailableNodes).contains(nodeID));
+    }
+
+    @Test
+    public void testConnectionFailedNotificationSentToListener() throws IOException, InterruptedException
+    {
+        NotificationListener listener = (notification, handback) -> receivedNotifications.add(notification);
+
+        controller.addStorageServiceListener(nodeID, listener);
+
+        // Verify the listener receives a jmx.remote.connection.failed notification
+        Awaitility.await()
+                .atMost(10, TimeUnit.SECONDS)
+                .untilAsserted(() ->
+                {
+                    assertThat(receivedNotifications)
+                            .anyMatch(n -> "jmx.remote.connection.failed".equals(n.getType()));
+                });
+    }
+
+    @Test
+    public void testNoCallbackWhenNotConfigured() throws IOException, InterruptedException
+    {
+        // Build a controller without a callback
+        DistributedNativeConnectionProvider mockNativeProvider = mock(DistributedNativeConnectionProvider.class);
+        Node mockNode = mock(Node.class);
+        IpTranslator ipTranslator = mock(IpTranslator.class);
+        InetSocketAddress broadcastAddr = new InetSocketAddress(InetAddress.getLoopbackAddress(), 9042);
+        when(mockNode.getBroadcastRpcAddress()).thenReturn(Optional.of(broadcastAddr));
+        when(mockNativeProvider.getNodes()).thenReturn(Map.of(nodeID, mockNode));
+
+        JolokiaNotificationController controllerNoCallback = JolokiaNotificationController.newBuilder()
+                .withNativeConnection(mockNativeProvider)
+                .withJolokiaPort(httpServer.getAddress().getPort())
+                .withJolokiaPEM(false)
+                .withReverseDNSResolution(false)
+                .withRunDelay(100)
+                .withIpTranslator(ipTranslator)
+                .build();
+
+        try
+        {
+            NotificationListener listener = (notification, handback) -> receivedNotifications.add(notification);
+            controllerNoCallback.addStorageServiceListener(nodeID, listener);
+
+            // Wait for failure notification to be sent (proves failures happened)
+            Awaitility.await()
+                    .atMost(10, TimeUnit.SECONDS)
+                    .untilAsserted(() ->
+                    {
+                        assertThat(receivedNotifications)
+                                .anyMatch(n -> "jmx.remote.connection.failed".equals(n.getType()));
+                    });
+
+            // No callback was configured, so unavailableNodes should remain empty
+            assertThat(unavailableNodes).isEmpty();
+        }
+        finally
+        {
+            controllerNoCallback.close();
+        }
+    }
+}

--- a/core.impl/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/incremental/TestIncrementalRepairJob.java
+++ b/core.impl/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/incremental/TestIncrementalRepairJob.java
@@ -296,7 +296,8 @@ public class TestIncrementalRepairJob
     @Test
     public void testEqualsAndHashcode()
     {
-        EqualsVerifier.simple().forClass(IncrementalRepairJob.class).withRedefinedSuperclass().verify();
+        EqualsVerifier.simple().forClass(IncrementalRepairJob.class).withRedefinedSuperclass()
+                .withIgnoredFields("myFailed").verify();
     }
 
     private IncrementalRepairJob getIncrementalRepairJob()

--- a/core.impl/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/scheduler/TestScheduleManagerConsecutiveFailures.java
+++ b/core.impl/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/scheduler/TestScheduleManagerConsecutiveFailures.java
@@ -1,0 +1,295 @@
+/*
+ * Copyright 2026 Telefonaktiebolaget LM Ericsson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ericsson.bss.cassandra.ecchronos.core.impl.repair.scheduler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+import com.datastax.oss.driver.api.core.metadata.Node;
+import com.ericsson.bss.cassandra.ecchronos.connection.DistributedNativeConnectionProvider;
+import com.ericsson.bss.cassandra.ecchronos.core.impl.locks.CASLockFactory;
+import com.ericsson.bss.cassandra.ecchronos.core.impl.locks.DummyLock;
+import com.ericsson.bss.cassandra.ecchronos.core.repair.scheduler.ScheduledJob;
+import com.ericsson.bss.cassandra.ecchronos.core.repair.scheduler.ScheduledTask;
+import com.ericsson.bss.cassandra.ecchronos.utils.exceptions.LockException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.Silent.class)
+public class TestScheduleManagerConsecutiveFailures
+{
+    @Mock
+    private CASLockFactory myLockFactory;
+    @Mock
+    private DistributedNativeConnectionProvider myNativeConnectionProvider;
+    @Mock
+    private Node node1;
+
+    private final UUID nodeID1 = UUID.randomUUID();
+    private final Collection<UUID> myNodes = Collections.singletonList(nodeID1);
+
+    private ScheduleManagerImpl myScheduler;
+
+    @Before
+    public void startup() throws LockException
+    {
+        Map<UUID, Node> nodeMap = Map.of(nodeID1, node1);
+        when(myNativeConnectionProvider.getNodes()).thenReturn(nodeMap);
+        when(myLockFactory.tryLock(any(), anyString(), anyInt(), anyMap(), any()))
+                .thenReturn(new DummyLock());
+        myScheduler = ScheduleManagerImpl.builder()
+                .withNodeIDList(myNodes)
+                .withNativeConnectionProvider(myNativeConnectionProvider)
+                .withLockFactory(myLockFactory)
+                .withSessionWindow(5, TimeUnit.MINUTES)
+                .build();
+        myScheduler.createScheduleFutureForNodeIDList(myNodes);
+    }
+
+    @After
+    public void cleanup()
+    {
+        if (myScheduler != null)
+        {
+            myScheduler.close();
+        }
+    }
+
+    @Test
+    public void testJobMarkedFailedAfterConsecutiveTaskFailures()
+    {
+        // A job whose tasks always fail
+        FailingJob job = new FailingJob(nodeID1, ScheduleManagerImpl.MAX_CONSECUTIVE_TASK_FAILURES);
+        myScheduler.schedule(nodeID1, job);
+
+        myScheduler.run(nodeID1);
+
+        assertThat(job.getState()).isEqualTo(ScheduledJob.State.FAILED);
+    }
+
+    @Test
+    public void testJobNotMarkedFailedBelowThreshold()
+    {
+        // A job with fewer failing tasks than the threshold
+        FailingJob job = new FailingJob(nodeID1, ScheduleManagerImpl.MAX_CONSECUTIVE_TASK_FAILURES - 1);
+        myScheduler.schedule(nodeID1, job);
+
+        myScheduler.run(nodeID1);
+
+        assertThat(job.getState()).isNotEqualTo(ScheduledJob.State.FAILED);
+    }
+
+    @Test
+    public void testSuccessfulTaskResetsFailureCounter()
+    {
+        // A job with 4 failures, then 1 success, then 4 more failures (total 9 tasks, never hits 5 consecutive)
+        MixedJob job = new MixedJob(nodeID1, new boolean[]{
+                false, false, false, false, // 4 failures
+                true,                        // 1 success (resets counter)
+                false, false, false, false   // 4 more failures
+        });
+        myScheduler.schedule(nodeID1, job);
+
+        myScheduler.run(nodeID1);
+
+        // Job should NOT be marked failed because the success in the middle reset the counter
+        assertThat(job.getState()).isNotEqualTo(ScheduledJob.State.FAILED);
+    }
+
+    @Test
+    public void testJobMarkedFailedAfterSuccessAndThenConsecutiveFailures()
+    {
+        // A job with 1 success, then enough consecutive failures to hit the threshold
+        boolean[] results = new boolean[1 + ScheduleManagerImpl.MAX_CONSECUTIVE_TASK_FAILURES];
+        results[0] = true;
+        for (int i = 1; i < results.length; i++)
+        {
+            results[i] = false;
+        }
+        MixedJob job = new MixedJob(nodeID1, results);
+        myScheduler.schedule(nodeID1, job);
+
+        myScheduler.run(nodeID1);
+
+        assertThat(job.getState()).isEqualTo(ScheduledJob.State.FAILED);
+    }
+
+    @Test
+    public void testFailedJobIsPurgedFromQueue()
+    {
+        FailingJob job = new FailingJob(nodeID1, ScheduleManagerImpl.MAX_CONSECUTIVE_TASK_FAILURES);
+        myScheduler.schedule(nodeID1, job);
+
+        myScheduler.run(nodeID1);
+        assertThat(job.getState()).isEqualTo(ScheduledJob.State.FAILED);
+
+        // Run again — the queue iterator should purge the FAILED job
+        myScheduler.run(nodeID1);
+        assertThat(myScheduler.getQueueSize(nodeID1)).isEqualTo(0);
+    }
+
+    @Test
+    public void testFailureCounterClearedOnDeschedule()
+    {
+        // A job that partially fails (below threshold)
+        FailingJob job = new FailingJob(nodeID1, 2);
+        myScheduler.schedule(nodeID1, job);
+
+        myScheduler.run(nodeID1);
+        assertThat(job.getState()).isNotEqualTo(ScheduledJob.State.FAILED);
+
+        // Deschedule and reschedule — counter should be reset
+        myScheduler.deschedule(nodeID1, job);
+
+        // New job with same pattern — should start with fresh counter
+        FailingJob job2 = new FailingJob(nodeID1, 2);
+        myScheduler.schedule(nodeID1, job2);
+        myScheduler.run(nodeID1);
+        assertThat(job2.getState()).isNotEqualTo(ScheduledJob.State.FAILED);
+    }
+
+    // --- ScheduledJob.markFailed() unit tests ---
+
+    @Test
+    public void testMarkFailedChangesState()
+    {
+        FailingJob job = new FailingJob(nodeID1, 1);
+        assertThat(job.getState()).isNotEqualTo(ScheduledJob.State.FAILED);
+
+        job.markFailed();
+
+        assertThat(job.getState()).isEqualTo(ScheduledJob.State.FAILED);
+    }
+
+    @Test
+    public void testMarkFailedMakesJobNotRunnable()
+    {
+        FailingJob job = new FailingJob(nodeID1, 1);
+        // Job should be runnable initially (configured with 1ms run interval)
+        assertThat(job.runnable()).isTrue();
+
+        job.markFailed();
+
+        assertThat(job.runnable()).isFalse();
+    }
+
+    // --- Test helpers ---
+
+    private static class FailingJob extends ScheduledJob
+    {
+        private final int myNumTasks;
+        private final AtomicInteger myTaskRuns = new AtomicInteger(0);
+
+        FailingJob(final UUID nodeId, final int numTasks)
+        {
+            super(new ConfigurationBuilder()
+                    .withPriority(Priority.LOW)
+                    .withRunInterval(1, TimeUnit.MILLISECONDS)
+                    .build(), nodeId);
+            myNumTasks = numTasks;
+        }
+
+        int getTaskRuns()
+        {
+            return myTaskRuns.get();
+        }
+
+        @Override
+        public Iterator<ScheduledTask> iterator()
+        {
+            List<ScheduledTask> tasks = new ArrayList<>();
+            for (int i = 0; i < myNumTasks; i++)
+            {
+                tasks.add(new FailingTask(myTaskRuns));
+            }
+            return tasks.iterator();
+        }
+    }
+
+    private static class FailingTask extends ScheduledTask
+    {
+        private final AtomicInteger myRunCounter;
+
+        FailingTask(final AtomicInteger runCounter)
+        {
+            myRunCounter = runCounter;
+        }
+
+        @Override
+        public boolean execute(final UUID nodeID)
+        {
+            myRunCounter.incrementAndGet();
+            return false;
+        }
+    }
+
+    private static class MixedJob extends ScheduledJob
+    {
+        private final boolean[] myResults;
+
+        MixedJob(final UUID nodeId, final boolean[] results)
+        {
+            super(new ConfigurationBuilder()
+                    .withPriority(Priority.LOW)
+                    .withRunInterval(1, TimeUnit.MILLISECONDS)
+                    .build(), nodeId);
+            myResults = results;
+        }
+
+        @Override
+        public Iterator<ScheduledTask> iterator()
+        {
+            List<ScheduledTask> tasks = new ArrayList<>();
+            for (boolean result : myResults)
+            {
+                tasks.add(new ConfigurableTask(result));
+            }
+            return tasks.iterator();
+        }
+    }
+
+    private static class ConfigurableTask extends ScheduledTask
+    {
+        private final boolean myResult;
+
+        ConfigurableTask(final boolean result)
+        {
+            myResult = result;
+        }
+
+        @Override
+        public boolean execute(final UUID nodeID)
+        {
+            return myResult;
+        }
+    }
+}

--- a/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/repair/scheduler/ScheduledJob.java
+++ b/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/repair/scheduler/ScheduledJob.java
@@ -35,7 +35,7 @@ public abstract class ScheduledJob implements Iterable<ScheduledTask>
     protected volatile long myLastSuccessfulRun = -1L;
     private volatile long myNextRunTimeInMs = -1L;
     private volatile long myRunOffset = 0;
-    private transient volatile boolean myFailed = false;
+    private volatile boolean myFailed = false;
     private final UUID myNodeID;
     private final UUID myJobID;
     private final TimeUnit myPriorityGranularity;

--- a/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/repair/scheduler/ScheduledJob.java
+++ b/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/repair/scheduler/ScheduledJob.java
@@ -35,6 +35,7 @@ public abstract class ScheduledJob implements Iterable<ScheduledTask>
     protected volatile long myLastSuccessfulRun = -1L;
     private volatile long myNextRunTimeInMs = -1L;
     private volatile long myRunOffset = 0;
+    private transient volatile boolean myFailed = false;
     private final UUID myNodeID;
     private final UUID myJobID;
     private final TimeUnit myPriorityGranularity;
@@ -121,13 +122,24 @@ public abstract class ScheduledJob implements Iterable<ScheduledTask>
     }
 
     /**
+     * Mark this job as permanently failed.
+     * <p>
+     * Once marked, {@link #getState()} will return {@link State#FAILED}
+     * and the job will be descheduled by the queue on the next iteration.
+     */
+    public void markFailed()
+    {
+        myFailed = true;
+    }
+
+    /**
      * Check if this job is runnable now.
      *
      * @return True if able to run now.
      */
     public boolean runnable()
     {
-        return myNextRunTimeInMs <= System.currentTimeMillis() && getRealPriority() > -1;
+        return !myFailed && myNextRunTimeInMs <= System.currentTimeMillis() && getRealPriority() > -1;
     }
 
     /**
@@ -137,6 +149,10 @@ public abstract class ScheduledJob implements Iterable<ScheduledTask>
      */
     public State getState()
     {
+        if (myFailed)
+        {
+            return State.FAILED;
+        }
         if (runnable())
         {
             return State.RUNNABLE;


### PR DESCRIPTION
- Validate HTTP status and non-blank response body in JolokiaHttpClient.checkForNotifications(), throwing IOException so existing retry logic handles transient network issues
- Move JSON deserialization into checkForNotificationsWithRetry() retry loop so JacksonException from malformed responses triggers retries instead of bypassing them
- Track consecutive task execution failures per job in ScheduleManagerImpl; after 5 consecutive failures, mark the job as FAILED via new ScheduledJob.markFailed() so it gets purged from the queue instead of looping indefinitely as ON_TIME
- Reset notification failure counters in JolokiaNotificationController when a new repair listener is registered, preventing stale counts from a previous network blip carrying over