### PR TITLE
test: remove leftover docker compose images after integration tests

### DIFF
--- a/cassandra-test-image/src/test/java/cassandracluster/AbstractCassandraCluster.java
+++ b/cassandra-test-image/src/test/java/cassandracluster/AbstractCassandraCluster.java
@@ -25,6 +25,7 @@ import java.nio.file.Paths;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.testcontainers.containers.DockerComposeContainer;
+import org.testcontainers.containers.DockerComposeContainer.RemoveImages;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
@@ -63,6 +64,9 @@ public class AbstractCassandraCluster
                 .withEnv("JOLOKIA", jolokiaEnabled)
                 .withEnv("CASSANDRA_VERSION", cassandraVersion)
                 .withEnv("CERTIFICATE_DIRECTORY", certificateDirectory)
+                // Remove the locally-built compose images on teardown so each test run
+                // does not leave behind a new set of '<project>_cassandra-*' images.
+                .withRemoveImages(RemoveImages.LOCAL)
                 .withLogConsumer(CASSANDRA_SEED_NODE_NAME, new Slf4jLogConsumer(LOG));
 
         composeContainer.start();
@@ -98,7 +102,10 @@ public class AbstractCassandraCluster
         {
             mySession.close();
         }
-        composeContainer.stop();
+        if (composeContainer != null)
+        {
+            composeContainer.stop();
+        }
     }
 
     protected void decommissionNode ( String node) throws IOException, InterruptedException

--- a/ecchronos-binary/src/test/bin/cass_config.py
+++ b/ecchronos-binary/src/test/bin/cass_config.py
@@ -327,19 +327,41 @@ class CassandraCluster:
         )
 
     def stop_cluster(self):
-        subprocess.run(
-            [
-                "docker",
-                "compose",
-                "-f",
-                f"{global_vars.CASSANDRA_DOCKER_COMPOSE_FILE_PATH}/docker-compose.yml",
-                "down",
-                "--volumes",
-                "--remove-orphans",
-                "--rmi",
-                "all",
-            ]
-        )
+        # Tear down using the same compose command prefix the wrapper used for 'up'
+        # (carries the correct -f/project so 'down' targets the images/volumes that
+        # were actually created). '--rmi local' removes the locally-built compose
+        # images so each run does not leave behind '<project>_cassandra-*' images.
+        # The pulled base image (cassandra:X.Y) is kept, since only locally-built
+        # images are removed.
+        #
+        # Note: this uses 'compose down --rmi local' rather than the name-based image
+        # removal done in the Java harness (SharedCassandraCluster). It works here
+        # because this is called from the pytest fixture teardown while the containers
+        # are still up, so compose can still associate the built images with the
+        # project. The Java shared-cluster path instead tears down at JVM exit, after
+        # the testcontainers Ryuk reaper has removed the containers, at which point
+        # 'compose down --rmi' is a no-op -- hence the different mechanism there.
+        if self.cassandra_compose is not None:
+            down_cmd = self.cassandra_compose.compose_command_property[:]
+            down_cmd += ["down", "--volumes", "--remove-orphans", "--rmi", "local"]
+            # Run in the compose context dir so the relative '-f docker-compose.yml'
+            # resolves and the default project name matches the one used at 'up'.
+            result = subprocess.run(
+                down_cmd,
+                capture_output=True,
+                text=True,
+                cwd=str(self.cassandra_compose.context),
+            )
+            if result.returncode != 0:
+                logger.warning(
+                    "compose down failed (rc=%s): %s. Falling back to wrapper stop().",
+                    result.returncode,
+                    result.stderr.strip(),
+                )
+                try:
+                    self.cassandra_compose.stop(down=True)
+                except Exception as e:
+                    logger.error(f"Fallback compose stop() also failed: {e}")
 
     def run_cql(self, query):
         command = ["docker", "exec", self.container_id, "cqlsh", "-e", query]

--- a/standalone-integration/src/test/java/com/ericsson/bss/cassandra/ecchronos/standalone/SharedCassandraCluster.java
+++ b/standalone-integration/src/test/java/com/ericsson/bss/cassandra/ecchronos/standalone/SharedCassandraCluster.java
@@ -15,11 +15,27 @@
 package com.ericsson.bss.cassandra.ecchronos.standalone;
 
 import cassandracluster.AbstractCassandraCluster;
+import com.github.dockerjava.api.DockerClient;
+import com.github.dockerjava.api.model.Image;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.DockerClientFactory;
 
 import java.io.IOException;
