### PR TITLE
feat(ecctool): add cluster-wide status command

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 
 * Upgrade ecChronos to Spring Boot 4 - Issue #1711
 * Add JSON output format for ecctool state - Issue #1739
+* Add cluster-wide ecctool status command backed by nodes_sync - Issue #680
 * Fix repair jobs stuck ON_TIME when Jolokia returns empty body due to transient network issues - Issue #1740
 
 ## Version 1.0.6

--- a/data/src/main/java/com/ericsson/bss/cassandra/ecchronos/data/sync/EccNodesSync.java
+++ b/data/src/main/java/com/ericsson/bss/cassandra/ecchronos/data/sync/EccNodesSync.java
@@ -73,6 +73,7 @@ public final class EccNodesSync
 
     private final PreparedStatement myGetByEccInstanceStatement;
     private final PreparedStatement myGetByEccInstanceAndDCStatement;
+    private final PreparedStatement myGetAllStatement;
     private final Long connectionDelayValue;
     private final ChronoUnit connectionDelayUnit;
 
@@ -125,6 +126,10 @@ public final class EccNodesSync
                 .build()
                 .setConsistencyLevel(ConsistencyLevel.LOCAL_QUORUM));
 
+        myGetAllStatement = mySession.prepare(selectFrom(KEYSPACE_NAME, TABLE_NAME).all()
+                .build()
+                .setConsistencyLevel(ConsistencyLevel.LOCAL_QUORUM));
+
         ecChronosID = builder.myEcchronosID;
 
         connectionDelayValue = builder.myConnectionDelayValue;
