### PR TITLE
Document rationale for PMD/CPD suppressions

### DIFF
--- a/application/src/main/java/com/ericsson/bss/cassandra/ecchronos/application/config/security/CertificateLoader.java
+++ b/application/src/main/java/com/ericsson/bss/cassandra/ecchronos/application/config/security/CertificateLoader.java
@@ -73,6 +73,9 @@ public final class CertificateLoader
      * @return the parsed private key.
      * @throws IOException if the file cannot be read or the key format is unsupported.
      */
+    // PreserveStackTrace suppressed intentionally: the EC/RSA InvalidKeySpecException are expected control flow
+    // (we try one key type then the other) and are deliberately not chained, to surface a clean
+    // "Unsupported private key format" IOException without leaking the internal spec-parsing failures.
     @SuppressWarnings("PMD.PreserveStackTrace")
     public static PrivateKey loadPrivateKey(final File file) throws IOException
     {

--- a/application/src/main/java/com/ericsson/bss/cassandra/ecchronos/application/spring/ECChronos.java
+++ b/application/src/main/java/com/ericsson/bss/cassandra/ecchronos/application/spring/ECChronos.java
@@ -104,7 +104,7 @@ public class ECChronos implements Closeable
      * @throws ConfigurationException
      *         if the configuration is invalid.
      */
-    public ECChronos(//NOPMD long parameter list
+    public ECChronos(//NOPMD ExcessiveParameterList - top-level wiring constructor; dependencies are injected explicitly rather than hidden behind a container
             final Config configuration,
             final ApplicationContext applicationContext,
             final DistributedNativeConnectionProvider nativeConnectionProvider,

--- a/application/src/main/java/com/ericsson/bss/cassandra/ecchronos/application/spring/MetricsServerProperties.java
+++ b/application/src/main/java/com/ericsson/bss/cassandra/ecchronos/application/spring/MetricsServerProperties.java
@@ -21,6 +21,8 @@ import org.springframework.boot.web.server.Ssl;
 
 /** Properties for the metrics server endpoint. */
 @ConfigurationProperties (prefix = "metrics-server")
+// Intentional data holder: Spring @ConfigurationProperties binding requires a plain getter/setter bean,
+// so the DataClass shape is mandated by the framework rather than a design choice to refactor.
 @SuppressWarnings("PMD.DataClass")
 public class MetricsServerProperties
 {

--- a/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/jmx/http/ClientRegisterResponse.java
+++ b/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/jmx/http/ClientRegisterResponse.java
@@ -22,7 +22,7 @@ import java.util.Map;
  */
 public final class ClientRegisterResponse
 {
-    // CPD-OFF
+    // CPD-OFF: generated-style DTO for Jolokia JSON with many near-identical getter/setter pairs across nested types; duplication is inherent to the data shape, not a refactoring target
     /**
      * Default constructor.
      */

--- a/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/state/RepairStateImpl.java
+++ b/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/state/RepairStateImpl.java
@@ -78,6 +78,9 @@ public class RepairStateImpl implements RepairState
      * @param replicaRepairGroupFactory the factory for generating replica repair groups.
      * @param postUpdateHook the hook invoked after state updates.
      */
+    // ConstructorCallsOverridableMethod suppressed intentionally: update() is final (cannot be overridden),
+    // so the constructor priming the initial repair state is safe; kept as a constructor call by design so an
+    // instance is never observable without an initial state.
     @SuppressWarnings("PMD.ConstructorCallsOverridableMethod")
     public RepairStateImpl(
             final Node node,

--- a/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/vnode/SubRangeRepairStates.java
+++ b/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/vnode/SubRangeRepairStates.java
@@ -28,7 +28,7 @@ import java.util.Objects;
  * Implementation of {@link VnodeRepairStates} that handles sub-range (partial) repair states.
  * Sub-ranges are summarized back into full vnodes when possible to reduce memory overhead.
  */
-public final class SubRangeRepairStates implements VnodeRepairStates // CPD-OFF
+public final class SubRangeRepairStates implements VnodeRepairStates // CPD-OFF: builder/immutable-list boilerplate is intentionally near-identical to VnodeRepairStatesImpl; kept as separate types for clarity rather than merged
 {
     private final ImmutableList<VnodeRepairState> myVnodeRepairStatuses;
     private static final float DEFAULT_LOAD_FACTOR = 0.75f;

--- a/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/vnode/VnodeRepairStatesImpl.java
+++ b/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/vnode/VnodeRepairStatesImpl.java
@@ -28,7 +28,7 @@ import java.util.Objects;
  * Implementation of {@link VnodeRepairStates} that maintains vnode repair state information.
  * Each vnode repair state tracks the last repaired timestamp for a specific token range.
  */
-public final class VnodeRepairStatesImpl implements VnodeRepairStates // CPD-OFF
+public final class VnodeRepairStatesImpl implements VnodeRepairStates // CPD-OFF: builder/immutable-list boilerplate is intentionally near-identical to SubRangeRepairStates; kept as separate types for clarity rather than merged
 {
     private final ImmutableList<VnodeRepairState> myVnodeRepairStatuses;
     private static final float DEFAULT_LOAD_FACTOR = 0.75f;

--- a/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/metrics/TableRepairMetricsImpl.java
+++ b/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/metrics/TableRepairMetricsImpl.java
@@ -55,7 +55,7 @@ public final class TableRepairMetricsImpl implements TableRepairMetrics, TableRe
     }
 
     @VisibleForTesting
-    static Clock clock = () -> System.currentTimeMillis(); // NOPMD
+    static Clock clock = () -> System.currentTimeMillis(); // NOPMD MutableStaticState - test seam, overridden by tests to control time
 
     private final Map<TableReference, TableGauges> myTableGauges = new ConcurrentHashMap<>();
     private final Set<TableReference> myRegisteredTables = ConcurrentHashMap.newKeySet();

--- a/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/repair/config/RepairOptions.java
+++ b/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/repair/config/RepairOptions.java
@@ -17,6 +17,8 @@ package com.ericsson.bss.cassandra.ecchronos.core.repair.config;
 /**
  * The repair options available for the repair.
  */
+// Intentional data holder: this class only exposes repair option key constants and has no behaviour to move
+// elsewhere, so redesigning away the DataClass shape would add indirection without value.
 @SuppressWarnings("PMD.DataClass")
 public final class RepairOptions
 {


### PR DESCRIPTION
Add explanatory comments to the source-level PMD suppressions so each records why suppression was chosen over redesign, matching the existing '- intentional ...' convention:

- PMD.DataClass: RepairOptions (constants-only holder), MetricsServerProperties (Spring @ConfigurationProperties bean)
- PMD.PreserveStackTrace: CertificateLoader (expected EC/RSA control flow)
- PMD.ConstructorCallsOverridableMethod: RepairStateImpl (update() is final)
- NOPMD ExcessiveParameterList: ECChronos (top-level wiring constructor)
- NOPMD MutableStaticState: TableRepairMetricsImpl (test seam)
- CPD-OFF: SubRangeRepairStates, VnodeRepairStatesImpl (near-identical builder boilerplate), ClientRegisterResponse (generated-style DTO)

Closes #759