### PR TITLE
fix: reuse repair state across replicas

### DIFF
--- a/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/vnode/VnodeRepairStateFactoryImpl.java
+++ b/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/vnode/VnodeRepairStateFactoryImpl.java
@@ -109,23 +109,39 @@ public class VnodeRepairStateFactoryImpl implements VnodeRepairStateFactory
                 = myReplicationState.getTokenRangeToReplicas(tableReference, node);
         long lastRepairedAt = previousLastRepairedAt(previous, tokenRangeToReplicaMap);
 
-        Iterator<RepairEntry> repairEntryIterator;
+        Set<DriverNode> replicaNodes = new HashSet<>();
+        tokenRangeToReplicaMap.values().forEach(replicaNodes::addAll);
 
-        if (lastRepairedAt == VnodeRepairState.UNREPAIRED)
+        List<RepairEntry> repairEntries = new ArrayList<>();
+
+        for (DriverNode replicaNode : replicaNodes)
         {
-            LOG.debug("No last repaired at found for {}, iterating over all repair entries", tableReference);
-            repairEntryIterator = myRepairHistoryProvider.iterate(node, tableReference, iterateToTime,
-                    (repairEntry) -> acceptRepairEntries(repairEntry, tokenRangeToReplicaMap));
-        }
-        else
-        {
-            LOG.debug("Table {} snapshot created at {}, iterating repair entries until that time", tableReference,
-                    previous.getCreatedAt());
-            repairEntryIterator = myRepairHistoryProvider.iterate(node, tableReference, iterateToTime,
-                    previous.getCreatedAt(), (repairEntry) -> acceptRepairEntries(repairEntry, tokenRangeToReplicaMap));
+            Iterator<RepairEntry> repairEntryIterator;
+
+            if (lastRepairedAt == VnodeRepairState.UNREPAIRED)
+            {
+                LOG.debug("No last repaired at found for {}, iterating over all repair entries", tableReference);
+                repairEntryIterator = myRepairHistoryProvider.iterate(replicaNode.getNode(), tableReference,
+                        iterateToTime,
+                        (repairEntry) -> acceptRepairEntries(repairEntry, tokenRangeToReplicaMap));
+            }
+            else
+            {
+                LOG.debug("Table {} snapshot created at {}, iterating repair entries until that time", tableReference,
+                        previous.getCreatedAt());
+                repairEntryIterator = myRepairHistoryProvider.iterate(replicaNode.getNode(), tableReference,
+                        iterateToTime, previous.getCreatedAt(),
+                        (repairEntry) -> acceptRepairEntries(repairEntry, tokenRangeToReplicaMap));
+            }
+
+            while (repairEntryIterator.hasNext())
+            {
+                repairEntries.add(repairEntryIterator.next());
+            }
         }
 