@@ -164,6 +169,16 @@ public final class EccNodesSync
     {
         BoundStatement boundStatement = myGetByEccInstanceAndDCStatement.bind(ecChronosID, dcName);
         return mySession.execute(boundStatement);
+    }
+
+    /**
+     * Gets all records from the nodes_sync table across all ecChronos instances.
+     *
+     * @return the result set containing all node records.
+     */
+    public ResultSet getAll()
+    {
+        return mySession.execute(myGetAllStatement.bind());
     }
 
     /**

--- a/data/src/test/java/com/ericsson/bss/cassandra/ecchronos/data/sync/TestEccNodesSync.java
+++ b/data/src/test/java/com/ericsson/bss/cassandra/ecchronos/data/sync/TestEccNodesSync.java
@@ -180,4 +180,36 @@ public class TestEccNodesSync extends AbstractCassandraTest
         ResultSet resultSet = eccNodesSync.getResultSet();
         assertNotNull(resultSet);
     }
+
+    @Test
+    public void testGetAllReturnsNodesFromAllInstances() throws UnknownHostException
+    {
+        UUID nodeId1 = UUID.randomUUID();
+        UUID nodeId2 = UUID.randomUUID();
+        eccNodesSync.verifyInsertNodeInfo(
+                datacenterName,
+                "127.0.0.1",
+                NodeStatus.AVAILABLE.name(),
+                Instant.now(),
+                Instant.now().plus(30, ChronoUnit.MINUTES),
+                nodeId1);
+
+        EccNodesSync otherInstance = EccNodesSync.newBuilder()
+                .withSession(mySession)
+                .withNativeConnection(nativeConnectionProvider)
+                .withConnectionDelayValue(Long.valueOf(10))
+                .withConnectionDelayUnit(TimeUnit.MINUTES)
+                .withEcchronosID("ecchronos-other")
+                .build();
+        otherInstance.verifyInsertNodeInfo(
+                datacenterName,
+                "127.0.0.2",
+                NodeStatus.UNAVAILABLE.name(),
+                Instant.now(),
+                Instant.now().plus(30, ChronoUnit.MINUTES),
+                nodeId2);
+
+        ResultSet resultSet = eccNodesSync.getAll();
+        assertEquals(2, resultSet.all().size());
+    }
 }

--- a/docs/ECCTOOL_EXAMPLES.md
+++ b/docs/ECCTOOL_EXAMPLES.md
@@ -424,19 +424,51 @@ ecctool state -o json nodes
 
 ## status
 
-The *status* command display whether ecChronos is running or not.
+The *status* command displays a cluster-wide view of Cassandra nodes registered in `nodes_sync` across all ecChronos instances. Each row shows which ecChronos instance (`ecchronos_id`) manages a node and the recorded node connectivity status. This reflects persisted registry data and JMX connectivity status; it does not prove that an ecChronos instance is currently alive, and rows may remain after an instance stops.
 
 ```cmd
 ecctool status
 ```
 ```text
-ecChronos is running.
+| EcchronosID | Datacenter | NodeID | Last Connection | Next Connection | Endpoint | Node Status |
+| ecc-1       | datacenter1| ...    | ...             | ...             | ...      | AVAILABLE   |
 ```
 
 With JSON output format selected:
 
 ```cmd
 ecctool status --output json
+```
+```json
+{
+    "timestamp": "2025-12-16 11:57:11",
+    "nodes": [
+        {
+            "ecchronos_id": "ecc-1",
+            "datacenter_name": "datacenter1",
+            "node_id": "8a9d2a57-1388-42be-aab6-06a4e5f6fe84",
+            "last_connection": "2025-12-15T15:49:41.762Z",
+            "next_connection": "2025-12-15T16:19:41.762Z",
+            "node_endpoint": "/127.0.0.1:9042",
+            "node_status": "AVAILABLE"
+        }
+    ]
+}
+```
+
+To check whether the local ecChronos REST API is reachable (the previous default behavior), use `--local`:
+
+```cmd
+ecctool status --local
+```
+```text
+ecChronos is running.
+```
+
+With JSON output:
+
+```cmd
+ecctool status --local --output json
 ```
 ```json
 {

--- a/docs/autogenerated/ECCTOOL.md
+++ b/docs/autogenerated/ECCTOOL.md
@@ -1,21 +1,53 @@
 # ecctool
 
-ecctool is a command line utility used to perform operations toward an ecChronos instance. Run ‘ecctool &lt;subcommand&gt; –help’ to get more information about each subcommand.
+ecctool is a command line utility used to perform operations toward an ecChronos instance. Run ‘ecctool <subcommand> –help’ to get more information about each subcommand.
 
 ```console
-usage: ecctool [-h] {rejections,repair-info,repairs,run-repair,running-job,schedules,start,state,status,stop} ...
+usage: ecctool [-h]
+               {config,rejections,repair-info,repairs,run-repair,running-job,schedules,start,state,status,stop} ...
 ```
 
 
 ### -h, --help
 show this help message and exit
+
+## ecctool config
+
+Show or update ecChronos configuration.
+
+```console
+usage: ecctool config [-h] [--session-window SESSION_WINDOW]
+                      [--cooldown COOLDOWN]
+                      [--locks-per-resource LOCKS_PER_RESOURCE] [-u URL]
+```
+
+
+### -h, --help
+show this help message and exit
+
+
+### --session-window <session_window>
+session window duration (e.g. 5m, 30s, 300000)
+
+
+### --cooldown <cooldown>
+cooldown duration (e.g. 5m, 30s, 300000)
+
+
+### --locks-per-resource <locks_per_resource>
+locks per resource
+
+
+### -u <url>, --url <url>
+ecchronos host URL (format: [http:/](http:/)/<host>:<port>)
 
 ## ecctool rejections
 
-Manage ecchronos rejections. Use ‘ecctool rejections &lt;action&gt; –help’ for action information.
+Manage ecchronos rejections. Use ‘ecctool rejections <action> –help’ for action information.
 
 ```console
-usage: ecctool rejections [-h] [-u URL] [-c COLUMNS] [-o OUTPUT] {create,delete,get,update} ...
+usage: ecctool rejections [-h] [-u URL] [-c COLUMNS] [-o OUTPUT]
+                          {create,delete,get,update} ...
 ```
 
 
@@ -23,21 +55,24 @@ usage: ecctool rejections [-h] [-u URL] [-c COLUMNS] [-o OUTPUT] {create,delete,
 show this help message and exit
 
 
-### -u &lt;url&gt;, --url &lt;url&gt;
-ecchronos host URL (format: [http:/](http:/)/&lt;host&gt;:&lt;port&gt;)
+### -u <url>, --url <url>
+ecchronos host URL (format: [http:/](http:/)/<host>:<port>)
 
 
-### -c &lt;columns&gt;, --columns &lt;columns&gt;
+### -c <columns>, --columns <columns>
 table columns to display (format: 0,1,2,…,N)
 
 
-### -o &lt;output&gt;, --output &lt;output&gt;
+### -o <output>, --output <output>
 output formats: json, table (default)
 
 ## ecctool rejections create
 
 ```console
-usage: ecctool rejections create [-h] -k KEYSPACE -t TABLE -sh START_HOUR -sm START_MINUTE -eh END_HOUR -em END_MINUTE -dcs DC_EXCLUSIONS [DC_EXCLUSIONS ...] [-u URL]
+usage: ecctool rejections create [-h] -k KEYSPACE -t TABLE -sh START_HOUR
+                                 -sm START_MINUTE -eh END_HOUR -em END_MINUTE
+                                 -dcs DC_EXCLUSIONS [DC_EXCLUSIONS ...]
+                                 [-u URL]
 ```
 
 
@@ -45,41 +80,44 @@ usage: ecctool rejections create [-h] -k KEYSPACE -t TABLE -sh START_HOUR -sm ST
 show this help message and exit
 
 
-### -k &lt;keyspace&gt;, --keyspace &lt;keyspace&gt;
+### -k <keyspace>, --keyspace <keyspace>
 keyspace
 
 
-### -t &lt;table&gt;, --table &lt;table&gt;
+### -t <table>, --table <table>
 table
 
 
-### -sh &lt;start_hour&gt;, --start-hour &lt;start_hour&gt;
+### -sh <start_hour>, --start-hour <start_hour>
 start hour
 
 
-### -sm &lt;start_minute&gt;, --start-minute &lt;start_minute&gt;
+### -sm <start_minute>, --start-minute <start_minute>
 start minute
 
 
-### -eh &lt;end_hour&gt;, --end-hour &lt;end_hour&gt;
+### -eh <end_hour>, --end-hour <end_hour>
 end hour
 
 
-### -em &lt;end_minute&gt;, --end-minute &lt;end_minute&gt;
+### -em <end_minute>, --end-minute <end_minute>
 end minute
 
 
-### -dcs &lt;dc_exclusions&gt;, --dc-exclusions &lt;dc_exclusions&gt;
-datacenters to exclude (format: &lt;dc1&gt; &lt;dc2&gt; … &lt;dcN&gt;)
+### -dcs <dc_exclusions>, --dc-exclusions <dc_exclusions>
+datacenters to exclude (format: <dc1> <dc2> … <dcN>)
 
 
-### -u &lt;url&gt;, --url &lt;url&gt;
-ecchronos host URL (format: [http:/](http:/)/&lt;host&gt;:&lt;port&gt;)
+### -u <url>, --url <url>
+ecchronos host URL (format: [http:/](http:/)/<host>:<port>)
 
 ## ecctool rejections delete
 
 ```console
-usage: ecctool rejections delete [-h] [-a ALL] [-k KEYSPACE] [-t TABLE] [-sh START_HOUR] [-sm START_MINUTE] [-dcs DC_EXCLUSIONS [DC_EXCLUSIONS ...]] [-u URL]
+usage: ecctool rejections delete [-h] [-a ALL] [-k KEYSPACE] [-t TABLE]
+                                 [-sh START_HOUR] [-sm START_MINUTE]
+                                 [-dcs DC_EXCLUSIONS [DC_EXCLUSIONS ...]]
+                                 [-u URL]
 ```
 
 
@@ -87,32 +125,32 @@ usage: ecctool rejections delete [-h] [-a ALL] [-k KEYSPACE] [-t TABLE] [-sh STA
 show this help message and exit
 
 
-### -a &lt;all&gt;, --all &lt;all&gt;
+### -a <all>, --all <all>
 delete all
 
 
-### -k &lt;keyspace&gt;, --keyspace &lt;keyspace&gt;
+### -k <keyspace>, --keyspace <keyspace>
 keyspace
 
 
-### -t &lt;table&gt;, --table &lt;table&gt;
+### -t <table>, --table <table>
 table
 
 
-### -sh &lt;start_hour&gt;, --start-hour &lt;start_hour&gt;
+### -sh <start_hour>, --start-hour <start_hour>
 start hour
 
 
-### -sm &lt;start_minute&gt;, --start-minute &lt;start_minute&gt;
+### -sm <start_minute>, --start-minute <start_minute>
 start minute
 
 
-### -dcs &lt;dc_exclusions&gt;, --dc-exclusions &lt;dc_exclusions&gt;
-datacenters to exclude (format: &lt;dc1&gt; &lt;dc2&gt; … &lt;dcN&gt;)
+### -dcs <dc_exclusions>, --dc-exclusions <dc_exclusions>
+datacenters to exclude (format: <dc1> <dc2> … <dcN>)
 
 
-### -u &lt;url&gt;, --url &lt;url&gt;
-ecchronos host URL (format: [http:/](http:/)/&lt;host&gt;:&lt;port&gt;)
+### -u <url>, --url <url>
+ecchronos host URL (format: [http:/](http:/)/<host>:<port>)
 
 ## ecctool rejections get
 
@@ -125,21 +163,24 @@ usage: ecctool rejections get [-h] [-k KEYSPACE] [-t TABLE] [-u URL]
 show this help message and exit
 
 
-### -k &lt;keyspace&gt;, --keyspace &lt;keyspace&gt;
+### -k <keyspace>, --keyspace <keyspace>
 keyspace
 
 
-### -t &lt;table&gt;, --table &lt;table&gt;
+### -t <table>, --table <table>
 table
 
 
-### -u &lt;url&gt;, --url &lt;url&gt;
-ecchronos host URL (format: [http:/](http:/)/&lt;host&gt;:&lt;port&gt;)
+### -u <url>, --url <url>
+ecchronos host URL (format: [http:/](http:/)/<host>:<port>)
 
 ## ecctool rejections update
 
 ```console
-usage: ecctool rejections update [-h] -k KEYSPACE -t TABLE -sh START_HOUR -sm START_MINUTE [-dcs DC_EXCLUSIONS [DC_EXCLUSIONS ...]] [-u URL]
+usage: ecctool rejections update [-h] -k KEYSPACE -t TABLE -sh START_HOUR
+                                 -sm START_MINUTE
+                                 [-dcs DC_EXCLUSIONS [DC_EXCLUSIONS ...]]
+                                 [-u URL]
 ```
 
 
@@ -147,35 +188,37 @@ usage: ecctool rejections update [-h] -k KEYSPACE -t TABLE -sh START_HOUR -sm ST
 show this help message and exit
 
 
-### -k &lt;keyspace&gt;, --keyspace &lt;keyspace&gt;
+### -k <keyspace>, --keyspace <keyspace>
 keyspace
 
 
-### -t &lt;table&gt;, --table &lt;table&gt;
+### -t <table>, --table <table>
 table
 
 
-### -sh &lt;start_hour&gt;, --start-hour &lt;start_hour&gt;
+### -sh <start_hour>, --start-hour <start_hour>
 start hour
 
 
-### -sm &lt;start_minute&gt;, --start-minute &lt;start_minute&gt;
+### -sm <start_minute>, --start-minute <start_minute>
 start minute
 
 
-### -dcs &lt;dc_exclusions&gt;, --dc-exclusions &lt;dc_exclusions&gt;
-datacenters to exclude (format: &lt;dc1&gt; &lt;dc2&gt; … &lt;dcN&gt;)
+### -dcs <dc_exclusions>, --dc-exclusions <dc_exclusions>
+datacenters to exclude (format: <dc1> <dc2> … <dcN>)
 
 
-### -u &lt;url&gt;, --url &lt;url&gt;
-ecchronos host URL (format: [http:/](http:/)/&lt;host&gt;:&lt;port&gt;)
+### -u <url>, --url <url>
+ecchronos host URL (format: [http:/](http:/)/<host>:<port>)
 
 ## ecctool repair-info
 
 Get information about repairs for tables. The repair information is based on repair history, meaning both manual and scheduled repairs will be a part of the repair information. This subcommand requires the user to provide either –since or –duration if –keyspace and –table is not provided. If repair info is fetched for a specific table using –keyspace and –table, the duration will default to the table’s GC_GRACE_SECONDS.
 
 ```console
-usage: ecctool repair-info [-h] [-c COLUMNS] [-n NODE] [-k KEYSPACE] [-t TABLE] [-s SINCE] [-d DURATION] [-u URL] [-l LIMIT] [-o OUTPUT]
+usage: ecctool repair-info [-h] [-c COLUMNS] [-n NODE] [-k KEYSPACE]
+                           [-t TABLE] [-s SINCE] [-d DURATION] [-u URL]
+                           [-l LIMIT] [-o OUTPUT]
 ```
 
 
@@ -183,39 +226,39 @@ usage: ecctool repair-info [-h] [-c COLUMNS] [-n NODE] [-k KEYSPACE] [-t TABLE] 
 show this help message and exit
 
 
-### -c &lt;columns&gt;, --columns &lt;columns&gt;
+### -c <columns>, --columns <columns>
 table columns to display (format: 0,1,2,…,N)
 
 
-### -n &lt;node&gt;, --node &lt;node&gt;
+### -n <node>, --node <node>
 only matching node id
 
 
-### -k &lt;keyspace&gt;, --keyspace &lt;keyspace&gt;
+### -k <keyspace>, --keyspace <keyspace>
 keyspace
 
 
-### -t &lt;table&gt;, --table &lt;table&gt;
+### -t <table>, --table <table>
 table
 
 
-### -s &lt;since&gt;, --since &lt;since&gt;
+### -s <since>, --since <since>
 repair information from specified date (ISO8601 format) to now (required unless using –duration or –keyspace/–table)
 
 
-### -d &lt;duration&gt;, --duration &lt;duration&gt;
+### -d <duration>, --duration <duration>
 repair information for specified duration (ISO8601 or simple format: 5s, 5m, 5h, 5d) from now-duration to now (required unless using –since or –keyspace/–table)
 
 
-### -u &lt;url&gt;, --url &lt;url&gt;
-ecchronos host URL (format: [http:/](http:/)/&lt;host&gt;:&lt;port&gt;)
+### -u <url>, --url <url>
+ecchronos host URL (format: [http:/](http:/)/<host>:<port>)
 
 
-### -l &lt;limit&gt;, --limit &lt;limit&gt;
+### -l <limit>, --limit <limit>
 limit output rows (use -1 for no limit)
 
 
-### -o &lt;output&gt;, --output &lt;output&gt;
+### -o <output>, --output <output>
 output formats: json, table (default)
 
 ## ecctool repairs
@@ -223,7 +266,8 @@ output formats: json, table (default)
 Show the status of all manual repairs.
 
 ```console
-usage: ecctool repairs [-h] [-c COLUMNS] [-k KEYSPACE] [-t TABLE] [-u URL] [-n NODE] [-i ID] [-l LIMIT] [-o OUTPUT]
+usage: ecctool repairs [-h] [-c COLUMNS] [-k KEYSPACE] [-t TABLE] [-u URL]
+                       [-n NODE] [-i ID] [-l LIMIT] [-o OUTPUT]
 ```
 
 
@@ -231,35 +275,35 @@ usage: ecctool repairs [-h] [-c COLUMNS] [-k KEYSPACE] [-t TABLE] [-u URL] [-n N
 show this help message and exit
 
 
-### -c &lt;columns&gt;, --columns &lt;columns&gt;
+### -c <columns>, --columns <columns>
 table columns to display (format: 0,1,2,…,N)
 
 
-### -k &lt;keyspace&gt;, --keyspace &lt;keyspace&gt;
+### -k <keyspace>, --keyspace <keyspace>
 keyspace (mutually exclusive with -n/–node)
 
 
-### -t &lt;table&gt;, --table &lt;table&gt;
+### -t <table>, --table <table>
 table (requires -k/–keyspace and is mutually exclusive with -n/–node)
 
 
-### -u &lt;url&gt;, --url &lt;url&gt;
-ecchronos host URL (format: [http:/](http:/)/&lt;host&gt;:&lt;port&gt;)
+### -u <url>, --url <url>
+ecchronos host URL (format: [http:/](http:/)/<host>:<port>)
 
 
-### -n &lt;node&gt;, --node &lt;node&gt;
+### -n <node>, --node <node>
 only matching node id (mutually exclusive with -k/–keyspace and -t/–table)
 
 
-### -i &lt;id&gt;, --id &lt;id&gt;
+### -i <id>, --id <id>
 only matching job id (mutually exclusive with -k/–keyspace and -t/–table)
 
 
-### -l &lt;limit&gt;, --limit &lt;limit&gt;
+### -l <limit>, --limit <limit>
 limit output rows (use -1 for no limit)
 
 
-### -o &lt;output&gt;, --output &lt;output&gt;
+### -o <output>, --output <output>
 output formats: json, table (default)
 
 ## ecctool run-repair
@@ -267,7 +311,9 @@ output formats: json, table (default)
 Triggers a manual repair in ecChronos. This will be done through the Cassandra JMX interface.
 
 ```console
-usage: ecctool run-repair [-h] [-c COLUMNS] [-n NODE] [-u URL] [-o OUTPUT] [-r REPAIR_TYPE] [-f] [-e] [-a] [-k KEYSPACE] [-t TABLE]
+usage: ecctool run-repair [-h] [-c COLUMNS] [-n NODE] [-u URL] [-o OUTPUT]
+                          [-r REPAIR_TYPE] [-f] [-e] [-a] [-k KEYSPACE]
+                          [-t TABLE]
 ```
 
 
@@ -275,23 +321,23 @@ usage: ecctool run-repair [-h] [-c COLUMNS] [-n NODE] [-u URL] [-o OUTPUT] [-r R
 show this help message and exit
 
 
-### -c &lt;columns&gt;, --columns &lt;columns&gt;
+### -c <columns>, --columns <columns>
 table columns to display (format: 0,1,2,…,N)
 
 
-### -n &lt;node&gt;, --node &lt;node&gt;
+### -n <node>, --node <node>
 only matching node id (mutually exclusive with -k/–keyspace and -t/–table)
 
 
-### -u &lt;url&gt;, --url &lt;url&gt;
-ecchronos host URL (format: [http:/](http:/)/&lt;host&gt;:&lt;port&gt;)
+### -u <url>, --url <url>
+ecchronos host URL (format: [http:/](http:/)/<host>:<port>)
 
 
-### -o &lt;output&gt;, --output &lt;output&gt;
+### -o <output>, --output <output>
 output formats: json, table (default)
 
 
-### -r &lt;repair_type&gt;, --repair_type &lt;repair_type&gt;
+### -r <repair_type>, --repair_type <repair_type>
 type of repair (accepted values: vnode, parallel_vnode and incremental)
 
 
@@ -307,11 +353,11 @@ force repair of disabled tables
 run repair for all nodes
 
 
-### -k &lt;keyspace&gt;, --keyspace &lt;keyspace&gt;
+### -k <keyspace>, --keyspace <keyspace>
 keyspace (applies to all tables within the keyspace with a replication factor greater than 1)
 
 
-### -t &lt;table&gt;, --table &lt;table&gt;
+### -t <table>, --table <table>
 table (requires -k/–keyspace)
 
 ## ecctool running-job
@@ -327,19 +373,21 @@ usage: ecctool running-job [-h] [-o OUTPUT] [-u URL]
 show this help message and exit
 
 
-### -o &lt;output&gt;, --output &lt;output&gt;
+### -o <output>, --output <output>
 output formats: json (defaults to no format)
 
 
-### -u &lt;url&gt;, --url &lt;url&gt;
-ecchronos host URL (format: [http:/](http:/)/&lt;host&gt;:&lt;port&gt;)
+### -u <url>, --url <url>
+ecchronos host URL (format: [http:/](http:/)/<host>:<port>)
 
 ## ecctool schedules
 
 Show the status of schedules.
 
 ```console
-usage: ecctool schedules [-h] [-c COLUMNS] [-f] [-n NODE] [-i ID] [-k KEYSPACE] [-l LIMIT] [-o OUTPUT] [-t TABLE] [-u URL]
+usage: ecctool schedules [-h] [-c COLUMNS] [-f] [-n NODE] [-i ID]
+                         [-k KEYSPACE] [-l LIMIT] [-o OUTPUT] [-t TABLE]
+                         [-u URL]
 ```
 
 
@@ -347,7 +395,7 @@ usage: ecctool schedules [-h] [-c COLUMNS] [-f] [-n NODE] [-i ID] [-k KEYSPACE] 
 show this help message and exit
 
 
-### -c &lt;columns&gt;, --columns &lt;columns&gt;
+### -c <columns>, --columns <columns>
 table columns to display (format: 0,1,2,…,N)
 
 
@@ -355,32 +403,32 @@ table columns to display (format: 0,1,2,…,N)
 show full schedules with configuration and vnode state (requires -n/–node)
 
 
-### -n &lt;node&gt;, --node &lt;node&gt;
+### -n <node>, --node <node>
 only matching node id (mutually exclusive with -k/–keyspace and -t/–table)
 
 
-### -i &lt;id&gt;, --id &lt;id&gt;
+### -i <id>, --id <id>
 only matching job id (mutually exclusive with -k/–keyspace and -t/–table)
 
 
-### -k &lt;keyspace&gt;, --keyspace &lt;keyspace&gt;
+### -k <keyspace>, --keyspace <keyspace>
 keyspace (mutually exclusive with -n/–node)
 
 
-### -l &lt;limit&gt;, --limit &lt;limit&gt;
+### -l <limit>, --limit <limit>
 limit output rows (use -1 for no limit)
 
 
-### -o &lt;output&gt;, --output &lt;output&gt;
+### -o <output>, --output <output>
 output formats: json, table (default)
 
 
-### -t &lt;table&gt;, --table &lt;table&gt;
+### -t <table>, --table <table>
 table (requires -k/–keyspace and is mutually exclusive with -n/–node)
 
 
-### -u &lt;url&gt;, --url &lt;url&gt;
-ecchronos host URL (format: [http:/](http:/)/&lt;host&gt;:&lt;port&gt;)
+### -u <url>, --url <url>
+ecchronos host URL (format: [http:/](http:/)/<host>:<port>)
 
 ## ecctool start
 
@@ -399,11 +447,11 @@ show this help message and exit
 run in foreground (executes in current terminal and logs to stdout)
 
 
-### -o &lt;output&gt;, --output &lt;output&gt;
+### -o <output>, --output <output>
 output formats: json (defaults to no format)
 
 
-### -p &lt;pidfile&gt;, --pidfile &lt;pidfile&gt;
+### -p <pidfile>, --pidfile <pidfile>
 file for storing process id
 
 ## ecctool state
@@ -419,16 +467,16 @@ usage: ecctool state [-h] [-c COLUMNS] [-o OUTPUT] [-u URL] {nodes} ...
 show this help message and exit
 
 
-### -c &lt;columns&gt;, --columns &lt;columns&gt;
+### -c <columns>, --columns <columns>
 table columns to display (format: 0,1,2,…,N)
 
 
-### -o &lt;output&gt;, --output &lt;output&gt;
+### -o <output>, --output <output>
 output formats: json (defaults to no format)
 
 
-### -u &lt;url&gt;, --url &lt;url&gt;
-ecchronos host URL (format: [http:/](http:/)/&lt;host&gt;:&lt;port&gt;)
+### -u <url>, --url <url>
+ecchronos host URL (format: [http:/](http:/)/<host>:<port>)
 
 ## ecctool state nodes
 
@@ -441,15 +489,15 @@ usage: ecctool state nodes [-h] [-u URL]
 show this help message and exit
 
 
-### -u &lt;url&gt;, --url &lt;url&gt;
-ecchronos host URL (format: [http:/](http:/)/&lt;host&gt;:&lt;port&gt;)
+### -u <url>, --url <url>
+ecchronos host URL (format: [http:/](http:/)/<host>:<port>)
 
 ## ecctool status
 
-View status of the ecChronos instance.
+View cluster-wide status of nodes registered in nodes_sync across all ecChronos instances.
 
 ```console
-usage: ecctool status [-h] [-u URL] [-o OUTPUT]
+usage: ecctool status [-h] [-c COLUMNS] [--local] [-u URL] [-o OUTPUT]
 ```
 
 
@@ -457,12 +505,20 @@ usage: ecctool status [-h] [-u URL] [-o OUTPUT]
 show this help message and exit
 
 
-### -u &lt;url&gt;, --url &lt;url&gt;
-ecchronos host URL (format: [http:/](http:/)/&lt;host&gt;:&lt;port&gt;)
+### -c <columns>, --columns <columns>
+table columns to display (format: 0,1,2,…,N)
 
 
-### -o &lt;output&gt;, --output &lt;output&gt;
-output formats: json (defaults to no format)
+### --local
+check whether the local ecChronos instance is running (legacy status check)
+
+
+### -u <url>, --url <url>
+ecchronos host URL (format: [http:/](http:/)/<host>:<port>)
+
+
+### -o <output>, --output <output>
+output formats: json, table (default)
 
 ## ecctool stop
 
@@ -477,34 +533,12 @@ usage: ecctool stop [-h] [-o OUTPUT] [-p PIDFILE]
 show this help message and exit
 
 
-### -o &lt;output&gt;, --output &lt;output&gt;
+### -o <output>, --output <output>
 output formats: json (defaults to no format)
 
 
-### -p &lt;pidfile&gt;, --pidfile &lt;pidfile&gt;
+### -p <pidfile>, --pidfile <pidfile>
 file containing process id
-
-## ecctool config
-
-Show or update ecChronos runtime configuration. Changes are in-memory only — restarting ecChronos restores values from `ecc.yml`.
-
-```console
-usage: ecctool config [-h] [--session-window SESSION_WINDOW] [--cooldown COOLDOWN] [--locks-per-resource LOCKS_PER_RESOURCE] [-u URL]
-```
-
-When called without arguments, displays the current configuration. When called with one or more parameters, updates the specified values.
-
-### --session-window &lt;duration&gt;
-Time window for batched lock sessions. Accepts duration format: `5m`, `30s`, `2h`, `500ms`, or raw milliseconds.
-
-### --cooldown &lt;duration&gt;
-Cooldown period after a session completes. Accepts same duration format as `--session-window`.
-
-### --locks-per-resource &lt;int&gt;
-Number of concurrent locks per datacenter resource. Must be >= 1.
-
-### -u &lt;url&gt;, --url &lt;url&gt;
-ecchronos host URL (format: [http:/](http:/)/&lt;host&gt;:&lt;port&gt;)
 
 # Examples
 

--- a/ecchronos-binary/src/bin/ecctool.py
+++ b/ecchronos-binary/src/bin/ecctool.py
@@ -104,6 +104,12 @@ ARG_JOB_ID = {
 }
 ARG_KEYSPACE = {"flags": ["-k", "--keyspace"], "type": str, "help": "keyspace"}
 ARG_LIMIT = {"flags": ["-l", "--limit"], "type": int, "help": "limit output rows (use -1 for no limit)", "default": -1}
+ARG_LOCAL = {
+    "flags": ["--local"],
+    "action": "store_true",
+    "help": "check whether the local ecChronos instance is running (legacy status check)",
+    "default": False,
+}
 ARG_NODE_ID = {
     "flags": ["-n", "--node"],
     "type": str,
@@ -426,9 +432,14 @@ def add_rejections_update_action(rejections_subparsers):
 
 
 def add_status_subcommand(sub_parsers):
-    parser_status = sub_parsers.add_parser("status", description="View status of the ecChronos instance.")
+    parser_status = sub_parsers.add_parser(
+        "status",
+        description="View cluster-wide status of nodes registered in nodes_sync across all ecChronos instances.",
+    )
+    add_common_arg(parser_status, ARG_COLUMNS)
+    add_common_arg(parser_status, ARG_LOCAL)
     add_common_arg(parser_status, ARG_URL)
-    add_common_arg(parser_status, ARG_OUTPUT_JSON)
+    add_common_arg(parser_status, ARG_OUTPUT_JSON_TABLE)
 
 
 def _create_rejections(arguments):
@@ -783,20 +794,35 @@ def stop(arguments):
             sys.exit(1)
 
 
-def status(arguments, print_running=False):
+def _verify_local_instance_running(arguments, print_running=False):
     request = rest.RepairSchedulerRequest(base_url=arguments.url)
     result = request.list_schedules()
     if result.is_successful():
         if print_running:
             if arguments.output == "json":
                 table_printer.output_json({"running": True})
-            elif print_running:
+            else:
                 print("ecChronos is running.")
     else:
         if arguments.output == "json":
             table_printer.output_json({"running": False})
         else:
             print("ecChronos is not running.")
+        sys.exit(1)
+
+
+def status(arguments):
+    if arguments.local:
+        _verify_local_instance_running(arguments, print_running=True)
+        return
+
+    request = rest.StateManagementRequest(base_url=arguments.url)
+    result = request.get_nodes(all_instances=True)
+
+    if result.is_successful():
+        table_printer.print_nodes(result.data, columns=arguments.columns, output=arguments.output)
+    else:
+        print(result.format_exception())
         sys.exit(1)
 
 
@@ -815,33 +841,33 @@ def running_job(arguments):
 
 def run_subcommand(arguments):
     if arguments.subcommand == "config":
-        status(arguments)
+        _verify_local_instance_running(arguments)
         config(arguments)
     elif arguments.subcommand == "rejections":
-        status(arguments)
+        _verify_local_instance_running(arguments)
         rejections(arguments)
     elif arguments.subcommand == "repair-info":
-        status(arguments)
+        _verify_local_instance_running(arguments)
         repair_info(arguments)
     elif arguments.subcommand == "repairs":
-        status(arguments)
+        _verify_local_instance_running(arguments)
         repairs(arguments)
     elif arguments.subcommand == "run-repair":
-        status(arguments)
+        _verify_local_instance_running(arguments)
         run_repair(arguments)
     elif arguments.subcommand == "running-job":
-        status(arguments)
+        _verify_local_instance_running(arguments)
         running_job(arguments)
     elif arguments.subcommand == "schedules":
-        status(arguments)
+        _verify_local_instance_running(arguments)
         schedules(arguments)
     elif arguments.subcommand == "start":
         start(arguments)
     elif arguments.subcommand == "state":
-        status(arguments)
+        _verify_local_instance_running(arguments)
         state(arguments)
     elif arguments.subcommand == "status":
-        status(arguments, print_running=True)
+        status(arguments)
     elif arguments.subcommand == "stop":
         stop(arguments)
 

--- a/ecchronos-binary/src/pylib/ecchronoslib/rest.py
+++ b/ecchronos-binary/src/pylib/ecchronoslib/rest.py
@@ -308,8 +308,11 @@ class StateManagementRequest(RestRequest):
     def __init__(self, base_url=None):
         RestRequest.__init__(self, base_url)
 
-    def get_nodes(self):
-        result = self.request(StateManagementRequest.NODES)
+    def get_nodes(self, all_instances=False):
+        request_url = StateManagementRequest.NODES
+        if all_instances:
+            request_url = "{0}?all=true".format(request_url)
+        result = self.request(request_url)
         if result.is_successful():
             result = result.transform_with_data(new_data=[NodeSyncState(x) for x in result.data])
         return result

--- a/ecchronos-binary/src/test/behave/features/ecc-rest-state.feature
+++ b/ecchronos-binary/src/test/behave/features/ecc-rest-state.feature
@@ -23,3 +23,11 @@ Feature: API to get state
     Then the response is successful
     And the response matches the json schema nodes
     And the number of nodes is 2
+
+  Scenario: Get nodes for all ecChronos instances
+    Given I have a json schema nodes
+    And I use the url localhost:8080/state/nodes?all=true
+    When I send a GET request
+    Then the response is successful
+    And the response matches the json schema nodes
+    And the number of nodes is 4

--- a/ecchronos-binary/src/test/behave/features/ecctool-status.feature
+++ b/ecchronos-binary/src/test/behave/features/ecctool-status.feature
@@ -1,0 +1,17 @@
+Feature: ecctool status
+
+  Scenario: Get status with json output option
+    Given we have access to ecctool
+    When we list status with json output option
+    Then the output should contain valid json data
+    And the json output should contain nodes
+
+  Scenario: Get status with table output
+    Given we have access to ecctool
+    When we list status
+    Then the output should contain a valid state nodes header
+
+  Scenario: Get local status with legacy health check
+    Given we have access to ecctool
+    When we list local status
+    Then the output should contain local ecchronos running status

--- a/ecchronos-binary/src/test/behave/features/steps/ecctool_state.py
+++ b/ecchronos-binary/src/test/behave/features/steps/ecctool_state.py
@@ -46,6 +46,24 @@ def step_list_state_nodes_with_json(context):
     handle_state_nodes_output(context)
 
 
+@when("we list status")
+def step_list_status(context):
+    run_ecctool(context, ["status"])
+    handle_state_nodes_output(context)
+
+
+@when("we list status with json output option")
+def step_list_status_with_json(context):
+    run_ecctool(context, ["status", "-o", "json"])
+    handle_state_nodes_output(context)
+
+
+@when("we list local status")
+def step_list_local_status(context):
+    run_ecctool(context, ["status", "--local"])
+    context.all = context.out.decode("ascii")
+
+
 @then("the output should contain a valid state nodes header")
 def step_validate_state_nodes_header(context):
     validate_header(context.header, STATE_NODES_HEADER)
@@ -57,3 +75,8 @@ def step_validate_state_nodes_json_content(context):
     assert "nodes" in data
     assert isinstance(data["nodes"], list)
     assert len(data["nodes"]) > 0
+
+
+@then("the output should contain local ecchronos running status")
+def step_validate_local_status(context):
+    assert "ecChronos is running." in context.all

--- a/ecchronos-binary/src/test/bin/conftest.py
+++ b/ecchronos-binary/src/test/bin/conftest.py
@@ -257,6 +257,10 @@ def run_ecctool_schedules(container_name="ecchronos-agent-cluster-wide"):
     return run_ecctool(["schedules"], container_name)
 
 
+def run_ecctool_status(container_name="ecchronos-agent-cluster-wide"):
+    return run_ecctool(["status"], container_name)
+
+
 def run_ecctool(params, container_name="ecchronos-agent-cluster-wide"):
     cmd = [f"{global_vars.CONTAINER_BASE_DIR}/bin/ecctool"] + params
     try:
@@ -282,3 +286,14 @@ def assert_schedules_size_is_equal(out, expected_schedules):
     output_data = out.decode("ascii").lstrip().rstrip().split("\n")
     rows = output_data[3:-1]
     assert len(rows) == expected_schedules, f"Expected {expected_schedules} schedules, but found {len(rows)}"
+
+
+def extract_ecchronos_ids(out):
+    output_data = out.decode("ascii").lstrip().rstrip().split("\n")
+    rows = output_data[3:-1]
+    ecchronos_ids = set()
+    for row in rows:
+        columns = [column.strip() for column in row.split("|") if column.strip()]
+        if columns:
+            ecchronos_ids.add(columns[0])
+    return ecchronos_ids

--- a/ecchronos-binary/src/test/bin/test_ecctool_status.py
+++ b/ecchronos-binary/src/test/bin/test_ecctool_status.py
@@ -1,0 +1,197 @@
+#
+# Copyright 2026 Telefonaktiebolaget LM Ericsson
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Tests for ecctool status subcommand."""
+import io
+import json
+import os
+import sys
+from contextlib import redirect_stdout
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "bin"))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "pylib"))
+
+from ecchronoslib.types import NodeSyncState  # pylint: disable=wrong-import-position
+
+
+def _sample_node(ecchronos_id="ecc-1"):
+    return NodeSyncState(
+        {
+            "ecchronosId": ecchronos_id,
+            "datacenterName": "datacenter1",
+            "nodeId": "8a9d2a57-1388-42be-aab6-06a4e5f6fe84",
+            "lastConnection": "2025-12-15T15:49:41.762Z",
+            "nextConnection": "2025-12-15T16:19:41.762Z",
+            "nodeEndpoint": "/127.0.0.1:9042",
+            "nodeStatus": "AVAILABLE",
+        }
+    )
+
+
+def test_status_command_parses_output_flags():
+    from ecctool import get_parser  # pylint: disable=import-outside-toplevel
+
+    args = get_parser().parse_args(["status", "-o", "json"])
+    assert args.output == "json"
+    assert args.subcommand == "status"
+
+
+def test_status_command_parses_local_flag():
+    from ecctool import get_parser  # pylint: disable=import-outside-toplevel
+
+    args = get_parser().parse_args(["status", "--local"])
+    assert args.local is True
+
+
+@patch("ecctool.rest.StateManagementRequest")
+def test_status_command_prints_nodes_table(mock_request_class):
+    from ecctool import status  # pylint: disable=import-outside-toplevel
+
+    mock_result = MagicMock()
+    mock_result.is_successful.return_value = True
+    mock_result.data = [_sample_node()]
+    mock_request_class.return_value.get_nodes.return_value = mock_result
+
+    args = MagicMock()
+    args.url = "http://localhost:8080"
+    args.columns = None
+    args.output = "table"
+    args.local = False
+
+    output = io.StringIO()
+    with redirect_stdout(output):
+        status(args)
+
+    rendered = output.getvalue()
+    assert "EcchronosID" in rendered
+    assert "ecc-1" in rendered
+    assert "AVAILABLE" in rendered
+    mock_request_class.return_value.get_nodes.assert_called_once_with(all_instances=True)
+
+
+@patch("ecctool.rest.StateManagementRequest")
+def test_status_command_prints_nodes_json(mock_request_class):
+    from ecctool import status  # pylint: disable=import-outside-toplevel
+
+    mock_result = MagicMock()
+    mock_result.is_successful.return_value = True
+    mock_result.data = [_sample_node()]
+    mock_request_class.return_value.get_nodes.return_value = mock_result
+
+    args = MagicMock()
+    args.url = "http://localhost:8080"
+    args.columns = None
+    args.output = "json"
+    args.local = False
+
+    output = io.StringIO()
+    with redirect_stdout(output):
+        status(args)
+
+    data = json.loads(output.getvalue())
+    assert "timestamp" in data
+    assert "nodes" in data
+    assert data["nodes"][0]["ecchronos_id"] == "ecc-1"
+
+
+@patch("ecctool.rest.StateManagementRequest")
+def test_status_command_prints_empty_nodes(mock_request_class):
+    from ecctool import status  # pylint: disable=import-outside-toplevel
+
+    mock_result = MagicMock()
+    mock_result.is_successful.return_value = True
+    mock_result.data = []
+    mock_request_class.return_value.get_nodes.return_value = mock_result
+
+    args = MagicMock()
+    args.url = "http://localhost:8080"
+    args.columns = None
+    args.output = "json"
+    args.local = False
+
+    output = io.StringIO()
+    with redirect_stdout(output):
+        status(args)
+
+    data = json.loads(output.getvalue())
+    assert data["nodes"] == []
+
+
+@patch("ecctool.rest.StateManagementRequest")
+def test_status_command_exits_on_failure(mock_request_class):
+    from ecctool import status  # pylint: disable=import-outside-toplevel
+
+    mock_result = MagicMock()
+    mock_result.is_successful.return_value = False
+    mock_result.format_exception.return_value = "Encountered issue (404)"
+    mock_request_class.return_value.get_nodes.return_value = mock_result
+
+    args = MagicMock()
+    args.url = "http://localhost:8080"
+    args.columns = None
+    args.output = "table"
+    args.local = False
+
+    try:
+        status(args)
+        assert False, "Expected SystemExit"
+    except SystemExit as exc:
+        assert exc.code == 1
+
+
+@patch("ecctool.rest.RepairSchedulerRequest")
+def test_status_local_reports_running(mock_request_class):
+    from ecctool import status  # pylint: disable=import-outside-toplevel
+
+    mock_result = MagicMock()
+    mock_result.is_successful.return_value = True
+    mock_request_class.return_value.list_schedules.return_value = mock_result
+
+    args = MagicMock()
+    args.url = "http://localhost:8080"
+    args.output = ""
+    args.local = True
+
+    output = io.StringIO()
+    with redirect_stdout(output):
+        status(args)
+
+    assert "ecChronos is running." in output.getvalue()
+
+
+@patch("ecctool.rest.RepairSchedulerRequest")
+def test_status_local_reports_not_running(mock_request_class):
+    from ecctool import status  # pylint: disable=import-outside-toplevel
+
+    mock_result = MagicMock()
+    mock_result.is_successful.return_value = False
+    mock_request_class.return_value.list_schedules.return_value = mock_result
+
+    args = MagicMock()
+    args.url = "http://localhost:8080"
+    args.output = "json"
+    args.local = True
+
+    output = io.StringIO()
+    try:
+        with redirect_stdout(output):
+            status(args)
+        assert False, "Expected SystemExit"
+    except SystemExit as exc:
+        assert exc.code == 1
+
+    data = json.loads(output.getvalue())
+    assert data["running"] is False

--- a/ecchronos-binary/src/test/bin/test_multi_agent_datacenter_aware.py
+++ b/ecchronos-binary/src/test/bin/test_multi_agent_datacenter_aware.py
@@ -26,9 +26,11 @@ from tenacity import retry, retry_if_result, stop_after_delay, wait_fixed
 
 from conftest import (
     assert_nodes_size_is_equal,
+    extract_ecchronos_ids,
     run_ecctool_repairs,
     run_ecctool_run_repair,
     run_ecctool_state_nodes,
+    run_ecctool_status,
 )
 
 logger = logging.getLogger(__name__)
@@ -111,6 +113,19 @@ def test_install_ecchronos_dc2(install_cassandra_cluster, test_environment):
     test_environment.wait_for_ecchronos_ready(fixed_ipv4_address="172.29.0.8", bind_port=8081)
     out, _ = run_ecctool_state_nodes(ECC_INSTANCE_NAME_DC2)
     assert_nodes_size_is_equal(out, 2)
+
+
+@pytest.mark.dependency(
+    name="test_ecctool_status_shows_multiple_instances",
+    depends=["test_install_ecchronos_dc1", "test_install_ecchronos_dc2"],
+)
+def test_ecctool_status_shows_multiple_instances():
+    out, exit_code = run_ecctool_status(ECC_INSTANCE_NAME_DC1)
+    assert exit_code == 0, out.decode("ascii")
+    ecchronos_ids = extract_ecchronos_ids(out)
+    assert ECC_INSTANCE_NAME_DC1 in ecchronos_ids
+    assert ECC_INSTANCE_NAME_DC2 in ecchronos_ids
+    assert len(ecchronos_ids) >= 2
 
 
 @pytest.mark.dependency(

--- a/rest/src/main/java/com/ericsson/bss/cassandra/ecchronos/rest/StateManagementREST.java
+++ b/rest/src/main/java/com/ericsson/bss/cassandra/ecchronos/rest/StateManagementREST.java
@@ -27,10 +27,11 @@ import java.util.List;
 public interface StateManagementREST
 {
     /**
-     * Get a list of nodes managed by local instance. Will fetch all if no datacenter is specified.
+     * Get a list of nodes managed by ecChronos instances.
      *
-     * @param datacenter The datacenter name(optional)
+     * @param datacenter The datacenter name (optional). Only applies when all is false.
+     * @param all When true, return nodes from all ecChronos instances. When false, return nodes for the local instance.
      * @return A list of JSON representations of {@link NodeSyncState}
      */