+import java.util.regex.Pattern;
 
 public class SharedCassandraCluster extends AbstractCassandraCluster
 {
+    private static final Logger LOG = LoggerFactory.getLogger(SharedCassandraCluster.class);
+    // Matches the images docker compose builds for the cluster services, regardless of
+    // the random testcontainers project prefix, e.g. 'awjhc7vxdswz_cassandra-seed-dc1-rack1-node1'.
+    // The service-name part must stay in sync with the services declared in
+    // cassandra-test-image/src/main/docker/docker-compose.yml; if those are renamed, this
+    // pattern needs updating (worst case if it drifts: the built images are not removed and
+    // accumulate again -- it never causes a test failure).
+    private static final Pattern COMPOSE_IMAGE_PATTERN =
+            Pattern.compile("^.*_cassandra-(seed|node)-dc\\d+-rack\\d+-node\\d+(:.*)?$");
+
     private static volatile boolean initialized = false;
     private static final Object lock = new Object();
 
@@ -33,8 +49,85 @@ public class SharedCassandraCluster extends AbstractCassandraCluster
                 {
                     setup();
                     initialized = true;
+                    // The shared cluster is started once and reused across all IT classes,
+                    // so there is no @AfterClass that tears it down. Register a JVM shutdown
+                    // hook (all ITs run in a single reused Failsafe fork) to tear the cluster
+                    // down and remove the locally-built compose images exactly once at the
+                    // end of the run. Image removal is by name (see removeComposeImages), so
+                    // it works regardless of whether the containers have already been reaped.
+                    Runtime.getRuntime().addShutdownHook(new Thread(
+                            SharedCassandraCluster::tearDownIfInitialized,
+                            "shared-cassandra-cluster-cleanup"));
                 }
             }
+        }
+    }
+
+    /**
+     * Tears down the shared cluster if it was started, and removes the locally-built
+     * compose images. Invoked once from the JVM shutdown hook registered in
+     * {@link #ensureInitialized()}.
+     *
+     * <p>The images are removed explicitly by name rather than via
+     * {@code docker compose down --rmi}, because the shared cluster is reused across all
+     * IT classes and, by the time teardown runs, compose can no longer reliably associate
+     * the built images with the (already torn-down) project. Matching on the stable
+     * service-name pattern removes them deterministically without depending on the random
+     * project prefix or compose project state. The pulled base image (cassandra:X.Y) does
+     * not match the pattern and is kept.
+     */
+    public static void tearDownIfInitialized()
+    {
+        synchronized (lock)
+        {
+            if (!initialized)
+            {
+                return;
+            }
+            try
+            {
+                tearDownCluster();
+            }
+            finally
+            {
+                initialized = false;
+                removeComposeImages();
+            }
+        }
+    }
+
+    private static void removeComposeImages()
+    {
+        try
+        {
+            DockerClient client = DockerClientFactory.lazyClient();
+            for (Image image : client.listImagesCmd().exec())
+            {
+                String[] repoTags = image.getRepoTags();
+                if (repoTags == null)
+                {
+                    continue;
+                }
+                for (String repoTag : repoTags)
+                {
+                    if (repoTag != null && COMPOSE_IMAGE_PATTERN.matcher(repoTag).matches())
+                    {
+                        try
+                        {
+                            client.removeImageCmd(repoTag).withForce(true).exec();
+                            LOG.info("Removed leftover compose test image {}", repoTag);
+                        }
+                        catch (RuntimeException e)
+                        {
+                            LOG.warn("Failed to remove compose test image {}: {}", repoTag, e.getMessage());
+                        }
+                    }
+                }
+            }
+        }
+        catch (RuntimeException e)
+        {
+            LOG.warn("Failed to remove leftover compose test images", e);
         }
     }
 


### PR DESCRIPTION
The integration-test harnesses build per-service docker compose images that were never removed, so each run left behind a new set of '<project>_cassandra-*' images.

- Java harness (AbstractCassandraCluster / SharedCassandraCluster): the shared cluster is started once and reused across all IT classes with no @AfterClass teardown, so it was left to the testcontainers Ryuk reaper, which removes containers but not images. Register a JVM shutdown hook that removes the built images by name. Name-based removal is used instead of 'compose down --rmi' because the latter is a no-op once Ryuk has already removed the containers.
- Python harness (cass_config.py): fix stop_cluster() to tear down using the wrapper's own compose command/context with '--rmi local' (the previous raw command targeted the wrong compose project and removed nothing).

The pulled base image (cassandra:X.Y) is kept in both paths.