-        return generateVnodeRepairStates(lastRepairedAt, previous, repairEntryIterator, tokenRangeToReplicaMap);
+        return generateVnodeRepairStates(lastRepairedAt, previous, repairEntries.iterator(),
+                tokenRangeToReplicaMap);
     }
 
     /**

--- a/core.impl/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/vnode/TestVnodeRepairStateFactoryImpl.java
+++ b/core.impl/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/vnode/TestVnodeRepairStateFactoryImpl.java
@@ -177,6 +177,61 @@ public class TestVnodeRepairStateFactoryImpl
     }
 
     @Test
+    public void testCalculateNewStateRecognizesRepairPerformedByAnotherReplica()
+            throws UnknownHostException
+    {
+        Node nodeA = mock(Node.class);
+        Node nodeB = mock(Node.class);
+
+        DriverNode driverNodeA = withNode("127.0.0.1");
+        DriverNode driverNodeB = withNode("127.0.0.2");
+
+        when(driverNodeA.getNode()).thenReturn(nodeA);
+        when(driverNodeB.getNode()).thenReturn(nodeB);
+
+        LongTokenRange tokenRange = range(1, 2);
+        ImmutableSet<DriverNode> replicas = ImmutableSet.of(driverNodeA, driverNodeB);
+
+        withRange(tokenRange, driverNodeA, driverNodeB);
+
+        when(mockReplicationState.getTokenRangeToReplicas(
+                eq(TABLE_REFERENCE), eq(nodeB))).thenReturn(tokenToNodeMap);
+
+        long startedAt = 1234L;
+        long finishedAt = 1235L;
+
+        RepairEntry successfulRepair =
+                new RepairEntry(tokenRange, startedAt, finishedAt, replicas, "SUCCESS");
+
+        Map<Node, List<RepairEntry>> historyByNode = new HashMap<>();
+        historyByNode.put(nodeA, Collections.singletonList(successfulRepair));
+        historyByNode.put(nodeB, Collections.emptyList());
+
+        RepairHistoryProvider nodeScopedHistory =
+                new NodeScopedRepairHistoryProvider(TABLE_REFERENCE, historyByNode);
+
+        VnodeRepairStateFactory factory =
+                new VnodeRepairStateFactoryImpl(
+                        mockReplicationState,
+                        nodeScopedHistory,
+                        false);
+
+        VnodeRepairStates states =
+                factory.calculateNewState(
+                        nodeB,
+                        TABLE_REFERENCE,
+                        null,
+                        finishedAt);
+
+        assertThat(states.getVnodeRepairStates())
+                .containsOnly(new VnodeRepairState(
+                        tokenRange,
+                        replicas,
+                        startedAt,
+                        finishedAt));
+    }
+
+    @Test
     public void testCalculateClusterWideStateWithHistoryIsRepaired() throws UnknownHostException
     {
         DriverNode node1 = withNode("127.0.0.1");
@@ -617,6 +672,7 @@ public class TestVnodeRepairStateFactoryImpl
         DriverNode node = mock(DriverNode.class);
         InetAddress nodeAddress = InetAddress.getByName(inetAddress);
         when(node.getPublicAddress()).thenReturn(nodeAddress);
+        when(node.getNode()).thenReturn(myMockNode);
         return node;
     }
 
@@ -729,6 +785,53 @@ public class TestVnodeRepairStateFactoryImpl
 
         Collection<VnodeRepairState> vnodeRepairStates = newStates.getVnodeRepairStates();
         assertThat(vnodeRepairStates).containsOnlyElementsOf(expectedStates);
+    }
+
+    private static class NodeScopedRepairHistoryProvider implements RepairHistoryProvider
+    {
+        private final TableReference myTableReference;
+        private final Map<Node, List<RepairEntry>> myHistoryByNode;
+
+        NodeScopedRepairHistoryProvider(
+                TableReference tableReference,
+                Map<Node, List<RepairEntry>> historyByNode)
+        {
+            myTableReference = tableReference;
+            myHistoryByNode = historyByNode;
+        }
+
+        @Override
+        public Iterator<RepairEntry> iterate(
+                Node node,
+                TableReference tableReference,
+                long to,
+                Predicate<RepairEntry> predicate)
+        {
+            assertThat(tableReference).isEqualTo(myTableReference);
+
+            return new MockedRepairEntryIterator(
+                    myHistoryByNode.getOrDefault(node, Collections.emptyList()).iterator(),
+                    predicate,
+                    to,
+                    -1L);
+        }
+
+        @Override
+        public Iterator<RepairEntry> iterate(
+                Node node,
+                TableReference tableReference,
+                long to,
+                long from,
+                Predicate<RepairEntry> predicate)
+        {
+            assertThat(tableReference).isEqualTo(myTableReference);
+
+            return new MockedRepairEntryIterator(
+                    myHistoryByNode.getOrDefault(node, Collections.emptyList()).iterator(),
+                    predicate,
+                    to,
+                    from);
+        }
     }
 
     private class MockedRepairHistoryProvider implements RepairHistoryProvider


### PR DESCRIPTION
Fixes #1089 

Repair state was rebuilt using history from only the node currently being evaluated.

That means a successful repair recorded through another replica could be missed, so the same token range could appear unrepaired and be scheduled again.

This updates `calculateNewState()` to read repair history from the replica nodes for the relevant ranges before rebuilding vnode state.

I also added a regression test covering the case where the repair is recorded for one replica and state is calculated for another.

Testing:
- `TestVnodeRepairStateFactoryImpl`: 19/19 passed
- `mvn -pl core.impl -am test` progressed through the reactor, but the `data-agent` Testcontainers tests could not run locally because Docker was not available