### PR TITLE
Use active liveness probe in JMX connection health check

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 * Upgrade ecChronos to Spring Boot 4 - Issue #1711
 * Add JSON output format for ecctool state - Issue #1739
 * Fix repair jobs stuck ON_TIME when Jolokia returns empty body due to transient network issues - Issue #1740
+* Fix Jolokia JMX connection health check always returning true for stale connections - Issue #1764
 
 ## Version 1.0.6
 

--- a/connection.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/connection/impl/providers/DistributedJmxConnectionProviderImpl.java
+++ b/connection.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/connection/impl/providers/DistributedJmxConnectionProviderImpl.java
@@ -71,8 +71,15 @@ public class DistributedJmxConnectionProviderImpl implements DistributedJmxConne
         try
         {
             jmxConnector.getConnectionId();
-            // Additional check for MBeanServerConnection availability
-            return jmxConnector.getMBeanServerConnection() != null;
+            javax.management.MBeanServerConnection mbs = jmxConnector.getMBeanServerConnection();
+            if (mbs == null)
+            {
+                return false;
+            }
+            // Active liveness probe: getMBeanCount() triggers an actual network call
+            // for both Jolokia (HTTP) and RMI, verifying the endpoint is reachable.
+            mbs.getMBeanCount();
+            return true;
         }
         catch (IOException | NullPointerException e)
         {

--- a/connection.impl/src/test/java/com/ericsson/bss/cassandra/ecchronos/connection/impl/providers/TestDistributedJmxConnectionProviderIsConnected.java
+++ b/connection.impl/src/test/java/com/ericsson/bss/cassandra/ecchronos/connection/impl/providers/TestDistributedJmxConnectionProviderIsConnected.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2026 Telefonaktiebolaget LM Ericsson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ericsson.bss.cassandra.ecchronos.connection.impl.providers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+
+import javax.management.MBeanServerConnection;
+import javax.management.remote.JMXConnector;
+
+import org.junit.Test;
+
+/**
+ * Tests for {@link DistributedJmxConnectionProviderImpl#isConnected(JMXConnector)}.
+ * Verifies the active liveness probe using getMBeanCount().
+ */
+public class TestDistributedJmxConnectionProviderIsConnected
+{
+    private final DistributedJmxConnectionProviderImpl provider =
+            new DistributedJmxConnectionProviderImpl(
+                    DistributedJmxConnectionProviderImpl.builder());
+
+    @Test
+    public void testNullConnectorReturnsFalse()
+    {
+        assertThat(provider.isConnected((JMXConnector) null)).isFalse();
+    }
+
+    @Test
+    public void testHealthyConnectionReturnsTrue() throws IOException
+    {
+        JMXConnector connector = mock(JMXConnector.class);
+        MBeanServerConnection mbs = mock(MBeanServerConnection.class);
+        when(connector.getConnectionId()).thenReturn("test-connection-id");
+        when(connector.getMBeanServerConnection()).thenReturn(mbs);
+        when(mbs.getMBeanCount()).thenReturn(42);
+
+        assertThat(provider.isConnected(connector)).isTrue();
+    }
+
+    @Test
+    public void testNullMBeanServerConnectionReturnsFalse() throws IOException
+    {
+        JMXConnector connector = mock(JMXConnector.class);
+        when(connector.getConnectionId()).thenReturn("test-connection-id");
+        when(connector.getMBeanServerConnection()).thenReturn(null);
+
+        assertThat(provider.isConnected(connector)).isFalse();
+    }
+
+    @Test
+    public void testGetConnectionIdThrowsReturnsFalse() throws IOException
+    {
+        JMXConnector connector = mock(JMXConnector.class);
+        when(connector.getConnectionId()).thenThrow(new IOException("connection lost"));
+
+        assertThat(provider.isConnected(connector)).isFalse();
+    }
+
+    @Test
+    public void testGetMBeanCountThrowsIOExceptionReturnsFalse() throws IOException
+    {
+        JMXConnector connector = mock(JMXConnector.class);
+        MBeanServerConnection mbs = mock(MBeanServerConnection.class);
+        when(connector.getConnectionId()).thenReturn("test-connection-id");
+        when(connector.getMBeanServerConnection()).thenReturn(mbs);
+        when(mbs.getMBeanCount()).thenThrow(new IOException("Jolokia endpoint unreachable"));
+
+        assertThat(provider.isConnected(connector)).isFalse();
+    }
+
+    @Test
+    public void testGetMBeanServerConnectionThrowsReturnsFalse() throws IOException
+    {
+        JMXConnector connector = mock(JMXConnector.class);
+        when(connector.getConnectionId()).thenReturn("test-connection-id");
+        when(connector.getMBeanServerConnection()).thenThrow(new IOException("stale connection"));
+
+        assertThat(provider.isConnected(connector)).isFalse();
+    }
+}


### PR DESCRIPTION
Replace the passive isConnected check (getConnectionId + getMBeanServerConnection != null) with an active probe using getMBeanCount(). The previous check always returned true for Jolokia connectors because both getConnectionId() and getMBeanServerConnection() return cached local state without making a network call.

getMBeanCount() triggers an actual HTTP request for Jolokia and a real RMI call for standard JMX, so stale connections are now properly detected. This allows RetrySchedulerService to correctly identify unreachable nodes and attempt reconnection.