### PR TITLE
Add missing @param eccNodesSync to jolokiaNotificationController javadoc

### DIFF
--- a/application/src/main/java/com/ericsson/bss/cassandra/ecchronos/application/spring/BeanConfigurator.java
+++ b/application/src/main/java/com/ericsson/bss/cassandra/ecchronos/application/spring/BeanConfigurator.java
@@ -283,6 +283,8 @@ public class BeanConfigurator
      *         the provider for Cassandra native connections.
      * @param ipTranslator
      *         the {@link IpTranslator} used for IP address translation.
+     * @param eccNodesSync
+     *         the {@link EccNodesSync} used to track and synchronize node state.
      * @return a {@link JolokiaNotificationController} instance.
      */
     @Bean


### PR DESCRIPTION
Fixes the javadoc:jar warning for BeanConfigurator.jolokiaNotificationController where the eccNodesSync parameter had no matching @param tag.