### PR TITLE
Fix incremental repair lock granularity for same-table repairs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@
 * Fix Jolokia JMX connection health check always returning true for stale connections - Issue #1764
 * Support runtime configuration of maxWaitTimeInMinutes via ecctool config - Issue #1783
 * Incremental Repair does not works properly - Issue #1777
+* Fix incremental repair lock granularity allowing concurrent repairs of the same table - Issue #1805
 * Jolokia MbeanServer check makes ecctool gets stuck - Issue #1799
 
 ## Version 1.0.6

--- a/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/locks/IncrementalRepairResourceFactory.java
+++ b/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/locks/IncrementalRepairResourceFactory.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2026 Telefonaktiebolaget LM Ericsson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ericsson.bss.cassandra.ecchronos.core.impl.locks;
+
+import com.ericsson.bss.cassandra.ecchronos.core.metadata.DriverNode;
+import com.ericsson.bss.cassandra.ecchronos.core.repair.RepairResource;
+import com.ericsson.bss.cassandra.ecchronos.core.repair.RepairResourceFactory;
+import com.ericsson.bss.cassandra.ecchronos.core.state.ReplicaRepairGroup;
+import com.ericsson.bss.cassandra.ecchronos.core.table.TableReference;
+import com.google.common.base.Preconditions;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Repair resource factory for incremental repair.
+ * <p>
+ * Incremental repair is a table-level operation: the whole owned dataset for the table is anticompacted, so two
+ * incremental repairs of the same table must not run concurrently even across different replica nodes. At the same
+ * time, incremental repairs of different tables should still be able to run in parallel, bounded per node by the
+ * globally configured locks-per-resource value.
+ * <p>
+ * To achieve this the factory produces two independent lock dimensions:
+ * <ul>
+ *     <li>A single, datacenter-independent table-level resource with one slot ({@code maxSlots = 1}) — the
+ *     correctness lock that serializes incremental repairs of the same table across all its replicas. The resource
+ *     name is {@code keyspace.table} so that identically named tables in different keyspaces do not collide.</li>
+ *     <li>One per-node resource per replica using the globally configured slot count — the load-throttling
+ *     lock that bounds how many incremental repairs a given node participates in at once.</li>
+ * </ul>
+ * Because {@link com.ericsson.bss.cassandra.ecchronos.core.repair.RepairLockFactory#getLock} acquires the whole set
+ * of resources atomically (all-or-nothing with rollback), locking both dimensions together yields the desired
+ * behavior.
+ */
+public class IncrementalRepairResourceFactory implements RepairResourceFactory
+{
+    /**
+     * Datacenter placeholder for the table-level correctness lock. The distributed lock identity is the resource
+     * name alone, so this value only needs to be stable and datacenter-independent to yield a single global lock
+     * for a given table across all replicas and datacenters.
+     */
+    private static final String GLOBAL_TABLE_LOCK_DC = "global";
+
+    private final TableReference myTableReference;
+
+    /**
+     * Constructor.
+     *
+     * @param tableReference the table being repaired; used to build the table-level correctness lock resource.
+     */
+    public IncrementalRepairResourceFactory(final TableReference tableReference)
+    {
+        myTableReference = Preconditions.checkNotNull(tableReference, "Table reference must be set");
+    }
+
+    @Override
+    public final Set<RepairResource> getRepairResources(final ReplicaRepairGroup replicaRepairGroup)
+    {
+        Set<RepairResource> repairResources = new HashSet<>();
+
+        // Dimension 1: a single, datacenter-independent one-per-table correctness lock (single slot). Keyed by
+        // keyspace.table so that same-named tables in different keyspaces remain distinct. Serializes same-table
+        // repairs across all replicas regardless of datacenter.
+        String tableResourceName = myTableReference.getKeyspace() + "." + myTableReference.getTable();
+        repairResources.add(new RepairResource(GLOBAL_TABLE_LOCK_DC, tableResourceName, 1));
+
+        // Dimension 2: per-node load lock, bounded by the global locks-per-resource value.
+        for (DriverNode replica : replicaRepairGroup.replicas())
+        {
+            repairResources.add(new RepairResource(replica.getDatacenter(), replica.getId().toString()));
+        }
+
+        return repairResources;
+    }
+}

--- a/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/IncrementalOnDemandRepairJob.java
+++ b/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/IncrementalOnDemandRepairJob.java
@@ -17,6 +17,7 @@ package com.ericsson.bss.cassandra.ecchronos.core.impl.repair;
 
 import com.datastax.oss.driver.api.core.metadata.Node;
 import com.ericsson.bss.cassandra.ecchronos.core.impl.locks.RepairLockType;
+import com.ericsson.bss.cassandra.ecchronos.core.impl.locks.IncrementalRepairResourceFactory;
 import com.ericsson.bss.cassandra.ecchronos.core.jmx.DistributedJmxProxyFactory;
 import com.ericsson.bss.cassandra.ecchronos.core.repair.config.RepairConfiguration;
 import com.ericsson.bss.cassandra.ecchronos.core.repair.scheduler.OnDemandRepairJobView;
@@ -87,7 +88,7 @@ public final class IncrementalOnDemandRepairJob extends OnDemandRepairJob
                 .withReplicaRepairGroup(replicaRepairGroup)
                 .withJmxProxyFactory(getJmxProxyFactory())
                 .withTableRepairMetrics(getTableRepairMetrics())
-                .withRepairResourceFactory(getRepairLockType().getLockFactory())
+                .withRepairResourceFactory(new IncrementalRepairResourceFactory(getTableReference()))
                 .withRepairLockFactory(REPAIR_LOCK_FACTORY)
                 .withRepairHistory(myRepairHistory)
                 .withJobId(getJobId())

--- a/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/RepairLockFactoryImpl.java
+++ b/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/RepairLockFactoryImpl.java
@@ -123,11 +123,11 @@ public class RepairLockFactoryImpl implements RepairLockFactory
     private void validateNoCachedFailures(final UUID nodeId, final LockFactory lockFactory, final Set<RepairResource> repairResources)
                                                                                                                     throws LockException
     {
-        int locksPerResource = getLocksPerResource();
         for (RepairResource repairResource : repairResources)
         {
+            int slots = effectiveMaxSlots(repairResource);
             Optional<LockException> cachedException = lockFactory.getCachedFailure(nodeId, repairResource.getDataCenter(),
-                    repairResource.getResourceName(locksPerResource));
+                    repairResource.getResourceName(slots));
             if (cachedException.isPresent())
             {
                 LockException e = cachedException.get();
@@ -135,6 +135,23 @@ public class RepairLockFactoryImpl implements RepairLockFactory
                 throw e;
             }
         }
+    }
+
+    /**
+     * Resolve the effective number of lock slots for a resource: the resource's own value if set,
+     * otherwise the globally configured value.
+     *
+     * @param repairResource the resource.
+     * @return the number of slots to use.
+     */
+    private static int effectiveMaxSlots(final RepairResource repairResource)
+    {
+        int maxSlots = repairResource.getMaxSlots();
+        if (maxSlots == RepairResource.USE_GLOBAL_SLOTS)
+        {
+            return getLocksPerResource();
+        }
+        return maxSlots;
     }
 
     private Collection<LockFactory.DistributedLock> getRepairResourceLocks(
@@ -197,7 +214,7 @@ public class RepairLockFactoryImpl implements RepairLockFactory
     {
         LockFactory.DistributedLock myLock;
         String dataCenter = repairResource.getDataCenter();
-        int locksPerResource = getLocksPerResource();
+        int locksPerResource = effectiveMaxSlots(repairResource);
 
         int startLock = LOCK_COUNTER.getAndIncrement();
         for (int i = 0; i < locksPerResource; i++)

--- a/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/incremental/IncrementalRepairJob.java
+++ b/core.impl/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/incremental/IncrementalRepairJob.java
@@ -16,6 +16,7 @@ package com.ericsson.bss.cassandra.ecchronos.core.impl.repair.incremental;
 
 import com.datastax.oss.driver.api.core.metadata.Node;
 import com.ericsson.bss.cassandra.ecchronos.core.impl.locks.RepairLockType;
+import com.ericsson.bss.cassandra.ecchronos.core.impl.locks.IncrementalRepairResourceFactory;
 import com.ericsson.bss.cassandra.ecchronos.core.impl.metrics.CassandraMetrics;
 import com.ericsson.bss.cassandra.ecchronos.core.impl.repair.RepairGroup;
 import com.ericsson.bss.cassandra.ecchronos.core.jmx.DistributedJmxProxyFactory;
@@ -157,7 +158,7 @@ public class IncrementalRepairJob extends ScheduledRepairJob
                 .withTableRepairMetrics(getTableRepairMetrics())
                 .withReplicaRepairGroup(replicaRepairGroup)
                 .withRepairLockFactory(REPAIR_LOCK_FACTORY)
-                .withRepairResourceFactory(getRepairLockType().getLockFactory())
+                .withRepairResourceFactory(new IncrementalRepairResourceFactory(getTableReference()))
                 .withRepairPolicies(getRepairPolicies()).withJobId(getJobId())
                 .withRepairHistory(myRepairHistory)
                 .withNode(myNode);

--- a/core.impl/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/impl/locks/TestIncrementalRepairResourceFactory.java
+++ b/core.impl/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/impl/locks/TestIncrementalRepairResourceFactory.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright 2026 Telefonaktiebolaget LM Ericsson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ericsson.bss.cassandra.ecchronos.core.impl.locks;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.ericsson.bss.cassandra.ecchronos.core.metadata.DriverNode;
+import com.ericsson.bss.cassandra.ecchronos.core.repair.RepairResource;
+import com.ericsson.bss.cassandra.ecchronos.core.state.ReplicaRepairGroup;
+import com.ericsson.bss.cassandra.ecchronos.core.table.TableReference;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import org.junit.Test;
+
+public class TestIncrementalRepairResourceFactory
+{
+    private static DriverNode mockNode(final String dataCenter, final UUID id)
+    {
+        DriverNode node = mock(DriverNode.class);
+        when(node.getDatacenter()).thenReturn(dataCenter);
+        when(node.getId()).thenReturn(id);
+        return node;
+    }
+
+    private static TableReference mockTable(final String keyspace, final String table)
+    {
+        TableReference tableReference = mock(TableReference.class);
+        when(tableReference.getKeyspace()).thenReturn(keyspace);
+        when(tableReference.getTable()).thenReturn(table);
+        return tableReference;
+    }
+
+    @Test
+    public void testTableResourceHasSingleSlotAndPerNodeResourcesUseGlobal()
+    {
+        UUID nodeIdA = UUID.randomUUID();
+        UUID nodeIdB = UUID.randomUUID();
+        DriverNode nodeA = mockNode("DC1", nodeIdA);
+        DriverNode nodeB = mockNode("DC1", nodeIdB);
+
+        ReplicaRepairGroup group = new ReplicaRepairGroup(
+                ImmutableSet.of(nodeA, nodeB), ImmutableList.of(), 0L);
+
+        IncrementalRepairResourceFactory factory =
+                new IncrementalRepairResourceFactory(mockTable("ks", "tbl"));
+
+        Set<RepairResource> resources = factory.getRepairResources(group);
+
+        // One table resource (single-DC group) + two per-node resources
+        assertThat(resources).hasSize(3);
+
+        Set<RepairResource> tableResources = resources.stream()
+                .filter(r -> r.getMaxSlots() == 1)
+                .collect(Collectors.toSet());
+        assertThat(tableResources).hasSize(1);
+        assertThat(tableResources.iterator().next().getResourceName(1))
+                .isEqualTo("RepairResource-ks.tbl-1");
+
+        Set<RepairResource> nodeResources = resources.stream()
+                .filter(r -> r.getMaxSlots() == RepairResource.USE_GLOBAL_SLOTS)
+                .collect(Collectors.toSet());
+        assertThat(nodeResources).hasSize(2);
+        assertThat(nodeResources.stream().map(r -> r.getResourceName(1)))
+                .containsExactlyInAnyOrder(
+                        "RepairResource-" + nodeIdA + "-1",
+                        "RepairResource-" + nodeIdB + "-1");
+    }
+
+    @Test
+    public void testDifferentTablesProduceDifferentTableResources()
+    {
+        DriverNode node = mockNode("DC1", UUID.randomUUID());
+        ReplicaRepairGroup group = new ReplicaRepairGroup(
+                ImmutableSet.of(node), ImmutableList.of(), 0L);
+
+        Set<RepairResource> resourcesTbl1 =
+                new IncrementalRepairResourceFactory(mockTable("ks", "tbl1")).getRepairResources(group);
+        Set<RepairResource> resourcesTbl2 =
+                new IncrementalRepairResourceFactory(mockTable("ks", "tbl2")).getRepairResources(group);
+
+        RepairResource table1 = resourcesTbl1.stream().filter(r -> r.getMaxSlots() == 1).findFirst().orElseThrow();
+        RepairResource table2 = resourcesTbl2.stream().filter(r -> r.getMaxSlots() == 1).findFirst().orElseThrow();
+
+        // Different tables -> different table resources -> no collision
+        assertThat(table1).isNotEqualTo(table2);
+    }
+
+    @Test
+    public void testSameTableProducesEqualTableResource()
+    {
+        DriverNode nodeA = mockNode("DC1", UUID.randomUUID());
+        DriverNode nodeB = mockNode("DC1", UUID.randomUUID());
+        ReplicaRepairGroup groupA = new ReplicaRepairGroup(ImmutableSet.of(nodeA), ImmutableList.of(), 0L);
+        ReplicaRepairGroup groupB = new ReplicaRepairGroup(ImmutableSet.of(nodeB), ImmutableList.of(), 0L);
+
+        Set<RepairResource> resourcesA =
+                new IncrementalRepairResourceFactory(mockTable("ks", "tbl")).getRepairResources(groupA);
+        Set<RepairResource> resourcesB =
+                new IncrementalRepairResourceFactory(mockTable("ks", "tbl")).getRepairResources(groupB);
+
+        RepairResource tableA = resourcesA.stream().filter(r -> r.getMaxSlots() == 1).findFirst().orElseThrow();
+        RepairResource tableB = resourcesB.stream().filter(r -> r.getMaxSlots() == 1).findFirst().orElseThrow();
+
+        // Same table across different replica nodes -> same table resource -> collide -> serialized
+        assertThat(tableA).isEqualTo(tableB);
+    }
+
+    @Test
+    public void testMultiDataCenterProducesSingleGlobalTableResource()
+    {
+        DriverNode nodeDc1 = mockNode("DC1", UUID.randomUUID());
+        DriverNode nodeDc2 = mockNode("DC2", UUID.randomUUID());
+        ReplicaRepairGroup group = new ReplicaRepairGroup(
+                ImmutableSet.of(nodeDc1, nodeDc2), ImmutableList.of(), 0L);
+
+        Set<RepairResource> resources =
+                new IncrementalRepairResourceFactory(mockTable("ks", "tbl")).getRepairResources(group);
+
+        Set<RepairResource> tableResources = resources.stream()
+                .filter(r -> r.getMaxSlots() == 1)
+                .collect(Collectors.toSet());
+        // A single, datacenter-independent table resource regardless of how many DCs the replicas span
+        assertThat(tableResources).hasSize(1);
+        assertThat(tableResources.iterator().next().getResourceName(1))
+                .isEqualTo("RepairResource-ks.tbl-1");
+    }
+
+    @Test
+    public void testTableResourceIsDataCenterIndependent()
+    {
+        // Same table replicated in different datacenters must still yield the SAME table lock resource,
+        // so the correctness lock serializes across datacenters.
+        DriverNode nodeDc1 = mockNode("DC1", UUID.randomUUID());
+        DriverNode nodeDc2 = mockNode("DC2", UUID.randomUUID());
+        ReplicaRepairGroup groupDc1 = new ReplicaRepairGroup(ImmutableSet.of(nodeDc1), ImmutableList.of(), 0L);
+        ReplicaRepairGroup groupDc2 = new ReplicaRepairGroup(ImmutableSet.of(nodeDc2), ImmutableList.of(), 0L);
+
+        RepairResource tableDc1 = new IncrementalRepairResourceFactory(mockTable("ks", "tbl"))
+                .getRepairResources(groupDc1).stream()
+                .filter(r -> r.getMaxSlots() == 1).findFirst().orElseThrow();
+        RepairResource tableDc2 = new IncrementalRepairResourceFactory(mockTable("ks", "tbl"))
+                .getRepairResources(groupDc2).stream()
+                .filter(r -> r.getMaxSlots() == 1).findFirst().orElseThrow();
+
+        assertThat(tableDc1).isEqualTo(tableDc2);
+    }
+
+    @Test
+    public void testSameTableNameDifferentKeyspacesDoNotCollide()
+    {
+        DriverNode node = mockNode("DC1", UUID.randomUUID());
+        ReplicaRepairGroup group = new ReplicaRepairGroup(ImmutableSet.of(node), ImmutableList.of(), 0L);
+
+        RepairResource ks1Table = new IncrementalRepairResourceFactory(mockTable("ks1", "tbl"))
+                .getRepairResources(group).stream()
+                .filter(r -> r.getMaxSlots() == 1).findFirst().orElseThrow();
+        RepairResource ks2Table = new IncrementalRepairResourceFactory(mockTable("ks2", "tbl"))
+                .getRepairResources(group).stream()
+                .filter(r -> r.getMaxSlots() == 1).findFirst().orElseThrow();
+
+        // Same table name in different keyspaces -> distinct table resources (keyspace.table naming)
+        assertThat(ks1Table).isNotEqualTo(ks2Table);
+        assertThat(ks1Table.getResourceName(1)).isEqualTo("RepairResource-ks1.tbl-1");
+        assertThat(ks2Table.getResourceName(1)).isEqualTo("RepairResource-ks2.tbl-1");
+    }
+}

--- a/core.impl/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/TestRepairLockFactoryImpl.java
+++ b/core.impl/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/impl/repair/TestRepairLockFactoryImpl.java
@@ -206,6 +206,83 @@ public class TestRepairLockFactoryImpl
     }
 
     @Test
+    public void testSingleSlotResourceOnlyTriesSlotOne() throws LockException
+    {
+        // A resource with maxSlots=1 (e.g. the incremental table resource) must only ever try slot 1,
+        // regardless of the global locks_per_resource value.
+        RepairResource tableResource = new RepairResource("DC1", "ks.tbl", 1);
+        Map<String, String> metadata = Collections.singletonMap("key", "value");
+        int priority = 1;
+
+        when(mockLockFactory.tryLock(eq("DC1"), eq(tableResource.getResourceName(1)), eq(priority), eq(metadata), any()))
+                .thenReturn(mockLock);
+
+        repairLockFactory.getLock(mockLockFactory, Sets.newHashSet(tableResource), metadata, priority, UUID.randomUUID());
+
+        verify(mockLockFactory).tryLock(eq("DC1"), eq(tableResource.getResourceName(1)), eq(priority), eq(metadata), any());
+        verify(mockLockFactory, never()).tryLock(eq("DC1"), eq(tableResource.getResourceName(2)), anyInt(), anyMap(), any());
+        verify(mockLockFactory, never()).tryLock(eq("DC1"), eq(tableResource.getResourceName(3)), anyInt(), anyMap(), any());
+    }
+
+    @Test
+    public void testSingleSlotResourceSerializesSecondAcquisition() throws LockException
+    {
+        // Simulates the incremental "same table across replicas" scenario: the single-slot table
+        // resource allows one holder; a second attempt must be blocked (no free slot).
+        RepairResource tableResource = new RepairResource("DC1", "ks.tbl", 1);
+        Map<String, String> metadata = Collections.singletonMap("key", "value");
+        int priority = 1;
+
+        when(mockLockFactory.tryLock(eq("DC1"), eq(tableResource.getResourceName(1)), eq(priority), eq(metadata), any()))
+                .thenReturn(mockLock);
+
+        LockFactory.DistributedLock first = repairLockFactory.getLock(
+                mockLockFactory, Sets.newHashSet(tableResource), metadata, priority, UUID.randomUUID());
+        assertThat(first).isNotNull();
+
+        // Second acquisition on the single-slot resource must fail while the first is held.
+        assertThatExceptionOfType(LockException.class)
+                .isThrownBy(() -> repairLockFactory.getLock(
+                        mockLockFactory, Sets.newHashSet(tableResource), metadata, priority, UUID.randomUUID()));
+
+        // Releasing the first frees the single slot.
+        first.close();
+        LockFactory.DistributedLock second = repairLockFactory.getLock(
+                mockLockFactory, Sets.newHashSet(tableResource), metadata, priority, UUID.randomUUID());
+        assertThat(second).isNotNull();
+        second.close();
+    }
+
+    @Test
+    public void testPerNodeResourceStillUsesGlobalSlots() throws LockException
+    {
+        // A default (global-slot) resource — the incremental per-node load lock — keeps N slots.
+        RepairResource nodeResource = new RepairResource("DC1", "node-a");
+        Map<String, String> metadata = Collections.singletonMap("key", "value");
+        int priority = 1;
+
+        for (int slot = 1; slot <= LOCKS_PER_RESOURCE; slot++)
+        {
+            when(mockLockFactory.tryLock(eq("DC1"), eq(nodeResource.getResourceName(slot)), eq(priority), eq(metadata), any()))
+                    .thenReturn(mockLock);
+        }
+
+        // All N slots can be acquired concurrently...
+        LockFactory.DistributedLock l1 = repairLockFactory.getLock(mockLockFactory, Sets.newHashSet(nodeResource), metadata, priority, UUID.randomUUID());
+        LockFactory.DistributedLock l2 = repairLockFactory.getLock(mockLockFactory, Sets.newHashSet(nodeResource), metadata, priority, UUID.randomUUID());
+        LockFactory.DistributedLock l3 = repairLockFactory.getLock(mockLockFactory, Sets.newHashSet(nodeResource), metadata, priority, UUID.randomUUID());
+
+        // ...the (N+1)th blocks.
+        assertThatExceptionOfType(LockException.class)
+                .isThrownBy(() -> repairLockFactory.getLock(
+                        mockLockFactory, Sets.newHashSet(nodeResource), metadata, priority, UUID.randomUUID()));
+
+        l1.close();
+        l2.close();
+        l3.close();
+    }
+
+    @Test
     public void testRuntimeReconfiguration()
     {
         try

--- a/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/repair/RepairResource.java
+++ b/core/src/main/java/com/ericsson/bss/cassandra/ecchronos/core/repair/RepairResource.java
@@ -23,19 +23,37 @@ import static com.google.common.base.Preconditions.checkNotNull;
  */
 public class RepairResource
 {
+    /** Sentinel indicating the resource should use the globally configured locks-per-resource value. */
+    public static final int USE_GLOBAL_SLOTS = -1;
+
     private final String myDataCenter;
     private final String myResourceName;
+    private final int myMaxSlots;
 
     /**
-     * Constructor.
+     * Constructor. The resource uses the globally configured locks-per-resource value.
      *
      * @param dataCenter The data center.
      * @param resourceName Resource name.
      */
     public RepairResource(final String dataCenter, final String resourceName)
     {
+        this(dataCenter, resourceName, USE_GLOBAL_SLOTS);
+    }
+
+    /**
+     * Constructor with an explicit maximum number of lock slots for this resource.
+     *
+     * @param dataCenter The data center.
+     * @param resourceName Resource name.
+     * @param maxSlots The maximum number of concurrent lock slots for this resource, or
+     *                 {@link #USE_GLOBAL_SLOTS} to use the globally configured value.
+     */
+    public RepairResource(final String dataCenter, final String resourceName, final int maxSlots)
+    {
         myDataCenter = dataCenter;
         myResourceName = checkNotNull(resourceName);
+        myMaxSlots = maxSlots;
     }
 
     /**
@@ -46,6 +64,16 @@ public class RepairResource
     public String getDataCenter()
     {
         return myDataCenter;
+    }
+
+    /**
+     * Get the maximum number of concurrent lock slots for this resource.
+     *
+     * @return the configured slot count, or {@link #USE_GLOBAL_SLOTS} if the global value should be used.
+     */
+    public int getMaxSlots()
+    {
+        return myMaxSlots;
     }
 
     /**

--- a/core/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/repair/TestRepairResource.java
+++ b/core/src/test/java/com/ericsson/bss/cassandra/ecchronos/core/repair/TestRepairResource.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2026 Telefonaktiebolaget LM Ericsson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ericsson.bss.cassandra.ecchronos.core.repair;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+
+public class TestRepairResource
+{
+    @Test
+    public void testDefaultConstructorUsesGlobalSlots()
+    {
+        RepairResource resource = new RepairResource("DC1", "my-resource");
+        assertThat(resource.getMaxSlots()).isEqualTo(RepairResource.USE_GLOBAL_SLOTS);
+    }
+
+    @Test
+    public void testExplicitMaxSlots()
+    {
+        RepairResource resource = new RepairResource("DC1", "ks.tbl", 1);
+        assertThat(resource.getMaxSlots()).isEqualTo(1);
+    }
+
+    @Test
+    public void testGetDataCenterAndResourceName()
+    {
+        RepairResource resource = new RepairResource("DC1", "my-resource", 5);
+        assertThat(resource.getDataCenter()).isEqualTo("DC1");
+        assertThat(resource.getResourceName(2)).isEqualTo("RepairResource-my-resource-2");
+    }
+
+    @Test
+    public void testEqualsIgnoresMaxSlots()
+    {
+        RepairResource global = new RepairResource("DC1", "my-resource");
+        RepairResource oneSlot = new RepairResource("DC1", "my-resource", 1);
+        RepairResource manySlots = new RepairResource("DC1", "my-resource", 10);
+
+        // Identity is datacenter + name only; slot count must not affect equality/hashCode,
+        // otherwise a table resource with maxSlots=1 could fail to collide with itself.
+        assertThat(oneSlot).isEqualTo(global);
+        assertThat(oneSlot).isEqualTo(manySlots);
+        assertThat(oneSlot.hashCode()).isEqualTo(global.hashCode());
+        assertThat(oneSlot.hashCode()).isEqualTo(manySlots.hashCode());
+    }
+
+    @Test
+    public void testNotEqualWhenNameOrDataCenterDiffers()
+    {
+        RepairResource base = new RepairResource("DC1", "my-resource", 1);
+        assertThat(base).isNotEqualTo(new RepairResource("DC1", "other-resource", 1));
+        assertThat(base).isNotEqualTo(new RepairResource("DC2", "my-resource", 1));
+    }
+}


### PR DESCRIPTION
Incremental repair is a table-level operation, but it used the vnode lock scheme keyed only by replica node + slot. With locks_per_resource > 1, different replica nodes of the same table could each acquire a distinct node slot and run incremental repair of the same table concurrently, causing overlapping anticompaction on the same data.

Add a table-level lock dimension for incremental repair:

- RepairResource gains an optional maxSlots (USE_GLOBAL_SLOTS sentinel by default). Identity (equals/hashCode) remains datacenter + name only, so slot count never affects collision detection.
- RepairLockFactoryImpl resolves the effective slot count per resource (resource value or the global locks_per_resource) in both the slot iteration and the cached-failure lookup.
- New IncrementalRepairResourceFactory produces two lock dimensions per repair: a single-slot table resource (keyspace.table) that serializes same-table repairs across replicas, plus per-node resources using the global slot count for load throttling. getLock already acquires the set atomically, so both dimensions are enforced together.
- IncrementalRepairJob and IncrementalOnDemandRepairJob use the new factory.

The vnode path is unchanged: its factory still produces node-keyed resources with the global slot count and no table resource.

Result:
- Same table across replicas -> serialized on the single-slot table resource
- Different tables, shared node -> parallel, bounded per node by locks_per_resource
- Different tables, disjoint replicas -> fully parallel