-    ResponseEntity<List<NodeSyncState>> getNodes(String datacenter);
+    ResponseEntity<List<NodeSyncState>> getNodes(String datacenter, boolean all);
 }

--- a/rest/src/main/java/com/ericsson/bss/cassandra/ecchronos/rest/StateManagementRESTImpl.java
+++ b/rest/src/main/java/com/ericsson/bss/cassandra/ecchronos/rest/StateManagementRESTImpl.java
@@ -54,21 +54,35 @@ public class StateManagementRESTImpl implements StateManagementREST
 
     @Override
     @GetMapping(value = INTERNAL_MANAGEMENT_ENDPOINT_PREFIX + "/nodes", produces = MediaType.APPLICATION_JSON_VALUE)
-    @Operation(operationId = "get-nodes", description = "Get nodes managed by local instance.",
-            summary = "Get nodes managed by local instance.")
+    @Operation(operationId = "get-nodes", description = "Get nodes managed by ecChronos instances.",
+            summary = "Get nodes managed by ecChronos instances.")
     public final ResponseEntity<List<NodeSyncState>> getNodes(
             @RequestParam(required = false)
             @Parameter(description = "Only return nodes managed by the local instance for the specified datacenter.")
-            final String datacenter
+            final String datacenter,
+            @RequestParam(required = false, defaultValue = "false")
+            @Parameter(description = "When true, return nodes from all ecChronos instances.")
+            final boolean all
     )
     {
-        return ResponseEntity.ok(getNodesAndFormat(datacenter));
+        return ResponseEntity.ok(getNodesAndFormat(datacenter, all));
     }
 
