### PR TITLE
Remove redundant cassandra-rackdc files, use env vars for topology

### DIFF
--- a/cassandra-test-image/README.md
+++ b/cassandra-test-image/README.md
@@ -17,8 +17,7 @@ cassandra-test-image/
 │   │   ├── ecc-entrypoint.sh                # Cassandra startup + config script
 │   │   ├── setup_db.sh                      # Runs CQL initialisation scripts
 │   │   ├── create_keyspaces.cql             # ecChronos + test keyspace schemas
-│   │   ├── users.cql                        # eccuser role creation
-│   │   └── cassandra-rackdc-*.properties    # Rack/DC topology files
+│   │   └── users.cql                        # eccuser role creation
 │   └── resources/
 │       └── generate_certificates.sh         # TLS certificate generation
 └── src/test/java/cassandracluster/

--- a/cassandra-test-image/src/main/docker/cassandra-rackdc-dc1-rack1.properties
+++ b/cassandra-test-image/src/main/docker/cassandra-rackdc-dc1-rack1.properties
@@ -1,2 +1,0 @@
-dc= datacenter1
-rack= rack1

--- a/cassandra-test-image/src/main/docker/cassandra-rackdc-dc1-rack2.properties
+++ b/cassandra-test-image/src/main/docker/cassandra-rackdc-dc1-rack2.properties
@@ -1,2 +1,0 @@
-dc=datacenter2
-rack=rack2

--- a/cassandra-test-image/src/main/docker/cassandra-rackdc-dc2-rack1.properties
+++ b/cassandra-test-image/src/main/docker/cassandra-rackdc-dc2-rack1.properties
@@ -1,2 +1,0 @@
-dc= datacenter2
-rack= rack1

--- a/cassandra-test-image/src/main/docker/docker-compose.yml
+++ b/cassandra-test-image/src/main/docker/docker-compose.yml
@@ -32,7 +32,6 @@ services:
       - JVM_EXTRA_OPTS=-Dcom.sun.management.jmxremote.authenticate=false -Dcassandra.superuser_setup_delay_ms=0 -Dcassandra.skip_wait_for_gossip_to_settle=0 -Dcassandra.ring_delay_ms=0
     volumes:
       - cassandra-seed-dc1-rack1-node1-data:/var/lib/cassandra
-      - ./cassandra-rackdc-dc1-rack1.properties:/etc/cassandra/cassandra-rackdc.properties
       - ${CERTIFICATE_DIRECTORY}:/etc/certificates
 
   cassandra-seed-dc2-rack1-node1:
@@ -66,7 +65,6 @@ services:
       - JVM_EXTRA_OPTS=-Dcom.sun.management.jmxremote.authenticate=false -Dcassandra.superuser_setup_delay_ms=0 -Dcassandra.skip_wait_for_gossip_to_settle=0 -Dcassandra.ring_delay_ms=0
     volumes:
       - cassandra-seed-dc2-rack1-node1-data:/var/lib/cassandra
-      - ./cassandra-rackdc-dc2-rack1.properties:/etc/cassandra/cassandra-rackdc.properties
       - ${CERTIFICATE_DIRECTORY}:/etc/certificates
 
   cassandra-node-dc1-rack1-node2:
@@ -100,7 +98,6 @@ services:
       - JVM_EXTRA_OPTS=-Dcom.sun.management.jmxremote.authenticate=false -Dcassandra.superuser_setup_delay_ms=0 -Dcassandra.skip_wait_for_gossip_to_settle=0 -Dcassandra.ring_delay_ms=0
     volumes:
       - cassandra-node-dc1-rack1-node2-data:/var/lib/cassandra
-      - ./cassandra-rackdc-dc1-rack1.properties:/etc/cassandra/cassandra-rackdc.properties
       - ${CERTIFICATE_DIRECTORY}:/etc/certificates
 
   cassandra-node-dc2-rack1-node2:
@@ -134,7 +131,6 @@ services:
       - JVM_EXTRA_OPTS=-Dcom.sun.management.jmxremote.authenticate=false -Dcassandra.superuser_setup_delay_ms=0 -Dcassandra.skip_wait_for_gossip_to_settle=0 -Dcassandra.ring_delay_ms=0
     volumes:
       - cassandra-node-dc2-rack1-node2-data:/var/lib/cassandra
-      - ./cassandra-rackdc-dc2-rack1.properties:/etc/cassandra/cassandra-rackdc.properties
       - ${CERTIFICATE_DIRECTORY}:/etc/certificates
 
 volumes:

--- a/ecchronos-binary/src/test/bin/cass_config.py
+++ b/ecchronos-binary/src/test/bin/cass_config.py
@@ -109,9 +109,6 @@ class CassandraCluster:
         )
 
         container_name = "cassandra-node-dc1-rack1-node3"
-        rackdc_file = os.path.join(
-            global_vars.CASSANDRA_DOCKER_COMPOSE_FILE_PATH, "cassandra-rackdc-dc1-rack1.properties"
-        )
         cert_dir = global_vars.CERTIFICATE_DIRECTORY
 
         cmd = [
@@ -154,8 +151,6 @@ class CassandraCluster:
             "-Dcassandra.write_survey=false",
             "-v",
             "cassandra-node3-data:/var/lib/cassandra",
-            "-v",
-            f"{rackdc_file}:/etc/cassandra/cassandra-rackdc.properties",
             "-v",
             f"{cert_dir}:/etc/certificates",
             "cassandra-node3:latest",


### PR DESCRIPTION
The rackdc files were bind-mounted into the containers, but the official cassandra entrypoint rewrites /etc/cassandra/cassandra-rackdc.properties in place from CASSANDRA_DC/CASSANDRA_RACK. Through the bind mount this wrote back to the host files and, if a container was torn down mid-write, truncated them to 0 bytes -- breaking GossipingPropertyFileSnitch and causing intermittent NoRouteToHost cluster startup failures.

The files were fully redundant with the CASSANDRA_DC/CASSANDRA_RACK env vars (which produce identical values via the base image's default rackdc file), so remove them and the bind mounts entirely.