-    private List<NodeSyncState> getNodesAndFormat(final String datacenter)
+    private List<NodeSyncState> getNodesAndFormat(final String datacenter, final boolean all)
     {
-        ResultSet rs = datacenter == null
-                ? myEccNodesSync.getAllByLocalInstance() : myEccNodesSync.getAllByLocalAndDCInstance(datacenter);
+        final ResultSet rs;
+        if (all)
+        {
+            rs = myEccNodesSync.getAll();
+        }
+        else if (datacenter == null)
+        {
+            rs = myEccNodesSync.getAllByLocalInstance();
+        }
+        else
+        {
+            rs = myEccNodesSync.getAllByLocalAndDCInstance(datacenter);
+        }
 
         List<NodeSyncState> nodesList = new ArrayList<>();
 

--- a/rest/src/test/java/com/ericsson/bss/cassandra/ecchronos/rest/TestStateManagementRESTImpl.java
+++ b/rest/src/test/java/com/ericsson/bss/cassandra/ecchronos/rest/TestStateManagementRESTImpl.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2026 Telefonaktiebolaget LM Ericsson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ericsson.bss.cassandra.ecchronos.rest;
+
+import com.datastax.oss.driver.api.core.cql.ResultSet;
+import com.datastax.oss.driver.api.core.cql.Row;
+import com.ericsson.bss.cassandra.ecchronos.core.repair.types.NodeSyncState;
+import com.ericsson.bss.cassandra.ecchronos.data.sync.EccNodesSync;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import java.util.function.Consumer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.Silent.class)
+public class TestStateManagementRESTImpl
+{
+    @Mock
+    private EccNodesSync myEccNodesSync;
+
+    private StateManagementREST stateManagementREST;
+
+    private final UUID nodeId = UUID.randomUUID();
+
+    @Before
+    public void setupMocks()
+    {
+        stateManagementREST = new StateManagementRESTImpl(myEccNodesSync);
+    }
+
+    @Test
+    public void testGetNodesReturnsLocalInstanceNodes()
+    {
+        ResultSet resultSet = mock(ResultSet.class);
+        Row row = mockRow("ecc-1", "datacenter1", nodeId, "AVAILABLE");
+        when(myEccNodesSync.getAllByLocalInstance()).thenReturn(resultSet);
+        doAnswer(invocation ->
+        {
+            Consumer<Row> consumer = invocation.getArgument(0);
+            consumer.accept(row);
+            return null;
+        }).when(resultSet).forEach(any());
+
+        ResponseEntity<List<NodeSyncState>> response = stateManagementREST.getNodes(null, false);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).hasSize(1);
+        assertThat(response.getBody().get(0).ecchronosId()).isEqualTo("ecc-1");
+        verify(myEccNodesSync).getAllByLocalInstance();
+        verify(myEccNodesSync, never()).getAll();
+    }
+
+    @Test
+    public void testGetNodesWithAllReturnsAllInstances()
+    {
+        ResultSet resultSet = mock(ResultSet.class);
+        UUID nodeId2 = UUID.randomUUID();
+        Row row1 = mockRow("ecc-1", "datacenter1", nodeId, "AVAILABLE");
+        Row row2 = mockRow("ecc-2", "datacenter2", nodeId2, "UNAVAILABLE");
+        when(myEccNodesSync.getAll()).thenReturn(resultSet);
+        doAnswer(invocation ->
+        {
+            Consumer<Row> consumer = invocation.getArgument(0);
+            consumer.accept(row1);
+            consumer.accept(row2);
+            return null;
+        }).when(resultSet).forEach(any());
+
+        ResponseEntity<List<NodeSyncState>> response = stateManagementREST.getNodes(null, true);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).hasSize(2);
+        assertThat(response.getBody().get(0).ecchronosId()).isEqualTo("ecc-1");
+        assertThat(response.getBody().get(1).ecchronosId()).isEqualTo("ecc-2");
+        verify(myEccNodesSync).getAll();
+        verify(myEccNodesSync, never()).getAllByLocalInstance();
+    }
+
+    @Test
+    public void testGetNodesWithAllReturnsEmptyList()
+    {
+        ResultSet resultSet = mock(ResultSet.class);
+        when(myEccNodesSync.getAll()).thenReturn(resultSet);
+
+        ResponseEntity<List<NodeSyncState>> response = stateManagementREST.getNodes(null, true);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isEmpty();
+    }
+
+    private Row mockRow(
+            final String ecchronosId,
+            final String datacenterName,
+            final UUID nodeIdValue,
+            final String nodeStatus
+    )
+    {
+        Row row = mock(Row.class);
+        Instant now = Instant.now();
+        when(row.getString(NodeSyncState.COLUMN_ECCHRONOS_ID)).thenReturn(ecchronosId);
+        when(row.getString(NodeSyncState.COLUMN_DATACENTER_NAME)).thenReturn(datacenterName);
+        when(row.getUuid(NodeSyncState.COLUMN_NODE_ID)).thenReturn(nodeIdValue);
+        when(row.getInstant(NodeSyncState.COLUMN_LAST_CONNECTION)).thenReturn(now);
+        when(row.getInstant(NodeSyncState.COLUMN_NEXT_CONNECTION)).thenReturn(now);
+        when(row.getString(NodeSyncState.COLUMN_NODE_ENDPOINT)).thenReturn("/127.0.0.1:9042");
+        when(row.getString(NodeSyncState.COLUMN_NODE_STATUS)).thenReturn(nodeStatus);
+        return row;
+    }
+}


### PR DESCRIPTION
## Summary

Implements #680 by adding cluster-wide status reporting to ecctool.

### Changes

- Added cluster-wide node retrieval through `GET /state/nodes?all=true`
- Updated `ecctool status` to display nodes across all EcChronos instances
- Added `ecctool status --local` for the legacy local health check
- Removed the obsolete `/state/status` endpoint and client method
- Added REST, Python, and integration/Behave test coverage
- Updated ecctool documentation and CHANGES.md

### Testing

- `TestStateManagementRESTImpl`: 3 passed
- `test_ecctool_status.py` + `test_ecctool_state.py`: 11 passed
- `mvn install -DskipTests`: passed
- `git diff --check`: passed

Docker-based integration tests were not run because the Docker integration environment was unavailable.

### Notes

`ecctool status` reports the persisted `nodes_sync` registry and does not guarantee current EcChronos JVM liveness.